### PR TITLE
Refactored the dialog system to use specialized components

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/EditApplicationInfoScreen.kt
+++ b/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/EditApplicationInfoScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -56,12 +55,12 @@ import com.eblan.launcher.domain.model.EblanApplicationInfoTag
 import com.eblan.launcher.domain.model.EblanApplicationInfoTagUi
 import com.eblan.launcher.domain.model.IconPackInfoComponent
 import com.eblan.launcher.domain.model.PackageManagerIconPackInfo
+import com.eblan.launcher.feature.editapplicationinfo.dialog.AddTagDialog
+import com.eblan.launcher.feature.editapplicationinfo.dialog.EditEblanApplicationInfoCustomLabelDialog
 import com.eblan.launcher.feature.editapplicationinfo.dialog.UpdateTagDialog
 import com.eblan.launcher.feature.editapplicationinfo.model.EditApplicationInfoUiState
 import com.eblan.launcher.ui.dialog.IconPackInfoFilesDialog
-import com.eblan.launcher.ui.dialog.SingleTextFieldDialog
 import com.eblan.launcher.ui.edit.CustomIcon
-import com.eblan.launcher.ui.edit.CustomLabelDialog
 import com.eblan.launcher.ui.settings.SettingsColumn
 import com.eblan.launcher.ui.settings.SettingsSwitch
 
@@ -277,36 +276,12 @@ private fun Success(
         }
 
         if (showCustomLabelDialog) {
-            var value by remember { mutableStateOf(eblanApplicationInfo.customLabel ?: "") }
-
-            var isError by remember { mutableStateOf(false) }
-
-            CustomLabelDialog(
-                title = "Custom Label",
-                textFieldTitle = "Custom Label",
-                value = value,
-                isError = isError,
-                keyboardType = KeyboardType.Text,
-                onValueChange = {
-                    value = it
-                },
+            EditEblanApplicationInfoCustomLabelDialog(
+                eblanApplicationInfo = eblanApplicationInfo,
                 onDismissRequest = {
                     showCustomLabelDialog = false
                 },
-                onUpdateClick = {
-                    if (value.isNotBlank()) {
-                        onUpdateEblanApplicationInfo(eblanApplicationInfo.copy(customLabel = value))
-
-                        showCustomLabelDialog = false
-                    } else {
-                        isError = true
-                    }
-                },
-                onResetClick = {
-                    onUpdateEblanApplicationInfo(eblanApplicationInfo.copy(customLabel = null))
-
-                    showCustomLabelDialog = false
-                },
+                onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
             )
         }
     }
@@ -352,31 +327,11 @@ private fun Tags(
     }
 
     if (showAddTagDialog) {
-        var value by remember { mutableStateOf("") }
-
-        var isError by remember { mutableStateOf(false) }
-
-        SingleTextFieldDialog(
-            title = "Add Tag",
-            textFieldTitle = "Add Tag",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Text,
-            onValueChange = {
-                value = it
-            },
+        AddTagDialog(
             onDismissRequest = {
                 showAddTagDialog = false
             },
-            onUpdateClick = {
-                if (value.isNotBlank()) {
-                    onAddEblanApplicationInfoTag(EblanApplicationInfoTag(name = value))
-
-                    showAddTagDialog = false
-                } else {
-                    isError = true
-                }
-            },
+            onAddEblanApplicationInfoTag = onAddEblanApplicationInfoTag,
         )
     }
 

--- a/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/EditEblanApplicationInfoCustomLabelDialog.kt
+++ b/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/EditEblanApplicationInfoCustomLabelDialog.kt
@@ -17,16 +17,9 @@
  */
 package com.eblan.launcher.feature.editapplicationinfo.dialog
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
@@ -35,10 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.EblanApplicationInfo
 import com.eblan.launcher.ui.dialog.TextFieldDialog
@@ -60,7 +50,45 @@ internal fun EditEblanApplicationInfoCustomLabelDialog(
         modifier = modifier,
         title = "Custom Label",
         onDismissRequest = onDismissRequest,
-        actions = {
+        topActions = {
+            IconButton(
+                enabled = value.isNotBlank(),
+                onClick = {
+                    onUpdateEblanApplicationInfo(
+                        eblanApplicationInfo.copy(customLabel = null),
+                    )
+
+                    onDismissRequest()
+                },
+            ) {
+                Icon(
+                    imageVector = EblanLauncherIcons.Delete,
+                    contentDescription = null,
+                )
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                    isError = false
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text(text = "Custom Label")
+                },
+                isError = isError,
+                supportingText = if (isError) {
+                    {
+                        Text("Custom label is not valid")
+                    }
+                } else {
+                    null
+                },
+            )
+        },
+        bottomActions = {
             TextButton(onClick = onDismissRequest) {
                 Text(text = "Cancel")
             }
@@ -71,6 +99,7 @@ internal fun EditEblanApplicationInfoCustomLabelDialog(
                         onUpdateEblanApplicationInfo(
                             eblanApplicationInfo.copy(customLabel = value),
                         )
+
                         onDismissRequest()
                     } else {
                         isError = true
@@ -78,59 +107,6 @@ internal fun EditEblanApplicationInfoCustomLabelDialog(
                 },
             ) {
                 Text(text = "Update")
-            }
-        },
-        textField = {
-            Column {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "Custom Label",
-                        style = MaterialTheme.typography.titleLarge,
-                    )
-
-                    IconButton(
-                        enabled = value.isNotBlank(),
-                        onClick = {
-                            onUpdateEblanApplicationInfo(
-                                eblanApplicationInfo.copy(customLabel = null),
-                            )
-                            onDismissRequest()
-                        },
-                    ) {
-                        Icon(
-                            imageVector = EblanLauncherIcons.Delete,
-                            contentDescription = null,
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                TextField(
-                    value = value,
-                    onValueChange = {
-                        value = it
-                        isError = false
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text(text = "Custom Label") },
-                    isError = isError,
-                    supportingText = if (isError) {
-                        {
-                            Text(text = "Custom Label is not valid")
-                        }
-                    } else {
-                        null
-                    },
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = KeyboardType.Text,
-                    ),
-                    singleLine = true,
-                )
             }
         },
     )

--- a/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/EditEblanApplicationInfoCustomLabelDialog.kt
+++ b/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/EditEblanApplicationInfoCustomLabelDialog.kt
@@ -15,7 +15,7 @@
  *   limitations under the License.
  *
  */
-package com.eblan.launcher.ui.edit
+package com.eblan.launcher.feature.editapplicationinfo.dialog
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,44 +31,75 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import com.eblan.launcher.designsystem.component.EblanDialogContainer
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
+import com.eblan.launcher.domain.model.EblanApplicationInfo
+import com.eblan.launcher.ui.dialog.TextFieldDialog
 
 @Composable
-fun CustomLabelDialog(
+internal fun EditEblanApplicationInfoCustomLabelDialog(
     modifier: Modifier = Modifier,
-    title: String,
-    textFieldTitle: String,
-    value: String,
-    isError: Boolean,
-    keyboardType: KeyboardType,
-    singleLine: Boolean = true,
-    onValueChange: (String) -> Unit,
+    eblanApplicationInfo: EblanApplicationInfo,
     onDismissRequest: () -> Unit,
-    onUpdateClick: () -> Unit,
-    onResetClick: () -> Unit,
+    onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
 ) {
-    EblanDialogContainer(
-        content = {
-            Column(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(10.dp),
+    var value by remember {
+        mutableStateOf(eblanApplicationInfo.customLabel ?: "")
+    }
+
+    var isError by remember { mutableStateOf(false) }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Custom Label",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    if (value.isNotBlank()) {
+                        onUpdateEblanApplicationInfo(
+                            eblanApplicationInfo.copy(customLabel = value),
+                        )
+                        onDismissRequest()
+                    } else {
+                        isError = true
+                    }
+                },
             ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            Column {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(text = title, style = MaterialTheme.typography.titleLarge)
+                    Text(
+                        text = "Custom Label",
+                        style = MaterialTheme.typography.titleLarge,
+                    )
 
                     IconButton(
                         enabled = value.isNotBlank(),
-                        onClick = onResetClick,
+                        onClick = {
+                            onUpdateEblanApplicationInfo(
+                                eblanApplicationInfo.copy(customLabel = null),
+                            )
+                            onDismissRequest()
+                        },
                     ) {
                         Icon(
                             imageVector = EblanLauncherIcons.Delete,
@@ -82,40 +112,22 @@ fun CustomLabelDialog(
 
                 TextField(
                     value = value,
-                    onValueChange = onValueChange,
+                    onValueChange = {
+                        value = it
+                        isError = false
+                    },
                     modifier = Modifier.fillMaxWidth(),
-                    label = {
-                        Text(text = textFieldTitle)
-                    },
-                    supportingText = {
-                        if (isError) {
-                            Text(text = "$textFieldTitle is not valid")
-                        }
-                    },
+                    label = { Text("Custom Label") },
                     isError = isError,
-                    keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-                    singleLine = singleLine,
+                    supportingText = {
+                        if (isError) Text("Custom Label is not valid")
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                    ),
+                    singleLine = true,
                 )
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    TextButton(
-                        onClick = onDismissRequest,
-                    ) {
-                        Text(text = "Cancel")
-                    }
-                    TextButton(
-                        onClick = onUpdateClick,
-                    ) {
-                        Text(text = "Update")
-                    }
-                }
             }
         },
-        onDismissRequest = onDismissRequest,
     )
 }

--- a/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/EditEblanApplicationInfoCustomLabelDialog.kt
+++ b/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/EditEblanApplicationInfoCustomLabelDialog.kt
@@ -62,7 +62,7 @@ internal fun EditEblanApplicationInfoCustomLabelDialog(
         onDismissRequest = onDismissRequest,
         actions = {
             TextButton(onClick = onDismissRequest) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -77,7 +77,7 @@ internal fun EditEblanApplicationInfoCustomLabelDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -117,10 +117,14 @@ internal fun EditEblanApplicationInfoCustomLabelDialog(
                         isError = false
                     },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Custom Label") },
+                    label = { Text(text = "Custom Label") },
                     isError = isError,
-                    supportingText = {
-                        if (isError) Text("Custom Label is not valid")
+                    supportingText = if (isError) {
+                        {
+                            Text(text = "Custom Label is not valid")
+                        }
+                    } else {
+                        null
                     },
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Text,

--- a/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/TagDialog.kt
+++ b/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/TagDialog.kt
@@ -1,0 +1,207 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.editapplicationinfo.dialog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.eblan.launcher.designsystem.component.EblanDialogContainer
+import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
+import com.eblan.launcher.domain.model.EblanApplicationInfoTag
+import com.eblan.launcher.domain.model.EblanApplicationInfoTagUi
+import com.eblan.launcher.ui.dialog.TextFieldDialog
+
+@Composable
+internal fun AddTagDialog(
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit,
+    onAddEblanApplicationInfoTag: (EblanApplicationInfoTag) -> Unit,
+) {
+    var value by remember { mutableStateOf("") }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Add Tag",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    if (value.isNotBlank()) {
+                        onAddEblanApplicationInfoTag(
+                            EblanApplicationInfoTag(
+                                name = value,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text("Add")
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text("Add Tag")
+                },
+                isError = value.isBlank(),
+                supportingText = {
+                    if (value.isBlank()) {
+                        Text("Tag is not valid")
+                    }
+                },
+            )
+        },
+    )
+}
+
+@Composable
+internal fun UpdateTagDialog(
+    modifier: Modifier = Modifier,
+    eblanApplicationInfoTagUi: EblanApplicationInfoTagUi?,
+    onDeleteEblanApplicationInfoTag: (EblanApplicationInfoTag) -> Unit,
+    onDismissRequest: () -> Unit,
+    onUpdateEblanApplicationInfoTag: (EblanApplicationInfoTag) -> Unit,
+) {
+    if (eblanApplicationInfoTagUi == null) return
+
+    var value by remember { mutableStateOf(eblanApplicationInfoTagUi.name) }
+
+    var isError by remember { mutableStateOf(false) }
+
+    EblanDialogContainer(
+        content = {
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(10.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(text = "Update Tag", style = MaterialTheme.typography.titleLarge)
+
+                    IconButton(
+                        onClick = {
+                            onDeleteEblanApplicationInfoTag(
+                                EblanApplicationInfoTag(
+                                    id = eblanApplicationInfoTagUi.id,
+                                    name = eblanApplicationInfoTagUi.name,
+                                ),
+                            )
+
+                            onDismissRequest()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = EblanLauncherIcons.Delete,
+                            contentDescription = null,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                TextField(
+                    value = value,
+                    onValueChange = {
+                        value = it
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = {
+                        Text(text = "Update Tag")
+                    },
+                    supportingText = {
+                        if (isError) {
+                            Text(text = "Tag is not valid")
+                        }
+                    },
+                    isError = isError,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+                    singleLine = true,
+                )
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(
+                        onClick = onDismissRequest,
+                    ) {
+                        Text(text = "Cancel")
+                    }
+                    TextButton(
+                        onClick = {
+                            if (value.isNotBlank()) {
+                                onUpdateEblanApplicationInfoTag(
+                                    EblanApplicationInfoTag(
+                                        id = eblanApplicationInfoTagUi.id,
+                                        name = value,
+                                    ),
+                                )
+
+                                onDismissRequest()
+                            } else {
+                                isError = true
+                            }
+                        },
+                    ) {
+                        Text(text = "Update")
+                    }
+                }
+            }
+        },
+        onDismissRequest = onDismissRequest,
+    )
+}

--- a/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/TagDialog.kt
+++ b/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/TagDialog.kt
@@ -60,7 +60,28 @@ internal fun AddTagDialog(
         modifier = modifier,
         title = "Add Tag",
         onDismissRequest = onDismissRequest,
-        actions = {
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                    isError = false
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text(text = "Add Tag")
+                },
+                isError = isError,
+                supportingText = if (isError) {
+                    {
+                        Text(text = "Tag is not valid")
+                    }
+                } else {
+                    null
+                },
+            )
+        },
+        bottomActions = {
             TextButton(
                 onClick = onDismissRequest,
             ) {
@@ -84,27 +105,6 @@ internal fun AddTagDialog(
             ) {
                 Text(text = "Add")
             }
-        },
-        textField = {
-            TextField(
-                value = value,
-                onValueChange = {
-                    value = it
-                    isError = false
-                },
-                modifier = Modifier.fillMaxWidth(),
-                label = {
-                    Text(text = "Add Tag")
-                },
-                isError = isError,
-                supportingText = if (isError) {
-                    {
-                        Text(text = "Tag is not valid")
-                    }
-                } else {
-                    null
-                },
-            )
         },
     )
 }

--- a/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/TagDialog.kt
+++ b/feature/edit-application-info/src/main/kotlin/com/eblan/launcher/feature/editapplicationinfo/dialog/TagDialog.kt
@@ -54,6 +54,8 @@ internal fun AddTagDialog(
 ) {
     var value by remember { mutableStateOf("") }
 
+    var isError by remember { mutableStateOf(false) }
+
     TextFieldDialog(
         modifier = modifier,
         title = "Add Tag",
@@ -62,7 +64,7 @@ internal fun AddTagDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -75,10 +77,12 @@ internal fun AddTagDialog(
                         )
 
                         onDismissRequest()
+                    } else {
+                        isError = true
                     }
                 },
             ) {
-                Text("Add")
+                Text(text = "Add")
             }
         },
         textField = {
@@ -86,16 +90,19 @@ internal fun AddTagDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {
-                    Text("Add Tag")
+                    Text(text = "Add Tag")
                 },
-                isError = value.isBlank(),
-                supportingText = {
-                    if (value.isBlank()) {
-                        Text("Tag is not valid")
+                isError = isError,
+                supportingText = if (isError) {
+                    {
+                        Text(text = "Tag is not valid")
                     }
+                } else {
+                    null
                 },
             )
         },

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/EditGridItemScreen.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/EditGridItemScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -51,11 +50,13 @@ import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.IconPackInfoComponent
 import com.eblan.launcher.domain.model.PackageManagerIconPackInfo
+import com.eblan.launcher.feature.editgriditem.dialog.EditApplicationInfoCustomLabelDialog
+import com.eblan.launcher.feature.editgriditem.dialog.EditFolderLabelDialog
+import com.eblan.launcher.feature.editgriditem.dialog.EditShortcutConfigCustomLabelDialog
+import com.eblan.launcher.feature.editgriditem.dialog.EditShortcutInfoCustomShortLabelDialog
 import com.eblan.launcher.feature.editgriditem.model.EditGridItemUiState
 import com.eblan.launcher.ui.dialog.IconPackInfoFilesDialog
-import com.eblan.launcher.ui.dialog.SingleTextFieldDialog
 import com.eblan.launcher.ui.edit.CustomIcon
-import com.eblan.launcher.ui.edit.CustomLabelDialog
 import com.eblan.launcher.ui.settings.EblanActionSettings
 import com.eblan.launcher.ui.settings.GridItemSettings
 import com.eblan.launcher.ui.settings.SettingsColumn
@@ -358,40 +359,13 @@ private fun EditApplicationInfo(
     }
 
     if (showCustomLabelDialog) {
-        var value by remember { mutableStateOf(data.customLabel ?: "") }
-
-        var isError by remember { mutableStateOf(false) }
-
-        CustomLabelDialog(
-            title = "Custom Label",
-            textFieldTitle = "Custom Label",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Text,
-            onValueChange = {
-                value = it
-            },
+        EditApplicationInfoCustomLabelDialog(
+            gridItem = gridItem,
+            data = data,
             onDismissRequest = {
                 showCustomLabelDialog = false
             },
-            onUpdateClick = {
-                if (value.isNotBlank()) {
-                    val newData = data.copy(customLabel = value)
-
-                    onUpdateGridItem(gridItem.copy(data = newData))
-
-                    showCustomLabelDialog = false
-                } else {
-                    isError = true
-                }
-            },
-            onResetClick = {
-                val newData = data.copy(customLabel = null)
-
-                onUpdateGridItem(gridItem.copy(data = newData))
-
-                showCustomLabelDialog = false
-            },
+            onUpdateGridItem = onUpdateGridItem,
         )
     }
 }
@@ -472,33 +446,13 @@ private fun EditFolder(
     }
 
     if (showEditLabelDialog) {
-        var value by remember { mutableStateOf(data.label) }
-
-        var isError by remember { mutableStateOf(false) }
-
-        SingleTextFieldDialog(
-            title = "Label",
-            textFieldTitle = "Label",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Text,
-            onValueChange = {
-                value = it
-            },
+        EditFolderLabelDialog(
+            gridItem = gridItem,
+            data = data,
             onDismissRequest = {
                 showEditLabelDialog = false
             },
-            onUpdateClick = {
-                if (value.isNotBlank()) {
-                    val newData = data.copy(label = value)
-
-                    onUpdateGridItem(gridItem.copy(data = newData))
-
-                    showEditLabelDialog = false
-                } else {
-                    isError = true
-                }
-            },
+            onUpdateGridItem = onUpdateGridItem,
         )
     }
 }
@@ -579,40 +533,13 @@ private fun EditShortcutInfo(
     }
 
     if (showCustomShortLabelDialog) {
-        var value by remember { mutableStateOf(data.customShortLabel ?: "") }
-
-        var isError by remember { mutableStateOf(false) }
-
-        CustomLabelDialog(
-            title = "Custom Short Label",
-            textFieldTitle = "Custom Short Label",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Text,
-            onValueChange = {
-                value = it
-            },
+        EditShortcutInfoCustomShortLabelDialog(
+            data = data,
+            gridItem = gridItem,
             onDismissRequest = {
                 showCustomShortLabelDialog = false
             },
-            onUpdateClick = {
-                if (value.isNotBlank()) {
-                    val newData = data.copy(customShortLabel = value)
-
-                    onUpdateGridItem(gridItem.copy(data = newData))
-
-                    showCustomShortLabelDialog = false
-                } else {
-                    isError = true
-                }
-            },
-            onResetClick = {
-                val newData = data.copy(customShortLabel = null)
-
-                onUpdateGridItem(gridItem.copy(data = newData))
-
-                showCustomShortLabelDialog = false
-            },
+            onUpdateGridItem = onUpdateGridItem,
         )
     }
 }
@@ -693,40 +620,13 @@ private fun EditShortcutConfig(
     }
 
     if (showCustomLabelDialog) {
-        var value by remember { mutableStateOf(data.customLabel ?: "") }
-
-        var isError by remember { mutableStateOf(false) }
-
-        CustomLabelDialog(
-            title = "Custom Label",
-            textFieldTitle = "Custom Label",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Text,
-            onValueChange = {
-                value = it
-            },
+        EditShortcutConfigCustomLabelDialog(
+            data = data,
+            gridItem = gridItem,
             onDismissRequest = {
                 showCustomLabelDialog = false
             },
-            onUpdateClick = {
-                if (value.isNotBlank()) {
-                    val newData = data.copy(customLabel = value)
-
-                    onUpdateGridItem(gridItem.copy(data = newData))
-
-                    showCustomLabelDialog = false
-                } else {
-                    isError = true
-                }
-            },
-            onResetClick = {
-                val newData = data.copy(customLabel = null)
-
-                onUpdateGridItem(gridItem.copy(data = newData))
-
-                showCustomLabelDialog = false
-            },
+            onUpdateGridItem = onUpdateGridItem,
         )
     }
 }

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditApplicationInfoCustomLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditApplicationInfoCustomLabelDialog.kt
@@ -76,6 +76,7 @@ internal fun EditApplicationInfoCustomLabelDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditApplicationInfoCustomLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditApplicationInfoCustomLabelDialog.kt
@@ -64,7 +64,7 @@ internal fun EditApplicationInfoCustomLabelDialog(
         onDismissRequest = onDismissRequest,
         actions = {
             TextButton(onClick = onDismissRequest) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -81,7 +81,7 @@ internal fun EditApplicationInfoCustomLabelDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -123,10 +123,14 @@ internal fun EditApplicationInfoCustomLabelDialog(
                         isError = false
                     },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Custom Label") },
+                    label = { Text(text = "Custom Label") },
                     isError = isError,
-                    supportingText = {
-                        if (isError) Text("Custom Label is not valid")
+                    supportingText = if (isError) {
+                        {
+                            Text(text = "Custom Label is not valid")
+                        }
+                    } else {
+                        null
                     },
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Text,

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditApplicationInfoCustomLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditApplicationInfoCustomLabelDialog.kt
@@ -17,16 +17,9 @@
  */
 package com.eblan.launcher.feature.editgriditem.dialog
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
@@ -35,10 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
@@ -62,7 +52,46 @@ internal fun EditApplicationInfoCustomLabelDialog(
         modifier = modifier,
         title = "Custom Label",
         onDismissRequest = onDismissRequest,
-        actions = {
+        topActions = {
+            IconButton(
+                enabled = value.isNotBlank(),
+                onClick = {
+                    onUpdateGridItem(
+                        gridItem.copy(
+                            data = data.copy(customLabel = null),
+                        ),
+                    )
+
+                    onDismissRequest()
+                },
+            ) {
+                Icon(
+                    imageVector = EblanLauncherIcons.Delete,
+                    contentDescription = null,
+                )
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text(text = "Custom Label")
+                },
+                isError = isError,
+                supportingText = if (isError) {
+                    {
+                        Text("Custom label is not valid")
+                    }
+                } else {
+                    null
+                },
+            )
+        },
+        bottomActions = {
             TextButton(onClick = onDismissRequest) {
                 Text(text = "Cancel")
             }
@@ -75,6 +104,7 @@ internal fun EditApplicationInfoCustomLabelDialog(
                                 data = data.copy(customLabel = value),
                             ),
                         )
+
                         onDismissRequest()
                     } else {
                         isError = true
@@ -82,61 +112,6 @@ internal fun EditApplicationInfoCustomLabelDialog(
                 },
             ) {
                 Text(text = "Update")
-            }
-        },
-        textField = {
-            Column {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "Custom Label",
-                        style = MaterialTheme.typography.titleLarge,
-                    )
-
-                    IconButton(
-                        enabled = value.isNotBlank(),
-                        onClick = {
-                            onUpdateGridItem(
-                                gridItem.copy(
-                                    data = data.copy(customLabel = null),
-                                ),
-                            )
-                            onDismissRequest()
-                        },
-                    ) {
-                        Icon(
-                            imageVector = EblanLauncherIcons.Delete,
-                            contentDescription = null,
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                TextField(
-                    value = value,
-                    onValueChange = {
-                        value = it
-                        isError = false
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text(text = "Custom Label") },
-                    isError = isError,
-                    supportingText = if (isError) {
-                        {
-                            Text(text = "Custom Label is not valid")
-                        }
-                    } else {
-                        null
-                    },
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = KeyboardType.Text,
-                    ),
-                    singleLine = true,
-                )
             }
         },
     )

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditApplicationInfoCustomLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditApplicationInfoCustomLabelDialog.kt
@@ -1,0 +1,139 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.editgriditem.dialog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
+import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.model.GridItemData
+import com.eblan.launcher.ui.dialog.TextFieldDialog
+
+@Composable
+internal fun EditApplicationInfoCustomLabelDialog(
+    modifier: Modifier = Modifier,
+    gridItem: GridItem,
+    data: GridItemData.ApplicationInfo,
+    onDismissRequest: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
+) {
+    var value by remember {
+        mutableStateOf(data.customLabel ?: "")
+    }
+
+    var isError by remember { mutableStateOf(false) }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Custom Label",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    if (value.isNotBlank()) {
+                        onUpdateGridItem(
+                            gridItem.copy(
+                                data = data.copy(customLabel = value),
+                            ),
+                        )
+                        onDismissRequest()
+                    } else {
+                        isError = true
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            Column {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Custom Label",
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+
+                    IconButton(
+                        enabled = value.isNotBlank(),
+                        onClick = {
+                            onUpdateGridItem(
+                                gridItem.copy(
+                                    data = data.copy(customLabel = null),
+                                ),
+                            )
+                            onDismissRequest()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = EblanLauncherIcons.Delete,
+                            contentDescription = null,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                TextField(
+                    value = value,
+                    onValueChange = {
+                        value = it
+                        isError = false
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Custom Label") },
+                    isError = isError,
+                    supportingText = {
+                        if (isError) Text("Custom Label is not valid")
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                    ),
+                    singleLine = true,
+                )
+            }
+        },
+    )
+}

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditFolderLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditFolderLabelDialog.kt
@@ -47,29 +47,6 @@ internal fun EditFolderLabelDialog(
         modifier = modifier,
         title = "Label",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    if (value.isNotBlank()) {
-                        val newData = data.copy(label = value)
-
-                        onUpdateGridItem(gridItem.copy(data = newData))
-
-                        onDismissRequest()
-                    } else {
-                        isError = true
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textField = {
             TextField(
                 value = value,
@@ -89,6 +66,27 @@ internal fun EditFolderLabelDialog(
                     null
                 },
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    if (value.isNotBlank()) {
+                        onUpdateGridItem(gridItem.copy(data = data.copy(label = value)))
+
+                        onDismissRequest()
+                    } else {
+                        isError = true
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditFolderLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditFolderLabelDialog.kt
@@ -51,7 +51,7 @@ internal fun EditFolderLabelDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -67,7 +67,7 @@ internal fun EditFolderLabelDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -78,13 +78,15 @@ internal fun EditFolderLabelDialog(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {
-                    Text("Label")
+                    Text(text = "Label")
                 },
                 isError = isError,
-                supportingText = {
-                    if (isError) {
+                supportingText = if (isError) {
+                    {
                         Text("Label is not valid")
                     }
+                } else {
+                    null
                 },
             )
         },

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditFolderLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditFolderLabelDialog.kt
@@ -52,6 +52,7 @@ internal fun EditFolderLabelDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditFolderLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditFolderLabelDialog.kt
@@ -1,0 +1,92 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.editgriditem.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.model.GridItemData
+import com.eblan.launcher.ui.dialog.TextFieldDialog
+
+@Composable
+internal fun EditFolderLabelDialog(
+    modifier: Modifier = Modifier,
+    gridItem: GridItem,
+    data: GridItemData.Folder,
+    onDismissRequest: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
+) {
+    var value by remember { mutableStateOf(data.label) }
+
+    var isError by remember { mutableStateOf(false) }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Label",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    if (value.isNotBlank()) {
+                        val newData = data.copy(label = value)
+
+                        onUpdateGridItem(gridItem.copy(data = newData))
+
+                        onDismissRequest()
+                    } else {
+                        isError = true
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text("Label")
+                },
+                isError = isError,
+                supportingText = {
+                    if (isError) {
+                        Text("Label is not valid")
+                    }
+                },
+            )
+        },
+    )
+}

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutConfigCustomLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutConfigCustomLabelDialog.kt
@@ -64,7 +64,7 @@ internal fun EditShortcutConfigCustomLabelDialog(
         onDismissRequest = onDismissRequest,
         actions = {
             TextButton(onClick = onDismissRequest) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -81,7 +81,7 @@ internal fun EditShortcutConfigCustomLabelDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -123,10 +123,14 @@ internal fun EditShortcutConfigCustomLabelDialog(
                         isError = false
                     },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Custom Label") },
+                    label = { Text(text = "Custom Label") },
                     isError = isError,
-                    supportingText = {
-                        if (isError) Text("Custom Label is not valid")
+                    supportingText = if (isError) {
+                        {
+                            Text("Custom Label is not valid")
+                        }
+                    } else {
+                        null
                     },
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Text,

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutConfigCustomLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutConfigCustomLabelDialog.kt
@@ -15,7 +15,7 @@
  *   limitations under the License.
  *
  */
-package com.eblan.launcher.feature.editapplicationinfo.dialog
+package com.eblan.launcher.feature.editgriditem.dialog
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -40,48 +39,71 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import com.eblan.launcher.designsystem.component.EblanDialogContainer
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
-import com.eblan.launcher.domain.model.EblanApplicationInfoTag
-import com.eblan.launcher.domain.model.EblanApplicationInfoTagUi
+import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.model.GridItemData
+import com.eblan.launcher.ui.dialog.TextFieldDialog
 
 @Composable
-internal fun UpdateTagDialog(
+internal fun EditShortcutConfigCustomLabelDialog(
     modifier: Modifier = Modifier,
-    eblanApplicationInfoTagUi: EblanApplicationInfoTagUi?,
-    onDeleteEblanApplicationInfoTag: (EblanApplicationInfoTag) -> Unit,
+    gridItem: GridItem,
+    data: GridItemData.ShortcutConfig,
     onDismissRequest: () -> Unit,
-    onUpdateEblanApplicationInfoTag: (EblanApplicationInfoTag) -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
-    if (eblanApplicationInfoTagUi == null) return
-
-    var value by remember { mutableStateOf(eblanApplicationInfoTagUi.name) }
+    var value by remember {
+        mutableStateOf(data.customLabel ?: "")
+    }
 
     var isError by remember { mutableStateOf(false) }
 
-    EblanDialogContainer(
-        content = {
-            Column(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(10.dp),
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Custom Label",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    if (value.isNotBlank()) {
+                        onUpdateGridItem(
+                            gridItem.copy(
+                                data = data.copy(customLabel = value),
+                            ),
+                        )
+                        onDismissRequest()
+                    } else {
+                        isError = true
+                    }
+                },
             ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            Column {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(text = "Update Tag", style = MaterialTheme.typography.titleLarge)
+                    Text(
+                        text = "Custom Label",
+                        style = MaterialTheme.typography.titleLarge,
+                    )
 
                     IconButton(
+                        enabled = value.isNotBlank(),
                         onClick = {
-                            onDeleteEblanApplicationInfoTag(
-                                EblanApplicationInfoTag(
-                                    id = eblanApplicationInfoTagUi.id,
-                                    name = eblanApplicationInfoTagUi.name,
+                            onUpdateGridItem(
+                                gridItem.copy(
+                                    data = data.copy(customLabel = null),
                                 ),
                             )
-
                             onDismissRequest()
                         },
                     ) {
@@ -98,53 +120,20 @@ internal fun UpdateTagDialog(
                     value = value,
                     onValueChange = {
                         value = it
+                        isError = false
                     },
                     modifier = Modifier.fillMaxWidth(),
-                    label = {
-                        Text(text = "Update Tag")
-                    },
-                    supportingText = {
-                        if (isError) {
-                            Text(text = "Tag is not valid")
-                        }
-                    },
+                    label = { Text("Custom Label") },
                     isError = isError,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+                    supportingText = {
+                        if (isError) Text("Custom Label is not valid")
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                    ),
                     singleLine = true,
                 )
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    TextButton(
-                        onClick = onDismissRequest,
-                    ) {
-                        Text(text = "Cancel")
-                    }
-                    TextButton(
-                        onClick = {
-                            if (value.isNotBlank()) {
-                                onUpdateEblanApplicationInfoTag(
-                                    EblanApplicationInfoTag(
-                                        id = eblanApplicationInfoTagUi.id,
-                                        name = value,
-                                    ),
-                                )
-
-                                onDismissRequest()
-                            } else {
-                                isError = true
-                            }
-                        },
-                    ) {
-                        Text(text = "Update")
-                    }
-                }
             }
         },
-        onDismissRequest = onDismissRequest,
     )
 }

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutConfigCustomLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutConfigCustomLabelDialog.kt
@@ -76,6 +76,7 @@ internal fun EditShortcutConfigCustomLabelDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutConfigCustomLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutConfigCustomLabelDialog.kt
@@ -17,16 +17,9 @@
  */
 package com.eblan.launcher.feature.editgriditem.dialog
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
@@ -35,10 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
@@ -62,7 +52,46 @@ internal fun EditShortcutConfigCustomLabelDialog(
         modifier = modifier,
         title = "Custom Label",
         onDismissRequest = onDismissRequest,
-        actions = {
+        topActions = {
+            IconButton(
+                enabled = value.isNotBlank(),
+                onClick = {
+                    onUpdateGridItem(
+                        gridItem.copy(
+                            data = data.copy(customLabel = null),
+                        ),
+                    )
+
+                    onDismissRequest()
+                },
+            ) {
+                Icon(
+                    imageVector = EblanLauncherIcons.Delete,
+                    contentDescription = null,
+                )
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text(text = "Custom Label")
+                },
+                isError = isError,
+                supportingText = if (isError) {
+                    {
+                        Text("Custom label is not valid")
+                    }
+                } else {
+                    null
+                },
+            )
+        },
+        bottomActions = {
             TextButton(onClick = onDismissRequest) {
                 Text(text = "Cancel")
             }
@@ -75,6 +104,7 @@ internal fun EditShortcutConfigCustomLabelDialog(
                                 data = data.copy(customLabel = value),
                             ),
                         )
+
                         onDismissRequest()
                     } else {
                         isError = true
@@ -82,61 +112,6 @@ internal fun EditShortcutConfigCustomLabelDialog(
                 },
             ) {
                 Text(text = "Update")
-            }
-        },
-        textField = {
-            Column {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "Custom Label",
-                        style = MaterialTheme.typography.titleLarge,
-                    )
-
-                    IconButton(
-                        enabled = value.isNotBlank(),
-                        onClick = {
-                            onUpdateGridItem(
-                                gridItem.copy(
-                                    data = data.copy(customLabel = null),
-                                ),
-                            )
-                            onDismissRequest()
-                        },
-                    ) {
-                        Icon(
-                            imageVector = EblanLauncherIcons.Delete,
-                            contentDescription = null,
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                TextField(
-                    value = value,
-                    onValueChange = {
-                        value = it
-                        isError = false
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text(text = "Custom Label") },
-                    isError = isError,
-                    supportingText = if (isError) {
-                        {
-                            Text("Custom Label is not valid")
-                        }
-                    } else {
-                        null
-                    },
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = KeyboardType.Text,
-                    ),
-                    singleLine = true,
-                )
             }
         },
     )

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutInfoCustomShortLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutInfoCustomShortLabelDialog.kt
@@ -17,16 +17,9 @@
  */
 package com.eblan.launcher.feature.editgriditem.dialog
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
@@ -35,10 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
@@ -62,7 +52,46 @@ internal fun EditShortcutInfoCustomShortLabelDialog(
         modifier = modifier,
         title = "Custom Short Label",
         onDismissRequest = onDismissRequest,
-        actions = {
+        topActions = {
+            IconButton(
+                enabled = value.isNotBlank(),
+                onClick = {
+                    onUpdateGridItem(
+                        gridItem.copy(
+                            data = data.copy(customShortLabel = null),
+                        ),
+                    )
+
+                    onDismissRequest()
+                },
+            ) {
+                Icon(
+                    imageVector = EblanLauncherIcons.Delete,
+                    contentDescription = null,
+                )
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text(text = "Custom Short Label")
+                },
+                isError = isError,
+                supportingText = if (isError) {
+                    {
+                        Text("Custom short label is not valid")
+                    }
+                } else {
+                    null
+                },
+            )
+        },
+        bottomActions = {
             TextButton(onClick = onDismissRequest) {
                 Text(text = "Cancel")
             }
@@ -75,6 +104,7 @@ internal fun EditShortcutInfoCustomShortLabelDialog(
                                 data = data.copy(customShortLabel = value),
                             ),
                         )
+
                         onDismissRequest()
                     } else {
                         isError = true
@@ -82,61 +112,6 @@ internal fun EditShortcutInfoCustomShortLabelDialog(
                 },
             ) {
                 Text(text = "Update")
-            }
-        },
-        textField = {
-            Column {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "Custom Short Label",
-                        style = MaterialTheme.typography.titleLarge,
-                    )
-
-                    IconButton(
-                        enabled = value.isNotBlank(),
-                        onClick = {
-                            onUpdateGridItem(
-                                gridItem.copy(
-                                    data = data.copy(customShortLabel = null),
-                                ),
-                            )
-                            onDismissRequest()
-                        },
-                    ) {
-                        Icon(
-                            imageVector = EblanLauncherIcons.Delete,
-                            contentDescription = null,
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                TextField(
-                    value = value,
-                    onValueChange = {
-                        value = it
-                        isError = false
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text(text = "Custom Short Label") },
-                    isError = isError,
-                    supportingText = if (isError) {
-                        {
-                            Text("Custom Short Label is not valid")
-                        }
-                    } else {
-                        null
-                    },
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = KeyboardType.Text,
-                    ),
-                    singleLine = true,
-                )
             }
         },
     )

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutInfoCustomShortLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutInfoCustomShortLabelDialog.kt
@@ -76,6 +76,7 @@ internal fun EditShortcutInfoCustomShortLabelDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutInfoCustomShortLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutInfoCustomShortLabelDialog.kt
@@ -64,7 +64,7 @@ internal fun EditShortcutInfoCustomShortLabelDialog(
         onDismissRequest = onDismissRequest,
         actions = {
             TextButton(onClick = onDismissRequest) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -81,7 +81,7 @@ internal fun EditShortcutInfoCustomShortLabelDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -123,10 +123,14 @@ internal fun EditShortcutInfoCustomShortLabelDialog(
                         isError = false
                     },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Custom Short Label") },
+                    label = { Text(text = "Custom Short Label") },
                     isError = isError,
-                    supportingText = {
-                        if (isError) Text("Custom Short Label is not valid")
+                    supportingText = if (isError) {
+                        {
+                            Text("Custom Short Label is not valid")
+                        }
+                    } else {
+                        null
                     },
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Text,

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutInfoCustomShortLabelDialog.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/dialog/EditShortcutInfoCustomShortLabelDialog.kt
@@ -1,0 +1,139 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.editgriditem.dialog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
+import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.model.GridItemData
+import com.eblan.launcher.ui.dialog.TextFieldDialog
+
+@Composable
+internal fun EditShortcutInfoCustomShortLabelDialog(
+    modifier: Modifier = Modifier,
+    gridItem: GridItem,
+    data: GridItemData.ShortcutInfo,
+    onDismissRequest: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
+) {
+    var value by remember {
+        mutableStateOf(data.customShortLabel ?: "")
+    }
+
+    var isError by remember { mutableStateOf(false) }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Custom Short Label",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    if (value.isNotBlank()) {
+                        onUpdateGridItem(
+                            gridItem.copy(
+                                data = data.copy(customShortLabel = value),
+                            ),
+                        )
+                        onDismissRequest()
+                    } else {
+                        isError = true
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            Column {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Custom Short Label",
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+
+                    IconButton(
+                        enabled = value.isNotBlank(),
+                        onClick = {
+                            onUpdateGridItem(
+                                gridItem.copy(
+                                    data = data.copy(customShortLabel = null),
+                                ),
+                            )
+                            onDismissRequest()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = EblanLauncherIcons.Delete,
+                            contentDescription = null,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                TextField(
+                    value = value,
+                    onValueChange = {
+                        value = it
+                        isError = false
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Custom Short Label") },
+                    isError = isError,
+                    supportingText = {
+                        if (isError) Text("Custom Short Label is not valid")
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                    ),
+                    singleLine = true,
+                )
+            }
+        },
+    )
+}

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -46,11 +45,12 @@ import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.AppDrawerSettings
 import com.eblan.launcher.domain.model.AppDrawerType
 import com.eblan.launcher.domain.model.EblanApplicationInfo
+import com.eblan.launcher.feature.settings.appdrawer.dialog.EditHorizontalGridDialog
+import com.eblan.launcher.feature.settings.appdrawer.dialog.EditVerticalGridDialog
 import com.eblan.launcher.feature.settings.appdrawer.dialog.HiddenEblanApplicationInfosDialog
 import com.eblan.launcher.feature.settings.appdrawer.model.AppDrawerSettingsUiState
 import com.eblan.launcher.ui.dialog.RadioOptionsDialog
 import com.eblan.launcher.ui.dialog.TextColorDialog
-import com.eblan.launcher.ui.dialog.TwoTextFieldsDialog
 import com.eblan.launcher.ui.settings.GridItemSettings
 import com.eblan.launcher.ui.settings.SettingsColumn
 import com.eblan.launcher.ui.settings.SettingsSwitch
@@ -245,126 +245,22 @@ private fun Success(
     }
 
     if (showVerticalGridDialog) {
-        var appDrawerColumns by remember { mutableStateOf("${appDrawerSettings.appDrawerColumns}") }
-
-        var appDrawerRowsHeight by remember { mutableStateOf("${appDrawerSettings.appDrawerRowsHeight}") }
-
-        var firstTextFieldIsError by remember { mutableStateOf(false) }
-
-        var secondTextFieldIsError by remember { mutableStateOf(false) }
-
-        TwoTextFieldsDialog(
-            title = "Vertical Grid",
-            firstTextFieldTitle = "Columns",
-            secondTextFieldTitle = "Rows Height",
-            firstTextFieldValue = appDrawerColumns,
-            secondTextFieldValue = appDrawerRowsHeight,
-            firstTextFieldIsError = firstTextFieldIsError,
-            secondTextFieldIsError = secondTextFieldIsError,
-            keyboardType = KeyboardType.Number,
-            onFirstValueChange = {
-                appDrawerColumns = it
-            },
-            onSecondValueChange = {
-                appDrawerRowsHeight = it
-            },
+        EditVerticalGridDialog(
+            appDrawerSettings = appDrawerSettings,
             onDismissRequest = {
                 showVerticalGridDialog = false
             },
-            onUpdateClick = {
-                val newAppDrawerColumns = try {
-                    appDrawerColumns.toInt()
-                } catch (_: NumberFormatException) {
-                    firstTextFieldIsError = true
-                    0
-                }
-
-                val newAppDrawerRowsHeight = try {
-                    appDrawerRowsHeight.toInt()
-                } catch (_: NumberFormatException) {
-                    secondTextFieldIsError = true
-                    0
-                }
-
-                if (newAppDrawerColumns > 0 && newAppDrawerRowsHeight > 0) {
-                    onUpdateAppDrawerSettings(
-                        appDrawerSettings.copy(
-                            appDrawerColumns = newAppDrawerColumns,
-                            appDrawerRowsHeight = newAppDrawerRowsHeight,
-                        ),
-                    )
-
-                    showVerticalGridDialog = false
-                }
-            },
+            onUpdateAppDrawerSettings = onUpdateAppDrawerSettings,
         )
     }
 
     if (showHorizontalGridDialog) {
-        var horizontalAppDrawerColumns by remember { mutableStateOf("${appDrawerSettings.horizontalAppDrawerColumns}") }
-
-        var horizontalAppDrawerRows by remember { mutableStateOf("${appDrawerSettings.horizontalAppDrawerRows}") }
-
-        var firstTextFieldIsError by remember { mutableStateOf(false) }
-
-        var secondTextFieldIsError by remember { mutableStateOf(false) }
-
-        TwoTextFieldsDialog(
-            title = "Horizontal Grid",
-            firstTextFieldTitle = "Columns",
-            secondTextFieldTitle = "Rows",
-            firstTextFieldValue = horizontalAppDrawerColumns,
-            secondTextFieldValue = horizontalAppDrawerRows,
-            firstTextFieldIsError = firstTextFieldIsError,
-            secondTextFieldIsError = secondTextFieldIsError,
-            keyboardType = KeyboardType.Number,
-            onFirstValueChange = {
-                horizontalAppDrawerColumns = it
-            },
-            onSecondValueChange = {
-                horizontalAppDrawerRows = it
-            },
+        EditHorizontalGridDialog(
+            appDrawerSettings = appDrawerSettings,
             onDismissRequest = {
                 showHorizontalGridDialog = false
             },
-            onUpdateClick = {
-                val newHorizontalAppDrawerColumns = try {
-                    if (horizontalAppDrawerColumns.toInt() > 2) {
-                        firstTextFieldIsError = false
-                        horizontalAppDrawerColumns.toInt()
-                    } else {
-                        firstTextFieldIsError = true
-                        0
-                    }
-                } catch (_: NumberFormatException) {
-                    firstTextFieldIsError = true
-                    0
-                }
-
-                val newHorizontalAppDrawerRows = try {
-                    if (horizontalAppDrawerRows.toInt() > 2) {
-                        secondTextFieldIsError = false
-                        horizontalAppDrawerRows.toInt()
-                    } else {
-                        secondTextFieldIsError = true
-                        0
-                    }
-                } catch (_: NumberFormatException) {
-                    secondTextFieldIsError = true
-                    0
-                }
-
-                if (newHorizontalAppDrawerColumns > 0 && newHorizontalAppDrawerRows > 0) {
-                    onUpdateAppDrawerSettings(
-                        appDrawerSettings.copy(
-                            horizontalAppDrawerColumns = newHorizontalAppDrawerColumns,
-                            horizontalAppDrawerRows = newHorizontalAppDrawerRows,
-                        ),
-                    )
-
-                    showHorizontalGridDialog = false
-                }
-            },
+            onUpdateAppDrawerSettings = onUpdateAppDrawerSettings,
         )
     }
 

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
@@ -111,10 +111,12 @@ internal fun EditHorizontalGridDialog(
                 onValueChange = { columns = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Columns") },
-                supportingText = {
-                    if (firstError) {
+                supportingText = if (firstError) {
+                    {
                         Text(text = "$columns is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
@@ -127,10 +129,12 @@ internal fun EditHorizontalGridDialog(
                 onValueChange = { rows = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Rows") },
-                supportingText = {
-                    if (secondError) {
+                supportingText = if (secondError) {
+                    {
                         Text(text = "$rows is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
@@ -56,7 +56,10 @@ internal fun EditHorizontalGridDialog(
         textFields = {
             TextField(
                 value = columns,
-                onValueChange = { columns = it },
+                onValueChange = {
+                    columns = it
+                    firstError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Columns") },
                 supportingText = if (firstError) {
@@ -74,7 +77,10 @@ internal fun EditHorizontalGridDialog(
 
             TextField(
                 value = rows,
-                onValueChange = { rows = it },
+                onValueChange = {
+                    rows = it
+                    secondError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Rows") },
                 supportingText = if (secondError) {

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
@@ -113,7 +113,7 @@ internal fun EditHorizontalGridDialog(
                 label = { Text(text = "Columns") },
                 supportingText = if (firstError) {
                     {
-                        Text(text = "$columns is not valid")
+                        Text(text = "Columns is not valid")
                     }
                 } else {
                     null
@@ -131,7 +131,7 @@ internal fun EditHorizontalGridDialog(
                 label = { Text(text = "Rows") },
                 supportingText = if (secondError) {
                     {
-                        Text(text = "$rows is not valid")
+                        Text(text = "Rows is not valid")
                     }
                 } else {
                     null

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
@@ -102,7 +102,7 @@ internal fun EditHorizontalGridDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textFields = {
@@ -110,7 +110,12 @@ internal fun EditHorizontalGridDialog(
                 value = columns,
                 onValueChange = { columns = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Columns") },
+                label = { Text(text = "Columns") },
+                supportingText = {
+                    if (firstError) {
+                        Text(text = "$columns is not valid")
+                    }
+                },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
@@ -121,7 +126,12 @@ internal fun EditHorizontalGridDialog(
                 value = rows,
                 onValueChange = { rows = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Rows") },
+                label = { Text(text = "Rows") },
+                supportingText = {
+                    if (secondError) {
+                        Text(text = "$rows is not valid")
+                    }
+                },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
@@ -17,8 +17,6 @@
  */
 package com.eblan.launcher.feature.settings.appdrawer.dialog
 
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -55,7 +53,44 @@ internal fun EditHorizontalGridDialog(
         modifier = modifier,
         title = "Horizontal Grid",
         onDismissRequest = onDismissRequest,
-        actions = {
+        textFields = {
+            TextField(
+                value = columns,
+                onValueChange = { columns = it },
+                modifier = Modifier.weight(1f),
+                label = { Text(text = "Columns") },
+                supportingText = if (firstError) {
+                    {
+                        Text(text = "Columns is not valid")
+                    }
+                } else {
+                    null
+                },
+                isError = firstError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+
+            TextField(
+                value = rows,
+                onValueChange = { rows = it },
+                modifier = Modifier.weight(1f),
+                label = { Text(text = "Rows") },
+                supportingText = if (secondError) {
+                    {
+                        Text(text = "Rows is not valid")
+                    }
+                } else {
+                    null
+                },
+                isError = secondError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+        bottomActions = {
             TextButton(
                 onClick = onDismissRequest,
             ) {
@@ -104,43 +139,6 @@ internal fun EditHorizontalGridDialog(
             ) {
                 Text(text = "Update")
             }
-        },
-        textFields = {
-            TextField(
-                value = columns,
-                onValueChange = { columns = it },
-                modifier = Modifier.weight(1f),
-                label = { Text(text = "Columns") },
-                supportingText = if (firstError) {
-                    {
-                        Text(text = "Columns is not valid")
-                    }
-                } else {
-                    null
-                },
-                isError = firstError,
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Number,
-                ),
-            )
-
-            TextField(
-                value = rows,
-                onValueChange = { rows = it },
-                modifier = Modifier.weight(1f),
-                label = { Text(text = "Rows") },
-                supportingText = if (secondError) {
-                    {
-                        Text(text = "Rows is not valid")
-                    }
-                } else {
-                    null
-                },
-                isError = secondError,
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Number,
-                ),
-            )
         },
     )
 }

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditHorizontalGridDialog.kt
@@ -1,0 +1,132 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.settings.appdrawer.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import com.eblan.launcher.domain.model.AppDrawerSettings
+import com.eblan.launcher.ui.dialog.RowTextFieldsDialog
+
+@Composable
+internal fun EditHorizontalGridDialog(
+    modifier: Modifier = Modifier,
+    appDrawerSettings: AppDrawerSettings,
+    onDismissRequest: () -> Unit,
+    onUpdateAppDrawerSettings: (AppDrawerSettings) -> Unit,
+) {
+    var columns by remember {
+        mutableStateOf("${appDrawerSettings.horizontalAppDrawerColumns}")
+    }
+
+    var rows by remember {
+        mutableStateOf("${appDrawerSettings.horizontalAppDrawerRows}")
+    }
+
+    var firstError by remember { mutableStateOf(false) }
+    var secondError by remember { mutableStateOf(false) }
+
+    RowTextFieldsDialog(
+        modifier = modifier,
+        title = "Horizontal Grid",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newColumns = try {
+                        if (columns.toInt() > 2) {
+                            firstError = false
+                            columns.toInt()
+                        } else {
+                            firstError = true
+                            0
+                        }
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newRows = try {
+                        if (rows.toInt() > 2) {
+                            secondError = false
+                            rows.toInt()
+                        } else {
+                            secondError = true
+                            0
+                        }
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newColumns > 0 && newRows > 0) {
+                        onUpdateAppDrawerSettings(
+                            appDrawerSettings.copy(
+                                horizontalAppDrawerColumns = newColumns,
+                                horizontalAppDrawerRows = newRows,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textFields = {
+            TextField(
+                value = columns,
+                onValueChange = { columns = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Columns") },
+                isError = firstError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+
+            TextField(
+                value = rows,
+                onValueChange = { rows = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Rows") },
+                isError = secondError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
@@ -56,7 +56,10 @@ internal fun EditVerticalGridDialog(
         textFields = {
             TextField(
                 value = columns,
-                onValueChange = { columns = it },
+                onValueChange = {
+                    columns = it
+                    firstError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Columns") },
                 supportingText = if (firstError) {
@@ -74,7 +77,10 @@ internal fun EditVerticalGridDialog(
 
             TextField(
                 value = rowsHeight,
-                onValueChange = { rowsHeight = it },
+                onValueChange = {
+                    rowsHeight = it
+                    secondError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Rows Height") },
                 supportingText = if (secondError) {

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
@@ -1,0 +1,118 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.settings.appdrawer.dialog
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import com.eblan.launcher.domain.model.AppDrawerSettings
+import com.eblan.launcher.ui.dialog.RowTextFieldsDialog
+
+@Composable
+internal fun EditVerticalGridDialog(
+    modifier: Modifier = Modifier,
+    appDrawerSettings: AppDrawerSettings,
+    onDismissRequest: () -> Unit,
+    onUpdateAppDrawerSettings: (AppDrawerSettings) -> Unit,
+) {
+    var columns by remember {
+        mutableStateOf("${appDrawerSettings.appDrawerColumns}")
+    }
+
+    var rowsHeight by remember {
+        mutableStateOf("${appDrawerSettings.appDrawerRowsHeight}")
+    }
+
+    var firstError by remember { mutableStateOf(false) }
+    var secondError by remember { mutableStateOf(false) }
+
+    RowTextFieldsDialog(
+        modifier = modifier,
+        title = "Vertical Grid",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newColumns = try {
+                        columns.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newRowsHeight = try {
+                        rowsHeight.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newColumns > 0 && newRowsHeight > 0) {
+                        onUpdateAppDrawerSettings(
+                            appDrawerSettings.copy(
+                                appDrawerColumns = newColumns,
+                                appDrawerRowsHeight = newRowsHeight,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textFields = {
+            TextField(
+                value = columns,
+                onValueChange = { columns = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Columns") },
+                isError = firstError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+
+            TextField(
+                value = rowsHeight,
+                onValueChange = { rowsHeight = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Rows Height") },
+                isError = secondError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
@@ -57,7 +57,7 @@ internal fun EditVerticalGridDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -88,7 +88,7 @@ internal fun EditVerticalGridDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textFields = {
@@ -96,7 +96,12 @@ internal fun EditVerticalGridDialog(
                 value = columns,
                 onValueChange = { columns = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Columns") },
+                label = { Text(text = "Columns") },
+                supportingText = {
+                    if (firstError) {
+                        Text(text = "$columns is not valid")
+                    }
+                },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
@@ -107,7 +112,12 @@ internal fun EditVerticalGridDialog(
                 value = rowsHeight,
                 onValueChange = { rowsHeight = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Rows Height") },
+                label = { Text(text = "Rows Height") },
+                supportingText = {
+                    if (secondError) {
+                        Text(text = "$rowsHeight is not valid")
+                    }
+                },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
@@ -97,10 +97,12 @@ internal fun EditVerticalGridDialog(
                 onValueChange = { columns = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Columns") },
-                supportingText = {
-                    if (firstError) {
+                supportingText = if (firstError) {
+                    {
                         Text(text = "$columns is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
@@ -113,10 +115,12 @@ internal fun EditVerticalGridDialog(
                 onValueChange = { rowsHeight = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Rows Height") },
-                supportingText = {
-                    if (secondError) {
+                supportingText = if (secondError) {
+                    {
                         Text(text = "$rowsHeight is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
@@ -99,7 +99,7 @@ internal fun EditVerticalGridDialog(
                 label = { Text(text = "Columns") },
                 supportingText = if (firstError) {
                     {
-                        Text(text = "$columns is not valid")
+                        Text(text = "Columns is not valid")
                     }
                 } else {
                     null
@@ -117,7 +117,7 @@ internal fun EditVerticalGridDialog(
                 label = { Text(text = "Rows Height") },
                 supportingText = if (secondError) {
                     {
-                        Text(text = "$rowsHeight is not valid")
+                        Text(text = "Rows height is not valid")
                     }
                 } else {
                     null

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/dialog/EditVerticalGridDialog.kt
@@ -53,44 +53,6 @@ internal fun EditVerticalGridDialog(
         modifier = modifier,
         title = "Vertical Grid",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    val newColumns = try {
-                        columns.toInt()
-                    } catch (_: NumberFormatException) {
-                        firstError = true
-                        0
-                    }
-
-                    val newRowsHeight = try {
-                        rowsHeight.toInt()
-                    } catch (_: NumberFormatException) {
-                        secondError = true
-                        0
-                    }
-
-                    if (newColumns > 0 && newRowsHeight > 0) {
-                        onUpdateAppDrawerSettings(
-                            appDrawerSettings.copy(
-                                appDrawerColumns = newColumns,
-                                appDrawerRowsHeight = newRowsHeight,
-                            ),
-                        )
-
-                        onDismissRequest()
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textFields = {
             TextField(
                 value = columns,
@@ -127,6 +89,44 @@ internal fun EditVerticalGridDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newColumns = try {
+                        columns.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newRowsHeight = try {
+                        rowsHeight.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newColumns > 0 && newRowsHeight > 0) {
+                        onUpdateAppDrawerSettings(
+                            appDrawerSettings.copy(
+                                appDrawerColumns = newColumns,
+                                appDrawerRowsHeight = newRowsHeight,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/HomeSettingsScreen.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/HomeSettingsScreen.kt
@@ -39,15 +39,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.HomeSettings
+import com.eblan.launcher.feature.settings.home.dialog.EditDockGridDialog
+import com.eblan.launcher.feature.settings.home.dialog.EditDockHeightDialog
+import com.eblan.launcher.feature.settings.home.dialog.EditFolderCellDimensionDialog
+import com.eblan.launcher.feature.settings.home.dialog.EditFolderMaxGridDialog
+import com.eblan.launcher.feature.settings.home.dialog.EditGridDialog
 import com.eblan.launcher.feature.settings.home.model.HomeSettingsUiState
-import com.eblan.launcher.ui.dialog.SingleTextFieldDialog
-import com.eblan.launcher.ui.dialog.TwoTextFieldsDialog
 import com.eblan.launcher.ui.settings.GridItemSettings
 import com.eblan.launcher.ui.settings.SettingsColumn
 import com.eblan.launcher.ui.settings.SettingsSwitch
@@ -272,262 +274,60 @@ private fun Success(
     }
 
     if (showGridDialog) {
-        var columns by remember { mutableStateOf("${homeSettings.columns}") }
-
-        var rows by remember { mutableStateOf("${homeSettings.rows}") }
-
-        var firstTextFieldIsError by remember { mutableStateOf(false) }
-
-        var secondTextFieldIsError by remember { mutableStateOf(false) }
-
-        TwoTextFieldsDialog(
-            title = "Grid",
-            firstTextFieldTitle = "Columns",
-            secondTextFieldTitle = "Rows",
-            firstTextFieldValue = columns,
-            secondTextFieldValue = rows,
-            firstTextFieldIsError = firstTextFieldIsError,
-            secondTextFieldIsError = secondTextFieldIsError,
-            keyboardType = KeyboardType.Number,
-            onFirstValueChange = {
-                columns = it
-            },
-            onSecondValueChange = {
-                rows = it
-            },
+        EditGridDialog(
+            homeSettings = homeSettings,
             onDismissRequest = {
                 showGridDialog = false
             },
-            onUpdateClick = {
-                val newColumns = try {
-                    columns.toInt()
-                } catch (_: NumberFormatException) {
-                    firstTextFieldIsError = true
-                    0
-                }
-
-                val newRows = try {
-                    rows.toInt()
-                } catch (_: NumberFormatException) {
-                    secondTextFieldIsError = true
-                    0
-                }
-
-                if (newColumns > 0 && newRows > 0) {
-                    onUpdateHomeSettings(
-                        homeSettings.copy(
-                            columns = newColumns,
-                            rows = newRows,
-                        ),
-                    )
-
-                    showGridDialog = false
-                }
-            },
+            onUpdateHomeSettings = onUpdateHomeSettings,
         )
     }
 
     if (showDockGridDialog) {
-        var dockColumns by remember { mutableStateOf("${homeSettings.dockColumns}") }
-
-        var dockRows by remember { mutableStateOf("${homeSettings.dockRows}") }
-
-        var firstTextFieldIsError by remember { mutableStateOf(false) }
-
-        var secondTextFieldIsError by remember { mutableStateOf(false) }
-
-        TwoTextFieldsDialog(
-            title = "Dock Grid",
-            firstTextFieldTitle = "Columns",
-            secondTextFieldTitle = "Rows",
-            firstTextFieldValue = dockColumns,
-            secondTextFieldValue = dockRows,
-            firstTextFieldIsError = firstTextFieldIsError,
-            secondTextFieldIsError = secondTextFieldIsError,
-            keyboardType = KeyboardType.Number,
-            onFirstValueChange = {
-                dockColumns = it
-            },
-            onSecondValueChange = {
-                dockRows = it
-            },
+        EditDockGridDialog(
+            homeSettings = homeSettings,
             onDismissRequest = {
                 showDockGridDialog = false
             },
-            onUpdateClick = {
-                val newDockColumns = try {
-                    dockColumns.toInt()
-                } catch (_: NumberFormatException) {
-                    firstTextFieldIsError = true
-                    0
-                }
-
-                val newDockRows = try {
-                    dockRows.toInt()
-                } catch (_: NumberFormatException) {
-                    secondTextFieldIsError = true
-                    0
-                }
-
-                if (newDockColumns > 0 && newDockRows > 0) {
-                    onUpdateHomeSettings(
-                        homeSettings.copy(
-                            dockColumns = newDockColumns,
-                            dockRows = newDockRows,
-                        ),
-                    )
-
-                    showDockGridDialog = false
-                }
-            },
+            onUpdateHomeSettings = onUpdateHomeSettings,
         )
     }
 
     if (showDockHeightDialog) {
-        var value by remember { mutableStateOf("${homeSettings.dockHeight}") }
-
-        var isError by remember { mutableStateOf(false) }
-
-        SingleTextFieldDialog(
-            title = "Dock Height",
-            textFieldTitle = "Dock Height",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Number,
-            onValueChange = {
-                value = it
-            },
+        EditDockHeightDialog(
+            dockHeight = homeSettings.dockHeight,
             onDismissRequest = {
                 showDockHeightDialog = false
             },
-            onUpdateClick = {
-                val dockHeight = try {
-                    value.toInt()
-                } catch (_: NumberFormatException) {
-                    isError = true
-                    0
-                }
+            onUpdateDockHeight = { dockHeight ->
+                onUpdateHomeSettings(
+                    homeSettings.copy(
+                        dockHeight = dockHeight,
+                    ),
+                )
 
-                if (dockHeight > 0) {
-                    onUpdateHomeSettings(
-                        homeSettings.copy(dockHeight = dockHeight),
-                    )
-
-                    showDockHeightDialog = false
-                }
+                showDockHeightDialog = false
             },
         )
     }
 
     if (showFolderCellDimensionDialog) {
-        var folderCellWidth by remember { mutableStateOf("${homeSettings.folderCellWidth}") }
-
-        var folderCellHeight by remember { mutableStateOf("${homeSettings.folderCellHeight}") }
-
-        var firstTextFieldIsError by remember { mutableStateOf(false) }
-
-        var secondTextFieldIsError by remember { mutableStateOf(false) }
-
-        TwoTextFieldsDialog(
-            title = "Folder Cell Dimension",
-            firstTextFieldTitle = "Cell Width",
-            secondTextFieldTitle = "Cell Height",
-            firstTextFieldValue = folderCellWidth,
-            secondTextFieldValue = folderCellHeight,
-            firstTextFieldIsError = firstTextFieldIsError,
-            secondTextFieldIsError = secondTextFieldIsError,
-            keyboardType = KeyboardType.Number,
-            onFirstValueChange = {
-                folderCellWidth = it
-            },
-            onSecondValueChange = {
-                folderCellHeight = it
-            },
+        EditFolderCellDimensionDialog(
+            homeSettings = homeSettings,
             onDismissRequest = {
                 showFolderCellDimensionDialog = false
             },
-            onUpdateClick = {
-                val newFolderCellWidth = try {
-                    folderCellWidth.toInt()
-                } catch (_: NumberFormatException) {
-                    firstTextFieldIsError = true
-                    0
-                }
-
-                val newFolderCellHeight = try {
-                    folderCellHeight.toInt()
-                } catch (_: NumberFormatException) {
-                    secondTextFieldIsError = true
-                    0
-                }
-
-                if (newFolderCellWidth > 0 && newFolderCellHeight > 0) {
-                    onUpdateHomeSettings(
-                        homeSettings.copy(
-                            folderCellWidth = newFolderCellWidth,
-                            folderCellHeight = newFolderCellHeight,
-                        ),
-                    )
-
-                    showFolderCellDimensionDialog = false
-                }
-            },
+            onUpdateHomeSettings = onUpdateHomeSettings,
         )
     }
 
     if (showFolderMaxGridDialog) {
-        var maxFolderColumns by remember { mutableStateOf("${homeSettings.maxFolderColumns}") }
-
-        var maxFolderRows by remember { mutableStateOf("${homeSettings.maxFolderRows}") }
-
-        var firstTextFieldIsError by remember { mutableStateOf(false) }
-
-        var secondTextFieldIsError by remember { mutableStateOf(false) }
-
-        TwoTextFieldsDialog(
-            title = "Folder Max Grid",
-            firstTextFieldTitle = "Columns",
-            secondTextFieldTitle = "Rows",
-            firstTextFieldValue = maxFolderColumns,
-            secondTextFieldValue = maxFolderRows,
-            firstTextFieldIsError = firstTextFieldIsError,
-            secondTextFieldIsError = secondTextFieldIsError,
-            keyboardType = KeyboardType.Number,
-            onFirstValueChange = {
-                maxFolderColumns = it
-            },
-            onSecondValueChange = {
-                maxFolderRows = it
-            },
+        EditFolderMaxGridDialog(
+            homeSettings = homeSettings,
             onDismissRequest = {
                 showFolderMaxGridDialog = false
             },
-            onUpdateClick = {
-                val newMaxFolderColumns = try {
-                    maxFolderColumns.toInt()
-                } catch (_: NumberFormatException) {
-                    firstTextFieldIsError = true
-                    0
-                }
-
-                val newMaxFolderRows = try {
-                    maxFolderRows.toInt()
-                } catch (_: NumberFormatException) {
-                    secondTextFieldIsError = true
-                    0
-                }
-
-                if (newMaxFolderColumns > 0 && newMaxFolderRows > 0) {
-                    onUpdateHomeSettings(
-                        homeSettings.copy(
-                            maxFolderColumns = newMaxFolderColumns,
-                            maxFolderRows = newMaxFolderRows,
-                        ),
-                    )
-
-                    showFolderMaxGridDialog = false
-                }
-            },
+            onUpdateHomeSettings = onUpdateHomeSettings,
         )
     }
 }

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
@@ -99,10 +99,12 @@ internal fun EditDockGridDialog(
                 onValueChange = { dockColumns = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Columns") },
-                supportingText = {
-                    if (firstError) {
+                supportingText = if (firstError) {
+                    {
                         Text(text = "$dockColumns is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
@@ -115,10 +117,12 @@ internal fun EditDockGridDialog(
                 onValueChange = { dockRows = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Rows") },
-                supportingText = {
-                    if (secondError) {
+                supportingText = if (secondError) {
+                    {
                         Text(text = "$dockRows is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
@@ -101,7 +101,7 @@ internal fun EditDockGridDialog(
                 label = { Text(text = "Columns") },
                 supportingText = if (firstError) {
                     {
-                        Text(text = "$dockColumns is not valid")
+                        Text(text = "Dock columns is not valid")
                     }
                 } else {
                     null
@@ -119,7 +119,7 @@ internal fun EditDockGridDialog(
                 label = { Text(text = "Rows") },
                 supportingText = if (secondError) {
                     {
-                        Text(text = "$dockRows is not valid")
+                        Text(text = "Dock rows is not valid")
                     }
                 } else {
                     null

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
@@ -1,0 +1,120 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.settings.home.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import com.eblan.launcher.domain.model.HomeSettings
+import com.eblan.launcher.ui.dialog.RowTextFieldsDialog
+
+@Composable
+internal fun EditDockGridDialog(
+    modifier: Modifier = Modifier,
+    homeSettings: HomeSettings,
+    onDismissRequest: () -> Unit,
+    onUpdateHomeSettings: (HomeSettings) -> Unit,
+) {
+    var dockColumns by remember {
+        mutableStateOf("${homeSettings.dockColumns}")
+    }
+
+    var dockRows by remember {
+        mutableStateOf("${homeSettings.dockRows}")
+    }
+
+    var firstError by remember { mutableStateOf(false) }
+    var secondError by remember { mutableStateOf(false) }
+
+    RowTextFieldsDialog(
+        modifier = modifier,
+        title = "Dock Grid",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newDockColumns = try {
+                        dockColumns.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newDockRows = try {
+                        dockRows.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newDockColumns > 0 && newDockRows > 0) {
+                        onUpdateHomeSettings(
+                            homeSettings.copy(
+                                dockColumns = newDockColumns,
+                                dockRows = newDockRows,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textFields = {
+            TextField(
+                value = dockColumns,
+                onValueChange = { dockColumns = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Columns") },
+                isError = firstError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+
+            TextField(
+                value = dockRows,
+                onValueChange = { dockRows = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Rows") },
+                isError = secondError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
@@ -17,8 +17,6 @@
  */
 package com.eblan.launcher.feature.settings.home.dialog
 
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -55,44 +53,6 @@ internal fun EditDockGridDialog(
         modifier = modifier,
         title = "Dock Grid",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    val newDockColumns = try {
-                        dockColumns.toInt()
-                    } catch (_: NumberFormatException) {
-                        firstError = true
-                        0
-                    }
-
-                    val newDockRows = try {
-                        dockRows.toInt()
-                    } catch (_: NumberFormatException) {
-                        secondError = true
-                        0
-                    }
-
-                    if (newDockColumns > 0 && newDockRows > 0) {
-                        onUpdateHomeSettings(
-                            homeSettings.copy(
-                                dockColumns = newDockColumns,
-                                dockRows = newDockRows,
-                            ),
-                        )
-
-                        onDismissRequest()
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textFields = {
             TextField(
                 value = dockColumns,
@@ -129,6 +89,44 @@ internal fun EditDockGridDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newDockColumns = try {
+                        dockColumns.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newDockRows = try {
+                        dockRows.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newDockColumns > 0 && newDockRows > 0) {
+                        onUpdateHomeSettings(
+                            homeSettings.copy(
+                                dockColumns = newDockColumns,
+                                dockRows = newDockRows,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
@@ -59,7 +59,7 @@ internal fun EditDockGridDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -90,7 +90,7 @@ internal fun EditDockGridDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textFields = {
@@ -98,7 +98,12 @@ internal fun EditDockGridDialog(
                 value = dockColumns,
                 onValueChange = { dockColumns = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Columns") },
+                label = { Text(text = "Columns") },
+                supportingText = {
+                    if (firstError) {
+                        Text(text = "$dockColumns is not valid")
+                    }
+                },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
@@ -109,7 +114,12 @@ internal fun EditDockGridDialog(
                 value = dockRows,
                 onValueChange = { dockRows = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Rows") },
+                label = { Text(text = "Rows") },
+                supportingText = {
+                    if (secondError) {
+                        Text(text = "$dockRows is not valid")
+                    }
+                },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockGridDialog.kt
@@ -56,7 +56,10 @@ internal fun EditDockGridDialog(
         textFields = {
             TextField(
                 value = dockColumns,
-                onValueChange = { dockColumns = it },
+                onValueChange = {
+                    dockColumns = it
+                    firstError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Columns") },
                 supportingText = if (firstError) {
@@ -74,7 +77,10 @@ internal fun EditDockGridDialog(
 
             TextField(
                 value = dockRows,
-                onValueChange = { dockRows = it },
+                onValueChange = {
+                    dockRows = it
+                    secondError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Rows") },
                 supportingText = if (secondError) {

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
@@ -52,7 +52,7 @@ internal fun EditDockHeightDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -69,7 +69,7 @@ internal fun EditDockHeightDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -80,12 +80,12 @@ internal fun EditDockHeightDialog(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {
-                    Text("Dock Height")
+                    Text(text = "Dock Height")
                 },
                 isError = isError,
                 supportingText = {
                     if (isError) {
-                        Text("Dock Height is not valid")
+                        Text(text = "Dock Height is not valid")
                     }
                 },
                 keyboardOptions = KeyboardOptions(

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
@@ -53,6 +53,7 @@ internal fun EditDockHeightDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
@@ -48,30 +48,6 @@ internal fun EditDockHeightDialog(
         modifier = modifier,
         title = "Dock Height",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    val newDockHeight = try {
-                        value.toInt()
-                    } catch (_: NumberFormatException) {
-                        isError = true
-                        0
-                    }
-
-                    if (newDockHeight > 0) {
-                        onUpdateDockHeight(newDockHeight)
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textField = {
             TextField(
                 value = value,
@@ -94,6 +70,30 @@ internal fun EditDockHeightDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newDockHeight = try {
+                        value.toInt()
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                        0
+                    }
+
+                    if (newDockHeight > 0) {
+                        onUpdateDockHeight(newDockHeight)
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
@@ -1,0 +1,97 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.settings.home.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import com.eblan.launcher.ui.dialog.TextFieldDialog
+
+@Composable
+internal fun EditDockHeightDialog(
+    modifier: Modifier = Modifier,
+    dockHeight: Int,
+    onDismissRequest: () -> Unit,
+    onUpdateDockHeight: (Int) -> Unit,
+) {
+    var value by remember {
+        mutableStateOf("$dockHeight")
+    }
+
+    var isError by remember { mutableStateOf(false) }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Dock Height",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newDockHeight = try {
+                        value.toInt()
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                        0
+                    }
+
+                    if (newDockHeight > 0) {
+                        onUpdateDockHeight(newDockHeight)
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text("Dock Height")
+                },
+                isError = isError,
+                supportingText = {
+                    if (isError) {
+                        Text("Dock Height is not valid")
+                    }
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditDockHeightDialog.kt
@@ -83,10 +83,12 @@ internal fun EditDockHeightDialog(
                     Text(text = "Dock Height")
                 },
                 isError = isError,
-                supportingText = {
-                    if (isError) {
+                supportingText = if (isError) {
+                    {
                         Text(text = "Dock Height is not valid")
                     }
+                } else {
+                    null
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
@@ -56,7 +56,10 @@ internal fun EditFolderCellDimensionDialog(
         textFields = {
             TextField(
                 value = cellWidth,
-                onValueChange = { cellWidth = it },
+                onValueChange = {
+                    cellWidth = it
+                    firstError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Cell Width") },
                 supportingText = if (firstError) {
@@ -74,7 +77,10 @@ internal fun EditFolderCellDimensionDialog(
 
             TextField(
                 value = cellHeight,
-                onValueChange = { cellHeight = it },
+                onValueChange = {
+                    cellHeight = it
+                    secondError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Cell Height") },
                 supportingText = if (secondError) {

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
@@ -59,7 +59,7 @@ internal fun EditFolderCellDimensionDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -90,7 +90,7 @@ internal fun EditFolderCellDimensionDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textFields = {
@@ -98,7 +98,12 @@ internal fun EditFolderCellDimensionDialog(
                 value = cellWidth,
                 onValueChange = { cellWidth = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Cell Width") },
+                label = { Text(text = "Cell Width") },
+                supportingText = {
+                    if (firstError) {
+                        Text(text = "$cellWidth is not valid")
+                    }
+                },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
@@ -109,7 +114,12 @@ internal fun EditFolderCellDimensionDialog(
                 value = cellHeight,
                 onValueChange = { cellHeight = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Cell Height") },
+                label = { Text(text = "Cell Height") },
+                supportingText = {
+                    if (secondError) {
+                        Text(text = "$cellHeight is not valid")
+                    }
+                },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
@@ -1,0 +1,120 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.settings.home.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import com.eblan.launcher.domain.model.HomeSettings
+import com.eblan.launcher.ui.dialog.RowTextFieldsDialog
+
+@Composable
+internal fun EditFolderCellDimensionDialog(
+    modifier: Modifier = Modifier,
+    homeSettings: HomeSettings,
+    onDismissRequest: () -> Unit,
+    onUpdateHomeSettings: (HomeSettings) -> Unit,
+) {
+    var cellWidth by remember {
+        mutableStateOf("${homeSettings.folderCellWidth}")
+    }
+
+    var cellHeight by remember {
+        mutableStateOf("${homeSettings.folderCellHeight}")
+    }
+
+    var firstError by remember { mutableStateOf(false) }
+    var secondError by remember { mutableStateOf(false) }
+
+    RowTextFieldsDialog(
+        modifier = modifier,
+        title = "Folder Cell Dimension",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newWidth = try {
+                        cellWidth.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newHeight = try {
+                        cellHeight.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newWidth > 0 && newHeight > 0) {
+                        onUpdateHomeSettings(
+                            homeSettings.copy(
+                                folderCellWidth = newWidth,
+                                folderCellHeight = newHeight,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textFields = {
+            TextField(
+                value = cellWidth,
+                onValueChange = { cellWidth = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Cell Width") },
+                isError = firstError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+
+            TextField(
+                value = cellHeight,
+                onValueChange = { cellHeight = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Cell Height") },
+                isError = secondError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
@@ -101,7 +101,7 @@ internal fun EditFolderCellDimensionDialog(
                 label = { Text(text = "Cell Width") },
                 supportingText = if (firstError) {
                     {
-                        Text(text = "$cellWidth is not valid")
+                        Text(text = "Cell width is not valid")
                     }
                 } else {
                     null
@@ -119,7 +119,7 @@ internal fun EditFolderCellDimensionDialog(
                 label = { Text(text = "Cell Height") },
                 supportingText = if (secondError) {
                     {
-                        Text(text = "$cellHeight is not valid")
+                        Text(text = "Cell height is not valid")
                     }
                 } else {
                     null

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
@@ -99,10 +99,12 @@ internal fun EditFolderCellDimensionDialog(
                 onValueChange = { cellWidth = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Cell Width") },
-                supportingText = {
-                    if (firstError) {
+                supportingText = if (firstError) {
+                    {
                         Text(text = "$cellWidth is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
@@ -115,10 +117,12 @@ internal fun EditFolderCellDimensionDialog(
                 onValueChange = { cellHeight = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Cell Height") },
-                supportingText = {
-                    if (secondError) {
+                supportingText = if (secondError) {
+                    {
                         Text(text = "$cellHeight is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderCellDimensionDialog.kt
@@ -17,8 +17,6 @@
  */
 package com.eblan.launcher.feature.settings.home.dialog
 
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -55,44 +53,6 @@ internal fun EditFolderCellDimensionDialog(
         modifier = modifier,
         title = "Folder Cell Dimension",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    val newWidth = try {
-                        cellWidth.toInt()
-                    } catch (_: NumberFormatException) {
-                        firstError = true
-                        0
-                    }
-
-                    val newHeight = try {
-                        cellHeight.toInt()
-                    } catch (_: NumberFormatException) {
-                        secondError = true
-                        0
-                    }
-
-                    if (newWidth > 0 && newHeight > 0) {
-                        onUpdateHomeSettings(
-                            homeSettings.copy(
-                                folderCellWidth = newWidth,
-                                folderCellHeight = newHeight,
-                            ),
-                        )
-
-                        onDismissRequest()
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textFields = {
             TextField(
                 value = cellWidth,
@@ -129,6 +89,44 @@ internal fun EditFolderCellDimensionDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newWidth = try {
+                        cellWidth.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newHeight = try {
+                        cellHeight.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newWidth > 0 && newHeight > 0) {
+                        onUpdateHomeSettings(
+                            homeSettings.copy(
+                                folderCellWidth = newWidth,
+                                folderCellHeight = newHeight,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
@@ -1,0 +1,120 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.settings.home.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import com.eblan.launcher.domain.model.HomeSettings
+import com.eblan.launcher.ui.dialog.RowTextFieldsDialog
+
+@Composable
+internal fun EditFolderMaxGridDialog(
+    modifier: Modifier = Modifier,
+    homeSettings: HomeSettings,
+    onDismissRequest: () -> Unit,
+    onUpdateHomeSettings: (HomeSettings) -> Unit,
+) {
+    var maxFolderColumns by remember {
+        mutableStateOf("${homeSettings.maxFolderColumns}")
+    }
+
+    var maxFolderRows by remember {
+        mutableStateOf("${homeSettings.maxFolderRows}")
+    }
+
+    var firstError by remember { mutableStateOf(false) }
+    var secondError by remember { mutableStateOf(false) }
+
+    RowTextFieldsDialog(
+        modifier = modifier,
+        title = "Folder Max Grid",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newColumns = try {
+                        maxFolderColumns.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newRows = try {
+                        maxFolderRows.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newColumns > 0 && newRows > 0) {
+                        onUpdateHomeSettings(
+                            homeSettings.copy(
+                                maxFolderColumns = newColumns,
+                                maxFolderRows = newRows,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textFields = {
+            TextField(
+                value = maxFolderColumns,
+                onValueChange = { maxFolderColumns = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Columns") },
+                isError = firstError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+
+            TextField(
+                value = maxFolderRows,
+                onValueChange = { maxFolderRows = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Rows") },
+                isError = secondError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
@@ -56,7 +56,10 @@ internal fun EditFolderMaxGridDialog(
         textFields = {
             TextField(
                 value = maxFolderColumns,
-                onValueChange = { maxFolderColumns = it },
+                onValueChange = {
+                    maxFolderColumns = it
+                    firstError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Max Columns") },
                 supportingText = if (firstError) {
@@ -74,7 +77,10 @@ internal fun EditFolderMaxGridDialog(
 
             TextField(
                 value = maxFolderRows,
-                onValueChange = { maxFolderRows = it },
+                onValueChange = {
+                    maxFolderRows = it
+                    secondError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Max Rows") },
                 supportingText = if (secondError) {

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
@@ -59,7 +59,7 @@ internal fun EditFolderMaxGridDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -90,7 +90,7 @@ internal fun EditFolderMaxGridDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textFields = {
@@ -98,7 +98,12 @@ internal fun EditFolderMaxGridDialog(
                 value = maxFolderColumns,
                 onValueChange = { maxFolderColumns = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Columns") },
+                label = { Text(text = "Max Columns") },
+                supportingText = {
+                    if (firstError) {
+                        Text(text = "$maxFolderColumns is not valid")
+                    }
+                },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
@@ -109,7 +114,12 @@ internal fun EditFolderMaxGridDialog(
                 value = maxFolderRows,
                 onValueChange = { maxFolderRows = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Rows") },
+                label = { Text(text = "Max Rows") },
+                supportingText = {
+                    if (secondError) {
+                        Text(text = "$maxFolderRows is not valid")
+                    }
+                },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
@@ -17,8 +17,6 @@
  */
 package com.eblan.launcher.feature.settings.home.dialog
 
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -55,44 +53,6 @@ internal fun EditFolderMaxGridDialog(
         modifier = modifier,
         title = "Folder Max Grid",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    val newColumns = try {
-                        maxFolderColumns.toInt()
-                    } catch (_: NumberFormatException) {
-                        firstError = true
-                        0
-                    }
-
-                    val newRows = try {
-                        maxFolderRows.toInt()
-                    } catch (_: NumberFormatException) {
-                        secondError = true
-                        0
-                    }
-
-                    if (newColumns > 0 && newRows > 0) {
-                        onUpdateHomeSettings(
-                            homeSettings.copy(
-                                maxFolderColumns = newColumns,
-                                maxFolderRows = newRows,
-                            ),
-                        )
-
-                        onDismissRequest()
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textFields = {
             TextField(
                 value = maxFolderColumns,
@@ -129,6 +89,44 @@ internal fun EditFolderMaxGridDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newColumns = try {
+                        maxFolderColumns.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newRows = try {
+                        maxFolderRows.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newColumns > 0 && newRows > 0) {
+                        onUpdateHomeSettings(
+                            homeSettings.copy(
+                                maxFolderColumns = newColumns,
+                                maxFolderRows = newRows,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
@@ -99,10 +99,12 @@ internal fun EditFolderMaxGridDialog(
                 onValueChange = { maxFolderColumns = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Max Columns") },
-                supportingText = {
-                    if (firstError) {
+                supportingText = if (firstError) {
+                    {
                         Text(text = "$maxFolderColumns is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
@@ -115,10 +117,12 @@ internal fun EditFolderMaxGridDialog(
                 onValueChange = { maxFolderRows = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Max Rows") },
-                supportingText = {
-                    if (secondError) {
+                supportingText = if (secondError) {
+                    {
                         Text(text = "$maxFolderRows is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditFolderMaxGridDialog.kt
@@ -101,7 +101,7 @@ internal fun EditFolderMaxGridDialog(
                 label = { Text(text = "Max Columns") },
                 supportingText = if (firstError) {
                     {
-                        Text(text = "$maxFolderColumns is not valid")
+                        Text(text = "Max columns is not valid")
                     }
                 } else {
                     null
@@ -119,7 +119,7 @@ internal fun EditFolderMaxGridDialog(
                 label = { Text(text = "Max Rows") },
                 supportingText = if (secondError) {
                     {
-                        Text(text = "$maxFolderRows is not valid")
+                        Text(text = "Max rows is not valid")
                     }
                 } else {
                     null

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
@@ -17,8 +17,6 @@
  */
 package com.eblan.launcher.feature.settings.home.dialog
 
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -55,44 +53,6 @@ internal fun EditGridDialog(
         modifier = modifier,
         title = "Grid",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    val newColumns = try {
-                        columns.toInt()
-                    } catch (_: NumberFormatException) {
-                        firstError = true
-                        0
-                    }
-
-                    val newRows = try {
-                        rows.toInt()
-                    } catch (_: NumberFormatException) {
-                        secondError = true
-                        0
-                    }
-
-                    if (newColumns > 0 && newRows > 0) {
-                        onUpdateHomeSettings(
-                            homeSettings.copy(
-                                columns = newColumns,
-                                rows = newRows,
-                            ),
-                        )
-
-                        onDismissRequest()
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textFields = {
             TextField(
                 value = columns,
@@ -129,6 +89,44 @@ internal fun EditGridDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newColumns = try {
+                        columns.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newRows = try {
+                        rows.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newColumns > 0 && newRows > 0) {
+                        onUpdateHomeSettings(
+                            homeSettings.copy(
+                                columns = newColumns,
+                                rows = newRows,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
@@ -59,7 +59,7 @@ internal fun EditGridDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -90,7 +90,7 @@ internal fun EditGridDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textFields = {
@@ -98,7 +98,12 @@ internal fun EditGridDialog(
                 value = columns,
                 onValueChange = { columns = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Columns") },
+                label = { Text(text = "Columns") },
+                supportingText = {
+                    if (firstError) {
+                        Text(text = "$columns is not valid")
+                    }
+                },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
@@ -109,7 +114,12 @@ internal fun EditGridDialog(
                 value = rows,
                 onValueChange = { rows = it },
                 modifier = Modifier.weight(1f),
-                label = { Text("Rows") },
+                label = { Text(text = "Rows") },
+                supportingText = {
+                    if (secondError) {
+                        Text(text = "$rows is not valid")
+                    }
+                },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
@@ -56,7 +56,10 @@ internal fun EditGridDialog(
         textFields = {
             TextField(
                 value = columns,
-                onValueChange = { columns = it },
+                onValueChange = {
+                    columns = it
+                    firstError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Columns") },
                 supportingText = if (firstError) {
@@ -74,7 +77,10 @@ internal fun EditGridDialog(
 
             TextField(
                 value = rows,
-                onValueChange = { rows = it },
+                onValueChange = {
+                    rows = it
+                    secondError = false
+                },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Rows") },
                 supportingText = if (secondError) {

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
@@ -1,0 +1,120 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.settings.home.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import com.eblan.launcher.domain.model.HomeSettings
+import com.eblan.launcher.ui.dialog.RowTextFieldsDialog
+
+@Composable
+internal fun EditGridDialog(
+    modifier: Modifier = Modifier,
+    homeSettings: HomeSettings,
+    onDismissRequest: () -> Unit,
+    onUpdateHomeSettings: (HomeSettings) -> Unit,
+) {
+    var columns by remember {
+        mutableStateOf("${homeSettings.columns}")
+    }
+
+    var rows by remember {
+        mutableStateOf("${homeSettings.rows}")
+    }
+
+    var firstError by remember { mutableStateOf(false) }
+    var secondError by remember { mutableStateOf(false) }
+
+    RowTextFieldsDialog(
+        modifier = modifier,
+        title = "Grid",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    val newColumns = try {
+                        columns.toInt()
+                    } catch (_: NumberFormatException) {
+                        firstError = true
+                        0
+                    }
+
+                    val newRows = try {
+                        rows.toInt()
+                    } catch (_: NumberFormatException) {
+                        secondError = true
+                        0
+                    }
+
+                    if (newColumns > 0 && newRows > 0) {
+                        onUpdateHomeSettings(
+                            homeSettings.copy(
+                                columns = newColumns,
+                                rows = newRows,
+                            ),
+                        )
+
+                        onDismissRequest()
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textFields = {
+            TextField(
+                value = columns,
+                onValueChange = { columns = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Columns") },
+                isError = firstError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+
+            TextField(
+                value = rows,
+                onValueChange = { rows = it },
+                modifier = Modifier.weight(1f),
+                label = { Text("Rows") },
+                isError = secondError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
@@ -99,10 +99,12 @@ internal fun EditGridDialog(
                 onValueChange = { columns = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Columns") },
-                supportingText = {
-                    if (firstError) {
+                supportingText = if (firstError) {
+                    {
                         Text(text = "$columns is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = firstError,
                 keyboardOptions = KeyboardOptions(
@@ -115,10 +117,12 @@ internal fun EditGridDialog(
                 onValueChange = { rows = it },
                 modifier = Modifier.weight(1f),
                 label = { Text(text = "Rows") },
-                supportingText = {
-                    if (secondError) {
+                supportingText = if (secondError) {
+                    {
                         Text(text = "$rows is not valid")
                     }
+                } else {
+                    null
                 },
                 isError = secondError,
                 keyboardOptions = KeyboardOptions(

--- a/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
+++ b/feature/settings/home/src/main/kotlin/com/eblan/launcher/feature/settings/home/dialog/EditGridDialog.kt
@@ -101,7 +101,7 @@ internal fun EditGridDialog(
                 label = { Text(text = "Columns") },
                 supportingText = if (firstError) {
                     {
-                        Text(text = "$columns is not valid")
+                        Text(text = "Columns is not valid")
                     }
                 } else {
                     null
@@ -119,7 +119,7 @@ internal fun EditGridDialog(
                 label = { Text(text = "Rows") },
                 supportingText = if (secondError) {
                     {
-                        Text(text = "$rows is not valid")
+                        Text(text = "Rows is not valid")
                     }
                 } else {
                     null

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
@@ -79,10 +79,12 @@ internal fun EditCornerRadiusDialog(
                     Text(text = "Corner Radius")
                 },
                 isError = isError,
-                supportingText = {
-                    if (isError) {
+                supportingText = if (isError) {
+                    {
                         Text(text = "Corner Radius is not valid")
                     }
+                } else {
+                    null
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
@@ -51,7 +51,7 @@ internal fun EditCornerRadiusDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -65,7 +65,7 @@ internal fun EditCornerRadiusDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -76,12 +76,12 @@ internal fun EditCornerRadiusDialog(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {
-                    Text("Corner Radius")
+                    Text(text = "Corner Radius")
                 },
                 isError = isError,
                 supportingText = {
                     if (isError) {
-                        Text("Corner Radius is not valid")
+                        Text(text = "Corner Radius is not valid")
                     }
                 },
                 keyboardOptions = KeyboardOptions(

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
@@ -52,6 +52,7 @@ internal fun EditCornerRadiusDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
@@ -1,0 +1,93 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.ui.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+
+@Composable
+internal fun EditCornerRadiusDialog(
+    modifier: Modifier = Modifier,
+    cornerRadius: Int,
+    onDismissRequest: () -> Unit,
+    onUpdateCornerRadius: (Int) -> Unit,
+) {
+    var value by remember {
+        mutableStateOf("$cornerRadius")
+    }
+
+    var isError by remember { mutableStateOf(false) }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Corner Radius",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    try {
+                        onUpdateCornerRadius(
+                            value.toInt(),
+                        )
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text("Corner Radius")
+                },
+                isError = isError,
+                supportingText = {
+                    if (isError) {
+                        Text("Corner Radius is not valid")
+                    }
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditCornerRadiusDialog.kt
@@ -47,27 +47,6 @@ internal fun EditCornerRadiusDialog(
         modifier = modifier,
         title = "Corner Radius",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    try {
-                        onUpdateCornerRadius(
-                            value.toInt(),
-                        )
-                    } catch (_: NumberFormatException) {
-                        isError = true
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textField = {
             TextField(
                 value = value,
@@ -90,6 +69,27 @@ internal fun EditCornerRadiusDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    try {
+                        onUpdateCornerRadius(
+                            value.toInt(),
+                        )
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
@@ -79,10 +79,12 @@ internal fun EditIconSizeDialog(
                     Text(text = "Icon Size")
                 },
                 isError = isError,
-                supportingText = {
-                    if (isError) {
+                supportingText = if (isError) {
+                    {
                         Text(text = "Icon Size is not valid")
                     }
+                } else {
+                    null
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
@@ -52,6 +52,7 @@ internal fun EditIconSizeDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
@@ -47,27 +47,6 @@ internal fun EditIconSizeDialog(
         modifier = modifier,
         title = "Icon Size",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    try {
-                        onUpdateIconSize(
-                            value.toInt().coerceAtLeast(1),
-                        )
-                    } catch (_: NumberFormatException) {
-                        isError = true
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textField = {
             TextField(
                 value = value,
@@ -90,6 +69,27 @@ internal fun EditIconSizeDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    try {
+                        onUpdateIconSize(
+                            value.toInt().coerceAtLeast(1),
+                        )
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
@@ -1,0 +1,93 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.ui.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+
+@Composable
+internal fun EditIconSizeDialog(
+    modifier: Modifier = Modifier,
+    iconSize: Int,
+    onDismissRequest: () -> Unit,
+    onUpdateIconSize: (Int) -> Unit,
+) {
+    var value by remember {
+        mutableStateOf("$iconSize")
+    }
+
+    var isError by remember { mutableStateOf(false) }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Icon Size",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    try {
+                        onUpdateIconSize(
+                            value.toInt().coerceAtLeast(1),
+                        )
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text("Icon Size")
+                },
+                isError = isError,
+                supportingText = {
+                    if (isError) {
+                        Text("Icon Size is not valid")
+                    }
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditIconSizeDialog.kt
@@ -51,7 +51,7 @@ internal fun EditIconSizeDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -65,7 +65,7 @@ internal fun EditIconSizeDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -76,12 +76,12 @@ internal fun EditIconSizeDialog(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {
-                    Text("Icon Size")
+                    Text(text = "Icon Size")
                 },
                 isError = isError,
                 supportingText = {
                     if (isError) {
-                        Text("Icon Size is not valid")
+                        Text(text = "Icon Size is not valid")
                     }
                 },
                 keyboardOptions = KeyboardOptions(

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
@@ -52,6 +52,7 @@ internal fun EditPaddingDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
@@ -1,0 +1,93 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.ui.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+
+@Composable
+internal fun EditPaddingDialog(
+    modifier: Modifier = Modifier,
+    padding: Int,
+    onDismissRequest: () -> Unit,
+    onUpdatePadding: (Int) -> Unit,
+) {
+    var value by remember {
+        mutableStateOf("$padding")
+    }
+
+    var isError by remember { mutableStateOf(false) }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Padding",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    try {
+                        onUpdatePadding(
+                            value.toInt(),
+                        )
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text("Padding")
+                },
+                isError = isError,
+                supportingText = {
+                    if (isError) {
+                        Text("Padding is not valid")
+                    }
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
@@ -47,27 +47,6 @@ internal fun EditPaddingDialog(
         modifier = modifier,
         title = "Padding",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    try {
-                        onUpdatePadding(
-                            value.toInt(),
-                        )
-                    } catch (_: NumberFormatException) {
-                        isError = true
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textField = {
             TextField(
                 value = value,
@@ -90,6 +69,27 @@ internal fun EditPaddingDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    try {
+                        onUpdatePadding(
+                            value.toInt(),
+                        )
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
@@ -51,7 +51,7 @@ internal fun EditPaddingDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -65,7 +65,7 @@ internal fun EditPaddingDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -76,12 +76,12 @@ internal fun EditPaddingDialog(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {
-                    Text("Padding")
+                    Text(text = "Padding")
                 },
                 isError = isError,
                 supportingText = {
                     if (isError) {
-                        Text("Padding is not valid")
+                        Text(text = "Padding is not valid")
                     }
                 },
                 keyboardOptions = KeyboardOptions(

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditPaddingDialog.kt
@@ -79,10 +79,12 @@ internal fun EditPaddingDialog(
                     Text(text = "Padding")
                 },
                 isError = isError,
-                supportingText = {
-                    if (isError) {
+                supportingText = if (isError) {
+                    {
                         Text(text = "Padding is not valid")
                     }
+                } else {
+                    null
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
@@ -1,0 +1,93 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.ui.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+
+@Composable
+internal fun EditTextSizeDialog(
+    modifier: Modifier = Modifier,
+    textSize: Int,
+    onDismissRequest: () -> Unit,
+    onUpdateTextSize: (Int) -> Unit,
+) {
+    var value by remember {
+        mutableStateOf("$textSize")
+    }
+
+    var isError by remember { mutableStateOf(false) }
+
+    TextFieldDialog(
+        modifier = modifier,
+        title = "Text Size",
+        onDismissRequest = onDismissRequest,
+        actions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text("Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    try {
+                        onUpdateTextSize(
+                            value.toInt().coerceAtLeast(1),
+                        )
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                    }
+                },
+            ) {
+                Text("Update")
+            }
+        },
+        textField = {
+            TextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = {
+                    Text("Text Size")
+                },
+                isError = isError,
+                supportingText = {
+                    if (isError) {
+                        Text("Text Size is not valid")
+                    }
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
+            )
+        },
+    )
+}

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
@@ -79,10 +79,12 @@ internal fun EditTextSizeDialog(
                     Text(text = "Text Size")
                 },
                 isError = isError,
-                supportingText = {
-                    if (isError) {
+                supportingText = if (isError) {
+                    {
                         Text(text = "Text Size is not valid")
                     }
+                } else {
+                    null
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
@@ -47,27 +47,6 @@ internal fun EditTextSizeDialog(
         modifier = modifier,
         title = "Text Size",
         onDismissRequest = onDismissRequest,
-        actions = {
-            TextButton(
-                onClick = onDismissRequest,
-            ) {
-                Text(text = "Cancel")
-            }
-
-            TextButton(
-                onClick = {
-                    try {
-                        onUpdateTextSize(
-                            value.toInt().coerceAtLeast(1),
-                        )
-                    } catch (_: NumberFormatException) {
-                        isError = true
-                    }
-                },
-            ) {
-                Text(text = "Update")
-            }
-        },
         textField = {
             TextField(
                 value = value,
@@ -90,6 +69,27 @@ internal fun EditTextSizeDialog(
                     keyboardType = KeyboardType.Number,
                 ),
             )
+        },
+        bottomActions = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) {
+                Text(text = "Cancel")
+            }
+
+            TextButton(
+                onClick = {
+                    try {
+                        onUpdateTextSize(
+                            value.toInt().coerceAtLeast(1),
+                        )
+                    } catch (_: NumberFormatException) {
+                        isError = true
+                    }
+                },
+            ) {
+                Text(text = "Update")
+            }
         },
     )
 }

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
@@ -51,7 +51,7 @@ internal fun EditTextSizeDialog(
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text("Cancel")
+                Text(text = "Cancel")
             }
 
             TextButton(
@@ -65,7 +65,7 @@ internal fun EditTextSizeDialog(
                     }
                 },
             ) {
-                Text("Update")
+                Text(text = "Update")
             }
         },
         textField = {
@@ -76,12 +76,12 @@ internal fun EditTextSizeDialog(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {
-                    Text("Text Size")
+                    Text(text = "Text Size")
                 },
                 isError = isError,
                 supportingText = {
                     if (isError) {
-                        Text("Text Size is not valid")
+                        Text(text = "Text Size is not valid")
                     }
                 },
                 keyboardOptions = KeyboardOptions(

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/EditTextSizeDialog.kt
@@ -52,6 +52,7 @@ internal fun EditTextSizeDialog(
                 value = value,
                 onValueChange = {
                     value = it
+                    isError = false
                 },
                 modifier = Modifier.fillMaxWidth(),
                 label = {

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/TextFieldDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/TextFieldDialog.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.component.EblanDialogContainer
@@ -38,8 +39,9 @@ fun TextFieldDialog(
     modifier: Modifier = Modifier,
     title: String,
     onDismissRequest: () -> Unit,
-    actions: @Composable RowScope.() -> Unit,
+    topActions: (@Composable RowScope.() -> Unit)? = null,
     textField: @Composable ColumnScope.() -> Unit,
+    bottomActions: @Composable RowScope.() -> Unit,
 ) {
     EblanDialogContainer(
         modifier = modifier,
@@ -50,10 +52,20 @@ fun TextFieldDialog(
                     .fillMaxWidth()
                     .padding(10.dp),
             ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleLarge,
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+
+                    if (topActions != null) {
+                        Row(content = topActions)
+                    }
+                }
 
                 Spacer(modifier = Modifier.height(10.dp))
 
@@ -64,7 +76,7 @@ fun TextFieldDialog(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End,
-                    content = actions,
+                    content = bottomActions,
                 )
             }
         },
@@ -76,8 +88,8 @@ fun RowTextFieldsDialog(
     modifier: Modifier = Modifier,
     title: String,
     onDismissRequest: () -> Unit,
-    actions: @Composable RowScope.() -> Unit,
     textFields: @Composable RowScope.() -> Unit,
+    bottomActions: @Composable RowScope.() -> Unit,
 ) {
     EblanDialogContainer(
         onDismissRequest = onDismissRequest,
@@ -105,7 +117,7 @@ fun RowTextFieldsDialog(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End,
-                    content = actions,
+                    content = bottomActions,
                 )
             }
         },

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/TextFieldDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/TextFieldDialog.kt
@@ -19,62 +19,84 @@ package com.eblan.launcher.ui.dialog
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.component.EblanDialogContainer
 
 @Composable
-fun SingleTextFieldDialog(
+fun TextFieldDialog(
     modifier: Modifier = Modifier,
     title: String,
-    textFieldTitle: String,
-    value: String,
-    isError: Boolean,
-    keyboardType: KeyboardType,
-    singleLine: Boolean = true,
-    onValueChange: (String) -> Unit,
     onDismissRequest: () -> Unit,
-    onUpdateClick: () -> Unit,
+    actions: @Composable RowScope.() -> Unit,
+    textField: @Composable ColumnScope.() -> Unit,
 ) {
     EblanDialogContainer(
+        modifier = modifier,
+        onDismissRequest = onDismissRequest,
+        content = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                )
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                textField()
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    content = actions,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+fun RowTextFieldsDialog(
+    modifier: Modifier = Modifier,
+    title: String,
+    onDismissRequest: () -> Unit,
+    actions: @Composable RowScope.() -> Unit,
+    textFields: @Composable RowScope.() -> Unit,
+) {
+    EblanDialogContainer(
+        onDismissRequest = onDismissRequest,
         content = {
             Column(
                 modifier = modifier
                     .fillMaxWidth()
                     .padding(10.dp),
             ) {
-                Text(text = title, style = MaterialTheme.typography.titleLarge)
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                )
 
                 Spacer(modifier = Modifier.height(10.dp))
 
-                TextField(
-                    value = value,
-                    onValueChange = onValueChange,
+                Row(
                     modifier = Modifier.fillMaxWidth(),
-                    label = {
-                        Text(text = textFieldTitle)
-                    },
-                    supportingText = {
-                        if (isError) {
-                            Text(text = "$textFieldTitle is not valid")
-                        }
-                    },
-                    isError = isError,
-                    keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-                    singleLine = singleLine,
+                    content = textFields,
                 )
 
                 Spacer(modifier = Modifier.height(10.dp))
@@ -82,109 +104,9 @@ fun SingleTextFieldDialog(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End,
-                ) {
-                    TextButton(
-                        onClick = onDismissRequest,
-                    ) {
-                        Text(text = "Cancel")
-                    }
-                    TextButton(
-                        onClick = onUpdateClick,
-                    ) {
-                        Text(text = "Update")
-                    }
-                }
+                    content = actions,
+                )
             }
         },
-        onDismissRequest = onDismissRequest,
-    )
-}
-
-@Composable
-fun TwoTextFieldsDialog(
-    modifier: Modifier = Modifier,
-    title: String,
-    firstTextFieldTitle: String,
-    secondTextFieldTitle: String,
-    firstTextFieldValue: String,
-    secondTextFieldValue: String,
-    firstTextFieldIsError: Boolean,
-    secondTextFieldIsError: Boolean,
-    keyboardType: KeyboardType,
-    singleLine: Boolean = true,
-    onFirstValueChange: (String) -> Unit,
-    onSecondValueChange: (String) -> Unit,
-    onDismissRequest: () -> Unit,
-    onUpdateClick: () -> Unit,
-) {
-    EblanDialogContainer(
-        content = {
-            Column(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(10.dp),
-            ) {
-                Text(text = title, style = MaterialTheme.typography.titleLarge)
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                Row(modifier = Modifier.fillMaxWidth()) {
-                    TextField(
-                        value = firstTextFieldValue,
-                        onValueChange = onFirstValueChange,
-                        modifier = Modifier.weight(1f),
-                        label = {
-                            Text(text = firstTextFieldTitle)
-                        },
-                        supportingText = {
-                            if (firstTextFieldIsError) {
-                                Text(text = "$firstTextFieldTitle is not valid")
-                            }
-                        },
-                        isError = firstTextFieldIsError,
-                        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-                        singleLine = singleLine,
-                    )
-
-                    Spacer(modifier = Modifier.width(5.dp))
-
-                    TextField(
-                        value = secondTextFieldValue,
-                        onValueChange = onSecondValueChange,
-                        modifier = Modifier.weight(1f),
-                        label = {
-                            Text(text = secondTextFieldTitle)
-                        },
-                        supportingText = {
-                            if (secondTextFieldIsError) {
-                                Text(text = "$secondTextFieldTitle is not valid")
-                            }
-                        },
-                        isError = secondTextFieldIsError,
-                        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-                        singleLine = singleLine,
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    TextButton(
-                        onClick = onDismissRequest,
-                    ) {
-                        Text(text = "Cancel")
-                    }
-                    TextButton(
-                        onClick = onUpdateClick,
-                    ) {
-                        Text(text = "Update")
-                    }
-                }
-            }
-        },
-        onDismissRequest = onDismissRequest,
     )
 }

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/TextFieldDialog.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/dialog/TextFieldDialog.kt
@@ -96,6 +96,7 @@ fun RowTextFieldsDialog(
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                     content = textFields,
                 )
 

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/settings/GridItemSettings.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/settings/GridItemSettings.kt
@@ -39,15 +39,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.domain.model.GridItemSettings
 import com.eblan.launcher.domain.model.HorizontalAlignment
 import com.eblan.launcher.domain.model.TextColor
 import com.eblan.launcher.domain.model.VerticalArrangement
 import com.eblan.launcher.ui.dialog.ColorPickerDialog
+import com.eblan.launcher.ui.dialog.EditCornerRadiusDialog
+import com.eblan.launcher.ui.dialog.EditIconSizeDialog
+import com.eblan.launcher.ui.dialog.EditPaddingDialog
+import com.eblan.launcher.ui.dialog.EditTextSizeDialog
 import com.eblan.launcher.ui.dialog.RadioOptionsDialog
-import com.eblan.launcher.ui.dialog.SingleTextFieldDialog
 import com.eblan.launcher.ui.dialog.TextColorDialog
 
 @Composable
@@ -192,34 +194,19 @@ fun GridItemSettings(
     }
 
     if (showIconSizeDialog) {
-        var value by remember { mutableStateOf("${gridItemSettings.iconSize}") }
-
-        var isError by remember { mutableStateOf(false) }
-
-        SingleTextFieldDialog(
-            title = "Icon Size",
-            textFieldTitle = "Icon Size",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Number,
-            onValueChange = {
-                value = it
-            },
+        EditIconSizeDialog(
+            iconSize = gridItemSettings.iconSize,
             onDismissRequest = {
                 showIconSizeDialog = false
             },
-            onUpdateClick = {
-                try {
-                    onUpdateGridItemSettings(
-                        gridItemSettings.copy(
-                            iconSize = value.toInt().coerceAtLeast(1),
-                        ),
-                    )
+            onUpdateIconSize = { iconSize ->
+                onUpdateGridItemSettings(
+                    gridItemSettings.copy(
+                        iconSize = iconSize,
+                    ),
+                )
 
-                    showIconSizeDialog = false
-                } catch (_: NumberFormatException) {
-                    isError = true
-                }
+                showIconSizeDialog = false
             },
         )
     }
@@ -246,34 +233,19 @@ fun GridItemSettings(
     }
 
     if (showTextSizeDialog) {
-        var value by remember { mutableStateOf("${gridItemSettings.textSize}") }
-
-        var isError by remember { mutableStateOf(false) }
-
-        SingleTextFieldDialog(
-            title = "Text Size",
-            textFieldTitle = "Text Size",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Number,
-            onValueChange = {
-                value = it
-            },
+        EditTextSizeDialog(
+            textSize = gridItemSettings.textSize,
             onDismissRequest = {
                 showTextSizeDialog = false
             },
-            onUpdateClick = {
-                try {
-                    onUpdateGridItemSettings(
-                        gridItemSettings.copy(
-                            textSize = value.toInt().coerceAtLeast(1),
-                        ),
-                    )
+            onUpdateTextSize = { textSize ->
+                onUpdateGridItemSettings(
+                    gridItemSettings.copy(
+                        textSize = textSize,
+                    ),
+                )
 
-                    showTextSizeDialog = false
-                } catch (_: NumberFormatException) {
-                    isError = true
-                }
+                showTextSizeDialog = false
             },
         )
     }
@@ -294,59 +266,37 @@ fun GridItemSettings(
     }
 
     if (showPaddingDialog) {
-        var value by remember { mutableStateOf("${gridItemSettings.padding}") }
-
-        var isError by remember { mutableStateOf(false) }
-
-        SingleTextFieldDialog(
-            title = "Padding",
-            textFieldTitle = "Padding",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Number,
-            onValueChange = {
-                value = it
-            },
+        EditPaddingDialog(
+            padding = gridItemSettings.padding,
             onDismissRequest = {
                 showPaddingDialog = false
             },
-            onUpdateClick = {
-                try {
-                    onUpdateGridItemSettings(gridItemSettings.copy(padding = value.toInt()))
+            onUpdatePadding = { padding ->
+                onUpdateGridItemSettings(
+                    gridItemSettings.copy(
+                        padding = padding,
+                    ),
+                )
 
-                    showPaddingDialog = false
-                } catch (_: NumberFormatException) {
-                    isError = true
-                }
+                showPaddingDialog = false
             },
         )
     }
 
     if (showCornerRadiusDialog) {
-        var value by remember { mutableStateOf("${gridItemSettings.cornerRadius}") }
-
-        var isError by remember { mutableStateOf(false) }
-
-        SingleTextFieldDialog(
-            title = "Corner Radius",
-            textFieldTitle = "Corner Radius",
-            value = value,
-            isError = isError,
-            keyboardType = KeyboardType.Number,
-            onValueChange = {
-                value = it
-            },
+        EditCornerRadiusDialog(
+            cornerRadius = gridItemSettings.cornerRadius,
             onDismissRequest = {
                 showCornerRadiusDialog = false
             },
-            onUpdateClick = {
-                try {
-                    onUpdateGridItemSettings(gridItemSettings.copy(cornerRadius = value.toInt()))
+            onUpdateCornerRadius = { cornerRadius ->
+                onUpdateGridItemSettings(
+                    gridItemSettings.copy(
+                        cornerRadius = cornerRadius,
+                    ),
+                )
 
-                    showCornerRadiusDialog = false
-                } catch (_: NumberFormatException) {
-                    isError = true
-                }
+                showCornerRadiusDialog = false
             },
         )
     }


### PR DESCRIPTION
- Replaced generic `SingleTextFieldDialog` and `TwoTextFieldsDialog` with more flexible `TextFieldDialog` and `RowTextFieldsDialog` using slot-based content for actions and inputs.
- Extracted specialized dialog components for various settings, including `EditGridDialog`, `EditDockHeightDialog`, `EditIconSizeDialog`, and `EditPaddingDialog`, moving them into dedicated files.
- Refactored `EditApplicationInfoScreen`, `AppDrawerSettingsScreen`, and `HomeSettingsScreen` to utilize these new specialized dialogs, significantly reducing inline state management and boilerplate.
- Deleted `CustomLabelDialog` in favor of feature-specific implementations like `EditShortcutConfigCustomLabelDialog` and `EditEblanApplicationInfoCustomLabelDialog`.
- Standardized input validation and error handling logic within the new dialog components to ensure consistent behavior across the UI.
- Improved code organization by separating dialog UI logic from the main screen composables in the `feature` modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified editing flows to use dedicated dialogs across labels, tags, folders, shortcuts, and grid/dock/home/drawer settings, replacing inline editors and centralizing validation and actions.

* **New Features**
  * Added dedicated dialogs for adding tags and editing labels, numeric UI metrics (icon/text size, padding, corner radius), and grid/dock/folder dimensions — with per-field validation, Update/Cancel actions, and delete/reset where applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JackEblan/YagniLauncher/pull/807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->