### PR TITLE
App Drawer Folder

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultApplicationInfoGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultApplicationInfoGridItemRepository.kt
@@ -31,52 +31,34 @@ import javax.inject.Inject
 internal class DefaultApplicationInfoGridItemRepository @Inject constructor(private val applicationInfoGridItemDao: ApplicationInfoGridItemDao) : ApplicationInfoGridItemRepository {
     override val gridItemsFlow =
         applicationInfoGridItemDao.getApplicationInfoGridItemEntitiesFlow().map { entities ->
-            entities.filter { entity ->
-                entity.folderId == null
-            }.map { entity ->
-                entity.asGridItem()
-            }
+            entities.filter { it.folderId == null }.map { it.asGridItem() }
         }
 
     override val gridItemsWithFolderIdFlow =
         applicationInfoGridItemDao.getApplicationInfoGridItemEntitiesFlow().map { entities ->
-            entities.map { entity ->
-                entity.asGridItem()
-            }
+            entities.map { it.asGridItem() }
         }
 
-    override suspend fun getGridItems(): List<GridItem> = applicationInfoGridItemDao.getApplicationInfoGridItemEntities().filter { entity ->
-        entity.folderId == null
-    }.map { entity ->
-        entity.asGridItem()
-    }
+    override suspend fun getGridItems(): List<GridItem> = applicationInfoGridItemDao.getApplicationInfoGridItemEntities().filter {
+        it.folderId == null
+    }.map { it.asGridItem() }
 
-    override suspend fun getGridItemsWithFolderId(): List<GridItem> = applicationInfoGridItemDao.getApplicationInfoGridItemEntities().map { entity ->
-        entity.asGridItem()
-    }
+    override suspend fun getGridItemsWithFolderId(): List<GridItem> = applicationInfoGridItemDao.getApplicationInfoGridItemEntities().map { it.asGridItem() }
 
-    override suspend fun getApplicationInfoGridItems(): List<ApplicationInfoGridItem> = applicationInfoGridItemDao.getApplicationInfoGridItemEntities().map { entity ->
-        entity.asModel()
-    }
+    override suspend fun getApplicationInfoGridItems(): List<ApplicationInfoGridItem> = applicationInfoGridItemDao.getApplicationInfoGridItemEntities().map { it.asModel() }
 
     override suspend fun upsertApplicationInfoGridItems(applicationInfoGridItems: List<ApplicationInfoGridItem>) {
-        val entities = applicationInfoGridItems.map { applicationInfoGridItem ->
-            applicationInfoGridItem.asEntity()
-        }
+        val entities = applicationInfoGridItems.map { it.asEntity() }
 
         applicationInfoGridItemDao.upsertApplicationInfoGridItemEntities(entities = entities)
     }
 
     override suspend fun updateApplicationInfoGridItem(applicationInfoGridItem: ApplicationInfoGridItem) {
-        applicationInfoGridItemDao.updateApplicationInfoGridItemEntity(
-            applicationInfoGridItem.asEntity(),
-        )
+        applicationInfoGridItemDao.updateApplicationInfoGridItemEntity(applicationInfoGridItem.asEntity())
     }
 
     override suspend fun deleteApplicationInfoGridItems(applicationInfoGridItems: List<ApplicationInfoGridItem>) {
-        val entities = applicationInfoGridItems.map { applicationInfoGridItem ->
-            applicationInfoGridItem.asEntity()
-        }
+        val entities = applicationInfoGridItems.map { it.asEntity() }
 
         applicationInfoGridItemDao.deleteApplicationInfoGridItemEntities(entities = entities)
     }
@@ -91,9 +73,7 @@ internal class DefaultApplicationInfoGridItemRepository @Inject constructor(priv
     ): List<ApplicationInfoGridItem> = applicationInfoGridItemDao.getApplicationInfoGridItemEntitiesByPackageName(
         serialNumber = serialNumber,
         packageName = packageName,
-    ).map { entity ->
-        entity.asModel()
-    }
+    ).map { it.asModel() }
 
     override suspend fun deleteApplicationInfoGridItem(
         serialNumber: Long,
@@ -112,9 +92,7 @@ internal class DefaultApplicationInfoGridItemRepository @Inject constructor(priv
     }
 
     override suspend fun insertApplicationInfoGridItems(applicationInfoGridItems: List<ApplicationInfoGridItem>) {
-        val entities = applicationInfoGridItems.map { applicationInfoGridItem ->
-            applicationInfoGridItem.asEntity()
-        }
+        val entities = applicationInfoGridItems.map { it.asEntity() }
 
         applicationInfoGridItemDao.insertApplicationInfoGridItemEntities(entities = entities)
     }
@@ -124,9 +102,7 @@ internal class DefaultApplicationInfoGridItemRepository @Inject constructor(priv
     }
 
     override suspend fun updateApplicationInfoGridItems(applicationInfoGridItems: List<ApplicationInfoGridItem>) {
-        val entities = applicationInfoGridItems.map { applicationInfoGridItem ->
-            applicationInfoGridItem.asEntity()
-        }
+        val entities = applicationInfoGridItems.map { it.asEntity() }
 
         applicationInfoGridItemDao.updateApplicationInfoGridItemEntities(entities = entities)
     }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanAppWidgetProviderInfoRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanAppWidgetProviderInfoRepository.kt
@@ -34,14 +34,10 @@ class DefaultEblanAppWidgetProviderInfoRepository @Inject constructor(private va
         }
 
     override suspend fun getEblanAppWidgetProviderInfos(): List<EblanAppWidgetProviderInfo> = eblanAppWidgetProviderInfoDao.getEblanAppWidgetProviderInfoEntityList()
-        .map { eblanAppWidgetProviderInfoEntity ->
-            eblanAppWidgetProviderInfoEntity.asModel()
-        }
+        .map { it.asModel() }
 
     override suspend fun upsertEblanAppWidgetProviderInfos(eblanAppWidgetProviderInfos: List<EblanAppWidgetProviderInfo>) {
-        val entities = eblanAppWidgetProviderInfos.map { eblanAppWidgetProviderInfo ->
-            eblanAppWidgetProviderInfo.asEntity()
-        }
+        val entities = eblanAppWidgetProviderInfos.map { it.asEntity() }
 
         eblanAppWidgetProviderInfoDao.upsertEblanAppWidgetProviderInfoEntities(entities = entities)
     }
@@ -54,9 +50,7 @@ class DefaultEblanAppWidgetProviderInfoRepository @Inject constructor(private va
 
     override suspend fun getEblanAppWidgetProviderInfosByPackageName(packageName: String): List<EblanAppWidgetProviderInfo> = eblanAppWidgetProviderInfoDao.getEblanAppWidgetProviderInfoEntitiesByPackageName(
         packageName = packageName,
-    ).map { entity ->
-        entity.asModel()
-    }
+    ).map { it.asModel() }
 
     override suspend fun deleteEblanAppWidgetProviderInfoByPackageName(packageName: String) {
         eblanAppWidgetProviderInfoDao.deleteEblanAppWidgetProviderInfoEntityByPackageName(

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanApplicationInfoRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanApplicationInfoRepository.kt
@@ -41,24 +41,18 @@ internal class DefaultEblanApplicationInfoRepository @Inject constructor(
 ) : EblanApplicationInfoRepository {
     override val eblanApplicationInfosFlow =
         eblanApplicationInfoDao.getEblanApplicationInfoEntitiesFlow().map { entities ->
-            entities.map { entity ->
-                entity.asModel()
-            }
+            entities.map { it.asModel() }
         }
 
     override suspend fun getEblanApplicationInfos(): List<EblanApplicationInfo> = eblanApplicationInfoDao.getEblanApplicationInfoEntity()
-        .map { eblanApplicationInfoEntity ->
-            eblanApplicationInfoEntity.asModel()
-        }
+        .map { it.asModel() }
 
     override suspend fun upsertEblanApplicationInfo(eblanApplicationInfo: EblanApplicationInfo) {
         eblanApplicationInfoDao.upsertEblanApplicationInfoEntity(entity = eblanApplicationInfo.asEntity())
     }
 
     override suspend fun updateEblanApplicationInfos(eblanApplicationInfos: List<EblanApplicationInfo>) {
-        val entities = eblanApplicationInfos.map { eblanApplicationInfo ->
-            eblanApplicationInfo.asEntity()
-        }
+        val entities = eblanApplicationInfos.map { it.asEntity() }
 
         eblanApplicationInfoDao.updateEblanApplicationInfoEntities(entities = entities)
     }
@@ -74,9 +68,7 @@ internal class DefaultEblanApplicationInfoRepository @Inject constructor(
     }
 
     override suspend fun deleteEblanApplicationInfos(eblanApplicationInfos: List<EblanApplicationInfo>) {
-        val entities = eblanApplicationInfos.map { eblanApplicationInfo ->
-            eblanApplicationInfo.asEntity()
-        }
+        val entities = eblanApplicationInfos.map { it.asEntity() }
 
         eblanApplicationInfoDao.deleteEblanApplicationInfoEntities(entities = entities)
     }
@@ -95,8 +87,8 @@ internal class DefaultEblanApplicationInfoRepository @Inject constructor(
 
     override suspend fun resetEblanApplicationInfoCustomIcon(eblanApplicationInfo: EblanApplicationInfo) {
         withContext(ioDispatcher) {
-            eblanApplicationInfo.customIcon?.let { customIcon ->
-                val customIconFile = File(customIcon)
+            eblanApplicationInfo.customIcon?.let {
+                val customIconFile = File(it)
 
                 if (customIconFile.exists()) {
                     customIconFile.delete()
@@ -121,9 +113,7 @@ internal class DefaultEblanApplicationInfoRepository @Inject constructor(
     ): List<EblanApplicationInfo> = eblanApplicationInfoDao.getEblanApplicationInfoEntitiesByPackageName(
         serialNumber = serialNumber,
         packageName = packageName,
-    ).map { entity ->
-        entity.asModel()
-    }
+    ).map { it.asModel() }
 
     override fun getEblanApplicationInfoTagsFlow(
         serialNumber: Long,
@@ -132,19 +122,15 @@ internal class DefaultEblanApplicationInfoRepository @Inject constructor(
         serialNumber = serialNumber,
         componentName = componentName,
     ).map { entities ->
-        entities.map { entity ->
-            entity.asModel()
-        }
+        entities.map { it.asModel() }
     }
 
-    override fun getEblanApplicationInfosByTagId(id: Long): List<EblanApplicationInfo> = eblanApplicationInfoDao.getEblanApplicationInfoEntitiesByTagId(id = id).map { entity ->
-        entity.asModel()
+    override fun getEblanApplicationInfosByTagId(id: Long): List<EblanApplicationInfo> = eblanApplicationInfoDao.getEblanApplicationInfoEntitiesByTagId(id = id).map {
+        it.asModel()
     }
 
     override fun getEblanApplicationInfosWithoutTag(): List<EblanApplicationInfo> = eblanApplicationInfoDao.getEblanApplicationInfoEntitiesWithoutTags()
-        .map { entity ->
-            entity.asModel()
-        }
+        .map { it.asModel() }
 
     private fun EblanApplicationInfoTagEntity.asModel(): EblanApplicationInfoTag = EblanApplicationInfoTag(
         id = id,

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanApplicationInfoTagRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanApplicationInfoTagRepository.kt
@@ -27,9 +27,7 @@ import javax.inject.Inject
 internal class DefaultEblanApplicationInfoTagRepository @Inject constructor(private val eblanApplicationInfoTagDao: EblanApplicationInfoTagDao) : EblanApplicationInfoTagRepository {
     override val eblanApplicationInfoTagsFlow =
         eblanApplicationInfoTagDao.getEblanApplicationInfoTagEntitiesFlow().map { entities ->
-            entities.map { entity ->
-                entity.asModel()
-            }
+            entities.map { it.asModel() }
         }
 
     override suspend fun insertEblanApplicationInfoTag(eblanApplicationInfoTag: EblanApplicationInfoTag) {

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanShortcutConfigRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanShortcutConfigRepository.kt
@@ -34,14 +34,10 @@ internal class DefaultEblanShortcutConfigRepository @Inject constructor(private 
         }
 
     override suspend fun getEblanShortcutConfigs(): List<EblanShortcutConfig> = eblanShortcutConfigDao.getEblanShortcutConfigEntities()
-        .map { eblanShortcutConfigEntity ->
-            eblanShortcutConfigEntity.asModel()
-        }
+        .map { it.asModel() }
 
     override suspend fun upsertEblanShortcutConfigs(eblanShortcutConfigs: List<EblanShortcutConfig>) {
-        val entities = eblanShortcutConfigs.map { eblanShortcutConfig ->
-            eblanShortcutConfig.asEntity()
-        }
+        val entities = eblanShortcutConfigs.map { it.asEntity() }
 
         eblanShortcutConfigDao.upsertEblanShortcutConfigEntities(entities = entities)
     }
@@ -66,9 +62,7 @@ internal class DefaultEblanShortcutConfigRepository @Inject constructor(private 
     ): List<EblanShortcutConfig> = eblanShortcutConfigDao.getEblanShortcutConfigEntitiesByPackageName(
         serialNumber = serialNumber,
         packageName = packageName,
-    ).map { entity ->
-        entity.asModel()
-    }
+    ).map { it.asModel() }
 
     private fun EblanShortcutConfig.asEntity(): EblanShortcutConfigEntity = EblanShortcutConfigEntity(
         componentName = componentName,

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanShortcutInfoRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultEblanShortcutInfoRepository.kt
@@ -28,20 +28,14 @@ import javax.inject.Inject
 class DefaultEblanShortcutInfoRepository @Inject constructor(private val eblanShortcutInfoDao: EblanShortcutInfoDao) : EblanShortcutInfoRepository {
     override val eblanShortcutInfosFlow =
         eblanShortcutInfoDao.getEblanShortcutInfoEntitiesFlow().map { entities ->
-            entities.map { entity ->
-                entity.asModel()
-            }
+            entities.map { it.asModel() }
         }
 
     override suspend fun getEblanShortcutInfos(): List<EblanShortcutInfo> = eblanShortcutInfoDao.getEblanShortcutInfoEntities()
-        .map { eblanShortcutInfoEntity ->
-            eblanShortcutInfoEntity.asModel()
-        }
+        .map { it.asModel() }
 
     override suspend fun upsertEblanShortcutInfos(eblanShortcutInfos: List<EblanShortcutInfo>) {
-        val entities = eblanShortcutInfos.map { eblanShortcutInfo ->
-            eblanShortcutInfo.asEntity()
-        }
+        val entities = eblanShortcutInfos.map { it.asEntity() }
 
         eblanShortcutInfoDao.upsertEblanShortcutInfoEntities(entities = entities)
     }
@@ -56,9 +50,7 @@ class DefaultEblanShortcutInfoRepository @Inject constructor(private val eblanSh
     ): List<EblanShortcutInfo> = eblanShortcutInfoDao.getEblanShortcutInfoEntities(
         serialNumber = serialNumber,
         packageName = packageName,
-    ).map { entity ->
-        entity.asModel()
-    }
+    ).map { it.asModel() }
 
     override suspend fun deleteEblanShortcutInfos(
         serialNumber: Long,

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderEblanApplicationInfoRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderEblanApplicationInfoRepository.kt
@@ -1,0 +1,109 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.data.repository
+
+import com.eblan.launcher.data.repository.mapper.asEntity
+import com.eblan.launcher.data.repository.mapper.asFolderEblanApplicationInfoWrapper
+import com.eblan.launcher.data.room.dao.FolderEblanApplicationInfoDao
+import com.eblan.launcher.domain.model.FolderEblanApplicationInfo
+import com.eblan.launcher.domain.model.FolderEblanApplicationInfoWrapper
+import com.eblan.launcher.domain.repository.FolderEblanApplicationInfoRepository
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+internal class DefaultFolderEblanApplicationInfoRepository @Inject constructor(private val folderEblanApplicationInfoDao: FolderEblanApplicationInfoDao) : FolderEblanApplicationInfoRepository {
+    override val folderEblanApplicationInfoWrappersFlow =
+        folderEblanApplicationInfoDao.getFolderEblanApplicationInfoWrapperEntitiesFlow()
+            .map { entities ->
+                entities.filter { entity ->
+                    entity.folderEblanApplicationInfoEntity.folderId == null
+                }.map { entity ->
+                    entity.asFolderEblanApplicationInfoWrapper()
+                }
+            }
+
+    override val folderEblanApplicationInfoWrappersWithFolderIdFlow =
+        folderEblanApplicationInfoDao.getFolderEblanApplicationInfoWrapperEntitiesFlow()
+            .map { entities ->
+                entities.map { entity ->
+                    entity.asFolderEblanApplicationInfoWrapper()
+                }
+            }
+
+    override suspend fun getFolderEblanApplicationInfoWrapper(id: String): FolderEblanApplicationInfoWrapper? = folderEblanApplicationInfoDao.getFolderEblanApplicationInfoWrapperEntity(id = id)
+        ?.asFolderEblanApplicationInfoWrapper()
+
+    override suspend fun getFolderEblanApplicationInfoWrappers(): List<FolderEblanApplicationInfoWrapper> = folderEblanApplicationInfoDao.getFolderEblanApplicationInfoWrapperEntities()
+        .filter { entity ->
+            entity.folderEblanApplicationInfoEntity.folderId == null
+        }.map { entity ->
+            entity.asFolderEblanApplicationInfoWrapper()
+        }
+
+    override suspend fun getFolderEblanApplicationInfoWrappersWithFolderId(): List<FolderEblanApplicationInfoWrapper> = folderEblanApplicationInfoDao.getFolderEblanApplicationInfoWrapperEntities().map { entity ->
+        entity.asFolderEblanApplicationInfoWrapper()
+    }
+
+    override suspend fun upsertFolderEblanApplicationInfos(folderEblanApplicationInfos: List<FolderEblanApplicationInfo>) {
+        val entities = folderEblanApplicationInfos.map { folderEblanApplicationInfo ->
+            folderEblanApplicationInfo.asEntity()
+        }
+
+        folderEblanApplicationInfoDao.upsertFolderEblanApplicationInfoEntities(entities = entities)
+    }
+
+    override suspend fun updateFolderEblanApplicationInfo(folderEblanApplicationInfo: FolderEblanApplicationInfo) {
+        folderEblanApplicationInfoDao.updateFolderEblanApplicationInfoEntity(entity = folderEblanApplicationInfo.asEntity())
+    }
+
+    override suspend fun deleteFolderEblanApplicationInfo(folderEblanApplicationInfo: FolderEblanApplicationInfo) {
+        folderEblanApplicationInfoDao.deleteFolderEblanApplicationInfoEntity(entity = folderEblanApplicationInfo.asEntity())
+    }
+
+    override suspend fun deleteFolderEblanApplicationInfos(folderEblanApplicationInfos: List<FolderEblanApplicationInfo>) {
+        val entities = folderEblanApplicationInfos.map { folderEblanApplicationInfo ->
+            folderEblanApplicationInfo.asEntity()
+        }
+
+        folderEblanApplicationInfoDao.deleteFolderEblanApplicationInfoEntities(entities = entities)
+    }
+
+    override suspend fun insertFolderEblanApplicationInfo(folderEblanApplicationInfo: FolderEblanApplicationInfo) {
+        folderEblanApplicationInfoDao.insertFolderEblanApplicationInfoEntity(entity = folderEblanApplicationInfo.asEntity())
+    }
+
+    override suspend fun updateFolderEblanApplicationInfos(folderEblanApplicationInfos: List<FolderEblanApplicationInfo>) {
+        val entities = folderEblanApplicationInfos.map { folderEblanApplicationInfo ->
+            folderEblanApplicationInfo.asEntity()
+        }
+
+        folderEblanApplicationInfoDao.updateFolderEblanApplicationInfoEntities(entities = entities)
+    }
+
+    override suspend fun insertFolderEblanApplicationInfos(folderEblanApplicationInfos: List<FolderEblanApplicationInfo>) {
+        val entities = folderEblanApplicationInfos.map { folderEblanApplicationInfo ->
+            folderEblanApplicationInfo.asEntity()
+        }
+
+        folderEblanApplicationInfoDao.insertFolderEblanApplicationInfoEntities(entities = entities)
+    }
+
+    override suspend fun upsertFolderEblanApplicationInfo(folderEblanApplicationInfo: FolderEblanApplicationInfo) {
+        folderEblanApplicationInfoDao.upsertFolderEblanApplicationInfoEntity(entity = folderEblanApplicationInfo.asEntity())
+    }
+}

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderGridItemRepository.kt
@@ -29,36 +29,27 @@ import javax.inject.Inject
 internal class DefaultFolderGridItemRepository @Inject constructor(private val folderGridItemDao: FolderGridItemDao) : FolderGridItemRepository {
     override val folderGridItemWrappersFlow =
         folderGridItemDao.getFolderGridItemWrapperEntitiesFlow().map { entities ->
-            entities.filter { entity ->
-                entity.folderGridItemEntity.folderId == null
-            }.map { entity ->
-                entity.asFolderGridItemWrapper()
-            }
+            entities.filter { it.folderGridItemEntity.folderId == null }
+                .map { it.asFolderGridItemWrapper() }
         }
 
     override val folderGridItemWrappersWithFolderIdFlow =
         folderGridItemDao.getFolderGridItemWrapperEntitiesFlow().map { entities ->
-            entities.map { entity ->
-                entity.asFolderGridItemWrapper()
-            }
+            entities.map { it.asFolderGridItemWrapper() }
         }
 
     override suspend fun getFolderGridItemWrapper(id: String): FolderGridItemWrapper? = folderGridItemDao.getFolderGridItemWrapperEntity(id = id)?.asFolderGridItemWrapper()
 
-    override suspend fun getFolderGridItemWrappers(): List<FolderGridItemWrapper> = folderGridItemDao.getFolderGridItemWrapperEntities().filter { entity ->
-        entity.folderGridItemEntity.folderId == null
-    }.map { entity ->
-        entity.asFolderGridItemWrapper()
-    }
+    override suspend fun getFolderGridItemWrappers(): List<FolderGridItemWrapper> = folderGridItemDao.getFolderGridItemWrapperEntities().filter {
+        it.folderGridItemEntity.folderId == null
+    }.map { it.asFolderGridItemWrapper() }
 
-    override suspend fun getFolderGridItemWrappersWithFolderId(): List<FolderGridItemWrapper> = folderGridItemDao.getFolderGridItemWrapperEntities().map { entity ->
-        entity.asFolderGridItemWrapper()
+    override suspend fun getFolderGridItemWrappersWithFolderId(): List<FolderGridItemWrapper> = folderGridItemDao.getFolderGridItemWrapperEntities().map {
+        it.asFolderGridItemWrapper()
     }
 
     override suspend fun upsertFolderGridItems(folderGridItems: List<FolderGridItem>) {
-        val entities = folderGridItems.map { folderGridItem ->
-            folderGridItem.asEntity()
-        }
+        val entities = folderGridItems.map { it.asEntity() }
 
         folderGridItemDao.upsertFolderGridItemEntities(entities = entities)
     }
@@ -72,9 +63,7 @@ internal class DefaultFolderGridItemRepository @Inject constructor(private val f
     }
 
     override suspend fun deleteFolderGridItems(folderGridItems: List<FolderGridItem>) {
-        val entities = folderGridItems.map { folderGridItem ->
-            folderGridItem.asEntity()
-        }
+        val entities = folderGridItems.map { it.asEntity() }
 
         folderGridItemDao.deleteFolderGridItemEntities(entities = entities)
     }
@@ -84,17 +73,13 @@ internal class DefaultFolderGridItemRepository @Inject constructor(private val f
     }
 
     override suspend fun updateFolderGridItems(folderGridItems: List<FolderGridItem>) {
-        val entities = folderGridItems.map { folderGridItem ->
-            folderGridItem.asEntity()
-        }
+        val entities = folderGridItems.map { it.asEntity() }
 
         folderGridItemDao.updateFolderGridItemEntities(entities = entities)
     }
 
     override suspend fun insertFolderGridItems(folderGridItems: List<FolderGridItem>) {
-        val entities = folderGridItems.map { folderGridItem ->
-            folderGridItem.asEntity()
-        }
+        val entities = folderGridItems.map { it.asEntity() }
 
         folderGridItemDao.insertFolderGridItemEntities(entities = entities)
     }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
@@ -158,8 +158,8 @@ internal class DefaultGridRepository @Inject constructor(
         withContext(ioDispatcher) {
             val gridItem = when (val data = gridItem.data) {
                 is GridItemData.ApplicationInfo -> {
-                    data.customIcon?.let { customIcon ->
-                        val customIconFile = File(customIcon)
+                    data.customIcon?.let {
+                        val customIconFile = File(it)
 
                         if (customIconFile.exists()) {
                             customIconFile.delete()
@@ -184,8 +184,8 @@ internal class DefaultGridRepository @Inject constructor(
                 }
 
                 is GridItemData.ShortcutConfig -> {
-                    data.customIcon?.let { customIcon ->
-                        val customIconFile = File(customIcon)
+                    data.customIcon?.let {
+                        val customIconFile = File(it)
 
                         if (customIconFile.exists()) {
                             customIconFile.delete()
@@ -198,8 +198,8 @@ internal class DefaultGridRepository @Inject constructor(
                 }
 
                 is GridItemData.ShortcutInfo -> {
-                    data.customIcon?.let { customIcon ->
-                        val customIconFile = File(customIcon)
+                    data.customIcon?.let {
+                        val customIconFile = File(it)
 
                         if (customIconFile.exists()) {
                             customIconFile.delete()
@@ -212,8 +212,8 @@ internal class DefaultGridRepository @Inject constructor(
                 }
 
                 is GridItemData.Folder -> {
-                    data.icon?.let { icon ->
-                        val iconFile = File(icon)
+                    data.icon?.let {
+                        val iconFile = File(it)
 
                         if (iconFile.exists()) {
                             iconFile.delete()

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutConfigGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutConfigGridItemRepository.kt
@@ -32,37 +32,37 @@ internal class DefaultShortcutConfigGridItemRepository @Inject constructor(priva
     override val gridItemsFlow =
         shortcutConfigGridItemDao.getShortcutConfigGridItemEntitiesFlow()
             .map { entities ->
-                entities.filter { entity ->
-                    entity.folderId == null
-                }.map { entity ->
-                    entity.asGridItem()
+                entities.filter {
+                    it.folderId == null
+                }.map {
+                    it.asGridItem()
                 }
             }
 
     override val gridItemsWithFolderIdFlow =
         shortcutConfigGridItemDao.getShortcutConfigGridItemEntitiesFlow().map { entities ->
-            entities.map { entity ->
-                entity.asGridItem()
+            entities.map {
+                it.asGridItem()
             }
         }
 
     override suspend fun getGridItems(): List<GridItem> = shortcutConfigGridItemDao.getShortcutConfigGridItemEntities().filter { entity ->
         entity.folderId == null
-    }.map { entity ->
-        entity.asGridItem()
+    }.map {
+        it.asGridItem()
     }
 
-    override suspend fun getGridItemsWithFolderId(): List<GridItem> = shortcutConfigGridItemDao.getShortcutConfigGridItemEntities().map { entity ->
-        entity.asGridItem()
+    override suspend fun getGridItemsWithFolderId(): List<GridItem> = shortcutConfigGridItemDao.getShortcutConfigGridItemEntities().map {
+        it.asGridItem()
     }
 
-    override suspend fun getShortcutConfigGridItems(): List<ShortcutConfigGridItem> = shortcutConfigGridItemDao.getShortcutConfigGridItemEntities().map { entity ->
-        entity.asModel()
+    override suspend fun getShortcutConfigGridItems(): List<ShortcutConfigGridItem> = shortcutConfigGridItemDao.getShortcutConfigGridItemEntities().map {
+        it.asModel()
     }
 
     override suspend fun upsertShortcutConfigGridItems(shortcutConfigGridItems: List<ShortcutConfigGridItem>) {
-        val entities = shortcutConfigGridItems.map { shortcutConfigGridItem ->
-            shortcutConfigGridItem.asEntity()
+        val entities = shortcutConfigGridItems.map {
+            it.asEntity()
         }
 
         shortcutConfigGridItemDao.upsertShortcutConfigGridItemEntities(entities = entities)
@@ -75,8 +75,8 @@ internal class DefaultShortcutConfigGridItemRepository @Inject constructor(priva
     }
 
     override suspend fun deleteShortcutConfigGridItems(shortcutConfigGridItems: List<ShortcutConfigGridItem>) {
-        val entities = shortcutConfigGridItems.map { shortcutConfigGridItem ->
-            shortcutConfigGridItem.asEntity()
+        val entities = shortcutConfigGridItems.map {
+            it.asEntity()
         }
 
         shortcutConfigGridItemDao.deleteShortcutConfigGridItemEntities(entities = entities)
@@ -92,8 +92,8 @@ internal class DefaultShortcutConfigGridItemRepository @Inject constructor(priva
     ): List<ShortcutConfigGridItem> = shortcutConfigGridItemDao.getShortcutConfigGridItemEntitiesByPackageName(
         serialNumber = serialNumber,
         packageName = packageName,
-    ).map { entity ->
-        entity.asModel()
+    ).map {
+        it.asModel()
     }
 
     override suspend fun deleteShortcutConfigGridItem(
@@ -119,16 +119,16 @@ internal class DefaultShortcutConfigGridItemRepository @Inject constructor(priva
     }
 
     override suspend fun updateShortcutConfigGridItems(shortcutConfigGridItems: List<ShortcutConfigGridItem>) {
-        val entities = shortcutConfigGridItems.map { shortcutConfigGridItem ->
-            shortcutConfigGridItem.asEntity()
+        val entities = shortcutConfigGridItems.map {
+            it.asEntity()
         }
 
         shortcutConfigGridItemDao.updateShortcutConfigGridItemEntities(entities = entities)
     }
 
     override suspend fun insertShortcutConfigGridItems(shortcutConfigGridItems: List<ShortcutConfigGridItem>) {
-        val entities = shortcutConfigGridItems.map { shortcutConfigGridItem ->
-            shortcutConfigGridItem.asEntity()
+        val entities = shortcutConfigGridItems.map {
+            it.asEntity()
         }
 
         shortcutConfigGridItemDao.insertShortcutConfigGridItemEntities(entities = entities)

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutInfoGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutInfoGridItemRepository.kt
@@ -31,38 +31,30 @@ import javax.inject.Inject
 internal class DefaultShortcutInfoGridItemRepository @Inject constructor(private val shortcutInfoGridItemDao: ShortcutInfoGridItemDao) : ShortcutInfoGridItemRepository {
     override val gridItemsFlow =
         shortcutInfoGridItemDao.getShortcutInfoGridItemEntitiesFlow().map { entities ->
-            entities.filter { entity ->
-                entity.folderId == null
-            }.map { entity ->
-                entity.asGridItem()
-            }
+            entities.filter {
+                it.folderId == null
+            }.map { it.asGridItem() }
         }
 
     override val gridItemsWithFolderIdFlow =
         shortcutInfoGridItemDao.getShortcutInfoGridItemEntitiesFlow().map { entities ->
-            entities.map { entity ->
-                entity.asGridItem()
-            }
+            entities.map { it.asGridItem() }
         }
 
-    override suspend fun getGridItems(): List<GridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntities().filter { entity ->
-        entity.folderId == null
-    }.map { entity ->
-        entity.asGridItem()
+    override suspend fun getGridItems(): List<GridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntities().filter {
+        it.folderId == null
+    }.map { it.asGridItem() }
+
+    override suspend fun getGridItemsWithFolderId(): List<GridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntities().map {
+        it.asGridItem()
     }
 
-    override suspend fun getGridItemsWithFolderId(): List<GridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntities().map { entity ->
-        entity.asGridItem()
-    }
-
-    override suspend fun getShortcutInfoGridItems(): List<ShortcutInfoGridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntities().map { entity ->
-        entity.asModel()
+    override suspend fun getShortcutInfoGridItems(): List<ShortcutInfoGridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntities().map {
+        it.asModel()
     }
 
     override suspend fun upsertShortcutInfoGridItems(shortcutInfoGridItems: List<ShortcutInfoGridItem>) {
-        val entities = shortcutInfoGridItems.map { shortcutInfoGridItem ->
-            shortcutInfoGridItem.asEntity()
-        }
+        val entities = shortcutInfoGridItems.map { it.asEntity() }
 
         shortcutInfoGridItemDao.upsertShortcutInfoGridItemEntities(entities = entities)
     }
@@ -74,9 +66,7 @@ internal class DefaultShortcutInfoGridItemRepository @Inject constructor(private
     }
 
     override suspend fun deleteShortcutInfoGridItems(shortcutInfoGridItems: List<ShortcutInfoGridItem>) {
-        val entities = shortcutInfoGridItems.map { shortcutInfoGridItem ->
-            shortcutInfoGridItem.asEntity()
-        }
+        val entities = shortcutInfoGridItems.map { it.asEntity() }
 
         shortcutInfoGridItemDao.deleteShortcutInfoGridItemEntities(entities = entities)
     }
@@ -91,9 +81,7 @@ internal class DefaultShortcutInfoGridItemRepository @Inject constructor(private
     ): List<ShortcutInfoGridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntitiesByPackageName(
         serialNumber = serialNumber,
         packageName = packageName,
-    ).map { entity ->
-        entity.asModel()
-    }
+    ).map { it.asModel() }
 
     override suspend fun deleteShortcutInfoGridItem(
         serialNumber: Long,
@@ -114,17 +102,13 @@ internal class DefaultShortcutInfoGridItemRepository @Inject constructor(private
     }
 
     override suspend fun updateShortcutInfoGridItems(shortcutInfoGridItems: List<ShortcutInfoGridItem>) {
-        val entities = shortcutInfoGridItems.map { shortcutInfoGridItem ->
-            shortcutInfoGridItem.asEntity()
-        }
+        val entities = shortcutInfoGridItems.map { it.asEntity() }
 
         shortcutInfoGridItemDao.updateShortcutInfoGridItemEntities(entities = entities)
     }
 
     override suspend fun insertShortcutInfoGridItems(shortcutInfoGridItems: List<ShortcutInfoGridItem>) {
-        val entities = shortcutInfoGridItems.map { shortcutInfoGridItem ->
-            shortcutInfoGridItem.asEntity()
-        }
+        val entities = shortcutInfoGridItems.map { it.asEntity() }
 
         shortcutInfoGridItemDao.insertShortcutInfoGridItemEntities(entities = entities)
     }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultWidgetGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultWidgetGridItemRepository.kt
@@ -32,22 +32,22 @@ import kotlin.collections.map
 internal class DefaultWidgetGridItemRepository @Inject constructor(private val widgetGridItemDao: WidgetGridItemDao) : WidgetGridItemRepository {
     override val gridItemsFlow =
         widgetGridItemDao.getWidgetGridItemEntitiesFlow().map { entities ->
-            entities.map { entity ->
-                entity.asGridItem()
+            entities.map {
+                it.asGridItem()
             }
         }
 
-    override suspend fun getGridItems(): List<GridItem> = widgetGridItemDao.getWidgetGridItemEntities().map { entity ->
-        entity.asGridItem()
+    override suspend fun getGridItems(): List<GridItem> = widgetGridItemDao.getWidgetGridItemEntities().map {
+        it.asGridItem()
     }
 
-    override suspend fun getWidgetGridItems(): List<WidgetGridItem> = widgetGridItemDao.getWidgetGridItemEntities().map { entity ->
-        entity.asModel()
+    override suspend fun getWidgetGridItems(): List<WidgetGridItem> = widgetGridItemDao.getWidgetGridItemEntities().map {
+        it.asModel()
     }
 
     override suspend fun upsertWidgetGridItems(widgetGridItems: List<WidgetGridItem>) {
-        val entities = widgetGridItems.map { widgetGridItem ->
-            widgetGridItem.asEntity()
+        val entities = widgetGridItems.map {
+            it.asEntity()
         }
 
         widgetGridItemDao.upsertWidgetGridItemEntities(entities = entities)
@@ -90,17 +90,13 @@ internal class DefaultWidgetGridItemRepository @Inject constructor(private val w
     }
 
     override suspend fun updateWidgetGridItems(widgetGridItems: List<WidgetGridItem>) {
-        val entities = widgetGridItems.map { widgetGridItem ->
-            widgetGridItem.asEntity()
-        }
+        val entities = widgetGridItems.map { it.asEntity() }
 
         widgetGridItemDao.updateWidgetGridItemEntities(entities = entities)
     }
 
     override suspend fun insertWidgetGridItems(widgetGridItems: List<WidgetGridItem>) {
-        val entities = widgetGridItems.map { widgetGridItem ->
-            widgetGridItem.asEntity()
-        }
+        val entities = widgetGridItems.map { it.asEntity() }
 
         widgetGridItemDao.insertWidgetGridItemEntities(entities = entities)
     }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/di/RepositoryModule.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/di/RepositoryModule.kt
@@ -25,6 +25,7 @@ import com.eblan.launcher.data.repository.DefaultEblanApplicationInfoTagReposito
 import com.eblan.launcher.data.repository.DefaultEblanIconPackInfoRepository
 import com.eblan.launcher.data.repository.DefaultEblanShortcutConfigRepository
 import com.eblan.launcher.data.repository.DefaultEblanShortcutInfoRepository
+import com.eblan.launcher.data.repository.DefaultFolderEblanApplicationInfoRepository
 import com.eblan.launcher.data.repository.DefaultFolderGridItemRepository
 import com.eblan.launcher.data.repository.DefaultGridRepository
 import com.eblan.launcher.data.repository.DefaultShortcutConfigGridItemRepository
@@ -39,6 +40,7 @@ import com.eblan.launcher.domain.repository.EblanApplicationInfoTagRepository
 import com.eblan.launcher.domain.repository.EblanIconPackInfoRepository
 import com.eblan.launcher.domain.repository.EblanShortcutConfigRepository
 import com.eblan.launcher.domain.repository.EblanShortcutInfoRepository
+import com.eblan.launcher.domain.repository.FolderEblanApplicationInfoRepository
 import com.eblan.launcher.domain.repository.FolderGridItemRepository
 import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.repository.ShortcutConfigGridItemRepository
@@ -109,4 +111,8 @@ internal interface RepositoryModule {
     @Binds
     @Singleton
     fun eblanApplicationInfoTagRepository(impl: DefaultEblanApplicationInfoTagRepository): EblanApplicationInfoTagRepository
+
+    @Binds
+    @Singleton
+    fun folderEblanApplicationInfoRepository(impl: DefaultFolderEblanApplicationInfoRepository): FolderEblanApplicationInfoRepository
 }

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/EblanApplicationInfoMapper.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/EblanApplicationInfoMapper.kt
@@ -32,6 +32,7 @@ fun EblanApplicationInfo.asEntity(): EblanApplicationInfoEntity = EblanApplicati
     lastUpdateTime = lastUpdateTime,
     index = index,
     flags = flags,
+    folderId = folderId,
 )
 
 fun EblanApplicationInfoEntity.asModel(): EblanApplicationInfo = EblanApplicationInfo(
@@ -46,4 +47,5 @@ fun EblanApplicationInfoEntity.asModel(): EblanApplicationInfo = EblanApplicatio
     lastUpdateTime = lastUpdateTime,
     index = index,
     flags = flags,
+    folderId = folderId,
 )

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/FolderEblanApplicationInfoMapper.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/FolderEblanApplicationInfoMapper.kt
@@ -1,0 +1,49 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.data.repository.mapper
+
+import com.eblan.launcher.data.room.entity.FolderEblanApplicationInfoEntity
+import com.eblan.launcher.data.room.entity.FolderEblanApplicationInfoWrapperEntity
+import com.eblan.launcher.domain.model.FolderEblanApplicationInfo
+import com.eblan.launcher.domain.model.FolderEblanApplicationInfoWrapper
+
+internal fun FolderEblanApplicationInfoWrapperEntity.asFolderEblanApplicationInfoWrapper(): FolderEblanApplicationInfoWrapper = FolderEblanApplicationInfoWrapper(
+    folderEblanApplicationInfo = folderEblanApplicationInfoEntity.asModel(),
+    eblanApplicationInfos = eblanApplicationInfoEntities.map { it.asModel() },
+    folderEblanApplicationInfos = folderEblanApplicationInfoEntities.map { it.asModel() },
+)
+
+internal fun FolderEblanApplicationInfoEntity.asModel(): FolderEblanApplicationInfo = FolderEblanApplicationInfo(
+    id = id,
+    icon = icon,
+    label = label,
+    customIcon = customIcon,
+    customLabel = customLabel,
+    index = index,
+    folderId = folderId,
+)
+
+internal fun FolderEblanApplicationInfo.asEntity(): FolderEblanApplicationInfoEntity = FolderEblanApplicationInfoEntity(
+    id = id,
+    icon = icon,
+    label = label,
+    customIcon = customIcon,
+    customLabel = customLabel,
+    index = index,
+    folderId = folderId,
+)

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/FolderGridItemMapper.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/FolderGridItemMapper.kt
@@ -26,17 +26,17 @@ import com.eblan.launcher.domain.model.GridItemData
 
 internal fun FolderGridItemWrapperEntity.asFolderGridItemWrapper(): FolderGridItemWrapper = FolderGridItemWrapper(
     folderGridItem = folderGridItemEntity.asModel(),
-    applicationInfoGridItems = applicationInfoGridItemEntities.map { applicationInfoGridItemEntity ->
-        applicationInfoGridItemEntity.asModel()
+    applicationInfoGridItems = applicationInfoGridItemEntities.map {
+        it.asModel()
     },
-    shortcutInfoGridItems = shortcutInfoGridItemEntities.map { shortcutInfoGridItemEntity ->
-        shortcutInfoGridItemEntity.asModel()
+    shortcutInfoGridItems = shortcutInfoGridItemEntities.map {
+        it.asModel()
     },
-    shortcutConfigGridItems = shortcutConfigGridItemEntities.map { shortcutConfigGridItemEntity ->
-        shortcutConfigGridItemEntity.asModel()
+    shortcutConfigGridItems = shortcutConfigGridItemEntities.map {
+        it.asModel()
     },
-    folderGridItems = folderGridItemEntities.map { folderGridItemEntity ->
-        folderGridItemEntity.asModel()
+    folderGridItems = folderGridItemEntities.map {
+        it.asModel()
     },
 )
 

--- a/data/room/schemas/com.eblan.launcher.data.room.EblanDatabase/16.json
+++ b/data/room/schemas/com.eblan.launcher.data.room.EblanDatabase/16.json
@@ -1,0 +1,1628 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "664a039b8d7fb711ab48f9101fc0bef5",
+    "entities": [
+      {
+        "tableName": "EblanApplicationInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`componentName` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `icon` TEXT, `label` TEXT NOT NULL, `customIcon` TEXT, `customLabel` TEXT, `isHidden` INTEGER NOT NULL DEFAULT 0, `lastUpdateTime` INTEGER NOT NULL DEFAULT 0, `index` INTEGER NOT NULL DEFAULT -1, `flags` INTEGER NOT NULL DEFAULT 0, `folderId` TEXT, PRIMARY KEY(`componentName`, `serialNumber`))",
+        "fields": [
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customIcon",
+            "columnName": "customIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customLabel",
+            "columnName": "customLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isHidden",
+            "columnName": "isHidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "componentName",
+            "serialNumber"
+          ]
+        }
+      },
+      {
+        "tableName": "EblanAppWidgetProviderInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`componentName` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `configure` TEXT, `packageName` TEXT NOT NULL, `targetCellWidth` INTEGER NOT NULL, `targetCellHeight` INTEGER NOT NULL, `minWidth` INTEGER NOT NULL, `minHeight` INTEGER NOT NULL, `resizeMode` INTEGER NOT NULL, `minResizeWidth` INTEGER NOT NULL, `minResizeHeight` INTEGER NOT NULL, `maxResizeWidth` INTEGER NOT NULL, `maxResizeHeight` INTEGER NOT NULL, `preview` TEXT, `applicationLabel` TEXT NOT NULL, `applicationIcon` TEXT, `lastUpdateTime` INTEGER NOT NULL DEFAULT 0, `label` TEXT, `description` TEXT, PRIMARY KEY(`componentName`))",
+        "fields": [
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configure",
+            "columnName": "configure",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCellWidth",
+            "columnName": "targetCellWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCellHeight",
+            "columnName": "targetCellHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minWidth",
+            "columnName": "minWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minHeight",
+            "columnName": "minHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resizeMode",
+            "columnName": "resizeMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minResizeWidth",
+            "columnName": "minResizeWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minResizeHeight",
+            "columnName": "minResizeHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxResizeWidth",
+            "columnName": "maxResizeWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxResizeHeight",
+            "columnName": "maxResizeHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preview",
+            "columnName": "preview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationLabel",
+            "columnName": "applicationLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "applicationIcon",
+            "columnName": "applicationIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "componentName"
+          ]
+        }
+      },
+      {
+        "tableName": "EblanShortcutInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`shortcutId` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `shortLabel` TEXT NOT NULL, `longLabel` TEXT NOT NULL, `icon` TEXT, `shortcutQueryFlag` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `lastChangedTimestamp` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`shortcutId`, `serialNumber`, `packageName`))",
+        "fields": [
+          {
+            "fieldPath": "shortcutId",
+            "columnName": "shortcutId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortLabel",
+            "columnName": "shortLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longLabel",
+            "columnName": "longLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortcutQueryFlag",
+            "columnName": "shortcutQueryFlag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChangedTimestamp",
+            "columnName": "lastChangedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "shortcutId",
+            "serialNumber",
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "ApplicationInfoGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `componentName` TEXT NOT NULL, `packageName` TEXT NOT NULL, `icon` TEXT, `label` TEXT NOT NULL, `override` INTEGER NOT NULL, `serialNumber` INTEGER NOT NULL, `customIcon` TEXT, `customLabel` TEXT, `index` INTEGER NOT NULL, `folderId` TEXT, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, `doubleTap_eblanActionType` TEXT NOT NULL, `doubleTap_serialNumber` INTEGER NOT NULL, `doubleTap_componentName` TEXT NOT NULL, `swipeUp_eblanActionType` TEXT NOT NULL, `swipeUp_serialNumber` INTEGER NOT NULL, `swipeUp_componentName` TEXT NOT NULL, `swipeDown_eblanActionType` TEXT NOT NULL, `swipeDown_serialNumber` INTEGER NOT NULL, `swipeDown_componentName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customIcon",
+            "columnName": "customIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customLabel",
+            "columnName": "customLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.eblanActionType",
+            "columnName": "doubleTap_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.serialNumber",
+            "columnName": "doubleTap_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.componentName",
+            "columnName": "doubleTap_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.eblanActionType",
+            "columnName": "swipeUp_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.serialNumber",
+            "columnName": "swipeUp_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.componentName",
+            "columnName": "swipeUp_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.eblanActionType",
+            "columnName": "swipeDown_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.serialNumber",
+            "columnName": "swipeDown_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.componentName",
+            "columnName": "swipeDown_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "WidgetGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `appWidgetId` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `componentName` TEXT NOT NULL, `configure` TEXT, `minWidth` INTEGER NOT NULL, `minHeight` INTEGER NOT NULL, `resizeMode` INTEGER NOT NULL, `minResizeWidth` INTEGER NOT NULL, `minResizeHeight` INTEGER NOT NULL, `maxResizeWidth` INTEGER NOT NULL, `maxResizeHeight` INTEGER NOT NULL, `targetCellHeight` INTEGER NOT NULL, `targetCellWidth` INTEGER NOT NULL, `preview` TEXT, `label` TEXT NOT NULL, `icon` TEXT, `override` INTEGER NOT NULL, `serialNumber` INTEGER NOT NULL, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appWidgetId",
+            "columnName": "appWidgetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configure",
+            "columnName": "configure",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "minWidth",
+            "columnName": "minWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minHeight",
+            "columnName": "minHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resizeMode",
+            "columnName": "resizeMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minResizeWidth",
+            "columnName": "minResizeWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minResizeHeight",
+            "columnName": "minResizeHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxResizeWidth",
+            "columnName": "maxResizeWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxResizeHeight",
+            "columnName": "maxResizeHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCellHeight",
+            "columnName": "targetCellHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCellWidth",
+            "columnName": "targetCellWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preview",
+            "columnName": "preview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ShortcutInfoGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `shortcutId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `shortLabel` TEXT NOT NULL, `longLabel` TEXT NOT NULL, `icon` TEXT, `override` INTEGER NOT NULL, `serialNumber` INTEGER NOT NULL, `isEnabled` INTEGER NOT NULL, `eblanApplicationInfoIcon` TEXT, `customIcon` TEXT, `customShortLabel` TEXT, `index` INTEGER NOT NULL, `folderId` TEXT, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, `doubleTap_eblanActionType` TEXT NOT NULL, `doubleTap_serialNumber` INTEGER NOT NULL, `doubleTap_componentName` TEXT NOT NULL, `swipeUp_eblanActionType` TEXT NOT NULL, `swipeUp_serialNumber` INTEGER NOT NULL, `swipeUp_componentName` TEXT NOT NULL, `swipeDown_eblanActionType` TEXT NOT NULL, `swipeDown_serialNumber` INTEGER NOT NULL, `swipeDown_componentName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortcutId",
+            "columnName": "shortcutId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortLabel",
+            "columnName": "shortLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longLabel",
+            "columnName": "longLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eblanApplicationInfoIcon",
+            "columnName": "eblanApplicationInfoIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customIcon",
+            "columnName": "customIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customShortLabel",
+            "columnName": "customShortLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.eblanActionType",
+            "columnName": "doubleTap_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.serialNumber",
+            "columnName": "doubleTap_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.componentName",
+            "columnName": "doubleTap_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.eblanActionType",
+            "columnName": "swipeUp_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.serialNumber",
+            "columnName": "swipeUp_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.componentName",
+            "columnName": "swipeUp_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.eblanActionType",
+            "columnName": "swipeDown_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.serialNumber",
+            "columnName": "swipeDown_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.componentName",
+            "columnName": "swipeDown_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "FolderGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `label` TEXT NOT NULL, `override` INTEGER NOT NULL, `icon` TEXT, `index` INTEGER NOT NULL, `folderId` TEXT, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, `doubleTap_eblanActionType` TEXT NOT NULL, `doubleTap_serialNumber` INTEGER NOT NULL, `doubleTap_componentName` TEXT NOT NULL, `swipeUp_eblanActionType` TEXT NOT NULL, `swipeUp_serialNumber` INTEGER NOT NULL, `swipeUp_componentName` TEXT NOT NULL, `swipeDown_eblanActionType` TEXT NOT NULL, `swipeDown_serialNumber` INTEGER NOT NULL, `swipeDown_componentName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.eblanActionType",
+            "columnName": "doubleTap_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.serialNumber",
+            "columnName": "doubleTap_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.componentName",
+            "columnName": "doubleTap_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.eblanActionType",
+            "columnName": "swipeUp_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.serialNumber",
+            "columnName": "swipeUp_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.componentName",
+            "columnName": "swipeUp_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.eblanActionType",
+            "columnName": "swipeDown_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.serialNumber",
+            "columnName": "swipeDown_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.componentName",
+            "columnName": "swipeDown_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "EblanIconPackInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `icon` TEXT, `label` TEXT, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "EblanShortcutConfigEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`componentName` TEXT NOT NULL, `packageName` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `activityIcon` TEXT, `activityLabel` TEXT, `applicationIcon` TEXT, `applicationLabel` TEXT, PRIMARY KEY(`componentName`, `serialNumber`))",
+        "fields": [
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityIcon",
+            "columnName": "activityIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activityLabel",
+            "columnName": "activityLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationIcon",
+            "columnName": "applicationIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationLabel",
+            "columnName": "applicationLabel",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "componentName",
+            "serialNumber"
+          ]
+        }
+      },
+      {
+        "tableName": "ShortcutConfigGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `componentName` TEXT NOT NULL, `packageName` TEXT NOT NULL, `activityIcon` TEXT, `activityLabel` TEXT, `applicationIcon` TEXT, `applicationLabel` TEXT, `override` INTEGER NOT NULL, `serialNumber` INTEGER NOT NULL, `shortcutIntentName` TEXT, `shortcutIntentIcon` TEXT, `shortcutIntentUri` TEXT, `customIcon` TEXT, `customLabel` TEXT, `index` INTEGER NOT NULL, `folderId` TEXT, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, `doubleTap_eblanActionType` TEXT NOT NULL, `doubleTap_serialNumber` INTEGER NOT NULL, `doubleTap_componentName` TEXT NOT NULL, `swipeUp_eblanActionType` TEXT NOT NULL, `swipeUp_serialNumber` INTEGER NOT NULL, `swipeUp_componentName` TEXT NOT NULL, `swipeDown_eblanActionType` TEXT NOT NULL, `swipeDown_serialNumber` INTEGER NOT NULL, `swipeDown_componentName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityIcon",
+            "columnName": "activityIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activityLabel",
+            "columnName": "activityLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationIcon",
+            "columnName": "applicationIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationLabel",
+            "columnName": "applicationLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortcutIntentName",
+            "columnName": "shortcutIntentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortcutIntentIcon",
+            "columnName": "shortcutIntentIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortcutIntentUri",
+            "columnName": "shortcutIntentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customIcon",
+            "columnName": "customIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customLabel",
+            "columnName": "customLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.eblanActionType",
+            "columnName": "doubleTap_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.serialNumber",
+            "columnName": "doubleTap_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.componentName",
+            "columnName": "doubleTap_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.eblanActionType",
+            "columnName": "swipeUp_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.serialNumber",
+            "columnName": "swipeUp_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.componentName",
+            "columnName": "swipeUp_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.eblanActionType",
+            "columnName": "swipeDown_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.serialNumber",
+            "columnName": "swipeDown_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.componentName",
+            "columnName": "swipeDown_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "EblanApplicationInfoTagCrossRefEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`componentName` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`componentName`, `serialNumber`, `id`), FOREIGN KEY(`componentName`, `serialNumber`) REFERENCES `EblanApplicationInfoEntity`(`componentName`, `serialNumber`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`id`) REFERENCES `EblanApplicationInfoTagEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "componentName",
+            "serialNumber",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_EblanApplicationInfoTagCrossRefEntity_id",
+            "unique": false,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_EblanApplicationInfoTagCrossRefEntity_id` ON `${TABLE_NAME}` (`id`)"
+          },
+          {
+            "name": "index_EblanApplicationInfoTagCrossRefEntity_componentName_serialNumber",
+            "unique": false,
+            "columnNames": [
+              "componentName",
+              "serialNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_EblanApplicationInfoTagCrossRefEntity_componentName_serialNumber` ON `${TABLE_NAME}` (`componentName`, `serialNumber`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "EblanApplicationInfoEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "componentName",
+              "serialNumber"
+            ],
+            "referencedColumns": [
+              "componentName",
+              "serialNumber"
+            ]
+          },
+          {
+            "table": "EblanApplicationInfoTagEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "EblanApplicationInfoTagEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '664a039b8d7fb711ab48f9101fc0bef5')"
+    ]
+  }
+}

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanAppWidgetProviderInfoDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanAppWidgetProviderInfoDao.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface EblanAppWidgetProviderInfoDao {
-
     @Query("SELECT * FROM EblanAppWidgetProviderInfoEntity")
     fun getEblanAppWidgetProviderInfoEntitiesFlow(): Flow<List<EblanAppWidgetProviderInfoEntity>>
 

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanApplicationInfoTagCrossRefDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanApplicationInfoTagCrossRefDao.kt
@@ -25,7 +25,6 @@ import com.eblan.launcher.data.room.entity.EblanApplicationInfoTagCrossRefEntity
 
 @Dao
 interface EblanApplicationInfoTagCrossRefDao {
-
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertEblanApplicationInfoTagCrossRefEntity(entity: EblanApplicationInfoTagCrossRefEntity)
 

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanShortcutInfoDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/EblanShortcutInfoDao.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface EblanShortcutInfoDao {
-
     @Query("SELECT * FROM EblanShortcutInfoEntity")
     fun getEblanShortcutInfoEntitiesFlow(): Flow<List<EblanShortcutInfoEntity>>
 

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/FolderEblanApplicationInfoDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/FolderEblanApplicationInfoDao.kt
@@ -1,0 +1,68 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import androidx.room.Upsert
+import com.eblan.launcher.data.room.entity.FolderEblanApplicationInfoEntity
+import com.eblan.launcher.data.room.entity.FolderEblanApplicationInfoWrapperEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FolderEblanApplicationInfoDao {
+    @Transaction
+    @Query("SELECT * FROM FolderEblanApplicationInfoEntity")
+    fun getFolderEblanApplicationInfoWrapperEntitiesFlow(): Flow<List<FolderEblanApplicationInfoWrapperEntity>>
+
+    @Transaction
+    @Query("SELECT * FROM FolderEblanApplicationInfoEntity WHERE id = :id")
+    suspend fun getFolderEblanApplicationInfoWrapperEntity(id: String): FolderEblanApplicationInfoWrapperEntity?
+
+    @Transaction
+    @Query("SELECT * FROM FolderEblanApplicationInfoEntity")
+    suspend fun getFolderEblanApplicationInfoWrapperEntities(): List<FolderEblanApplicationInfoWrapperEntity>
+
+    @Upsert
+    suspend fun upsertFolderEblanApplicationInfoEntities(entities: List<FolderEblanApplicationInfoEntity>)
+
+    @Update
+    suspend fun updateFolderEblanApplicationInfoEntity(entity: FolderEblanApplicationInfoEntity)
+
+    @Delete
+    suspend fun deleteFolderEblanApplicationInfoEntity(entity: FolderEblanApplicationInfoEntity)
+
+    @Delete
+    suspend fun deleteFolderEblanApplicationInfoEntities(entities: List<FolderEblanApplicationInfoEntity>)
+
+    @Insert
+    suspend fun insertFolderEblanApplicationInfoEntity(entity: FolderEblanApplicationInfoEntity)
+
+    @Update
+    suspend fun updateFolderEblanApplicationInfoEntities(entities: List<FolderEblanApplicationInfoEntity>)
+
+    @Insert
+    suspend fun insertFolderEblanApplicationInfoEntities(entities: List<FolderEblanApplicationInfoEntity>)
+
+    @Upsert
+    suspend fun upsertFolderEblanApplicationInfoEntity(entity: FolderEblanApplicationInfoEntity)
+}

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/FolderGridItemDao.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/dao/FolderGridItemDao.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface FolderGridItemDao {
-
     @Transaction
     @Query("SELECT * FROM FolderGridItemEntity")
     fun getFolderGridItemWrapperEntitiesFlow(): Flow<List<FolderGridItemWrapperEntity>>

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/FolderEblanApplicationInfoEntity.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/FolderEblanApplicationInfoEntity.kt
@@ -19,23 +19,17 @@ package com.eblan.launcher.data.room.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.PrimaryKey
 
-@Entity(primaryKeys = ["componentName", "serialNumber"])
-data class EblanApplicationInfoEntity(
-    val componentName: String,
-    val serialNumber: Long,
-    val packageName: String,
+@Entity
+data class FolderEblanApplicationInfoEntity(
+    @PrimaryKey
+    val id: String,
     val icon: String?,
     val label: String,
     val customIcon: String?,
     val customLabel: String?,
-    @ColumnInfo(defaultValue = "0")
-    val isHidden: Boolean,
-    @ColumnInfo(defaultValue = "0")
-    val lastUpdateTime: Long,
     @ColumnInfo(defaultValue = "-1")
     val index: Int,
-    @ColumnInfo(defaultValue = "0")
-    val flags: Int,
     val folderId: String?,
 )

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/FolderEblanApplicationInfoWrapperEntity.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/FolderEblanApplicationInfoWrapperEntity.kt
@@ -17,25 +17,21 @@
  */
 package com.eblan.launcher.data.room.entity
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
+import androidx.room.Embedded
+import androidx.room.Relation
 
-@Entity(primaryKeys = ["componentName", "serialNumber"])
-data class EblanApplicationInfoEntity(
-    val componentName: String,
-    val serialNumber: Long,
-    val packageName: String,
-    val icon: String?,
-    val label: String,
-    val customIcon: String?,
-    val customLabel: String?,
-    @ColumnInfo(defaultValue = "0")
-    val isHidden: Boolean,
-    @ColumnInfo(defaultValue = "0")
-    val lastUpdateTime: Long,
-    @ColumnInfo(defaultValue = "-1")
-    val index: Int,
-    @ColumnInfo(defaultValue = "0")
-    val flags: Int,
-    val folderId: String?,
+data class FolderEblanApplicationInfoWrapperEntity(
+    @Embedded val folderEblanApplicationInfoEntity: FolderEblanApplicationInfoEntity,
+
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "folderId",
+    )
+    val eblanApplicationInfoEntities: List<EblanApplicationInfoEntity>,
+
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "folderId",
+    )
+    val folderEblanApplicationInfoEntities: List<FolderEblanApplicationInfoEntity>,
 )

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/FolderEblanApplicationInfo.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/FolderEblanApplicationInfo.kt
@@ -15,27 +15,14 @@
  *   limitations under the License.
  *
  */
-package com.eblan.launcher.data.room.entity
+package com.eblan.launcher.domain.model
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-
-@Entity(primaryKeys = ["componentName", "serialNumber"])
-data class EblanApplicationInfoEntity(
-    val componentName: String,
-    val serialNumber: Long,
-    val packageName: String,
+data class FolderEblanApplicationInfo(
+    val id: String,
     val icon: String?,
     val label: String,
     val customIcon: String?,
     val customLabel: String?,
-    @ColumnInfo(defaultValue = "0")
-    val isHidden: Boolean,
-    @ColumnInfo(defaultValue = "0")
-    val lastUpdateTime: Long,
-    @ColumnInfo(defaultValue = "-1")
     val index: Int,
-    @ColumnInfo(defaultValue = "0")
-    val flags: Int,
     val folderId: String?,
 )

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/FolderEblanApplicationInfoWrapper.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/FolderEblanApplicationInfoWrapper.kt
@@ -17,17 +17,8 @@
  */
 package com.eblan.launcher.domain.model
 
-data class EblanApplicationInfo(
-    val componentName: String,
-    val serialNumber: Long,
-    val packageName: String,
-    val icon: String?,
-    val label: String,
-    val customIcon: String?,
-    val customLabel: String?,
-    val isHidden: Boolean,
-    val lastUpdateTime: Long,
-    val index: Int,
-    val flags: Int,
-    val folderId: String?,
+data class FolderEblanApplicationInfoWrapper(
+    val folderEblanApplicationInfo: FolderEblanApplicationInfo,
+    val eblanApplicationInfos: List<EblanApplicationInfo>,
+    val folderEblanApplicationInfos: List<FolderEblanApplicationInfo>,
 )

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/FolderEblanApplicationInfoRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/FolderEblanApplicationInfoRepository.kt
@@ -1,0 +1,50 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.domain.repository
+
+import com.eblan.launcher.domain.model.FolderEblanApplicationInfo
+import com.eblan.launcher.domain.model.FolderEblanApplicationInfoWrapper
+import kotlinx.coroutines.flow.Flow
+
+interface FolderEblanApplicationInfoRepository {
+    val folderEblanApplicationInfoWrappersFlow: Flow<List<FolderEblanApplicationInfoWrapper>>
+
+    val folderEblanApplicationInfoWrappersWithFolderIdFlow: Flow<List<FolderEblanApplicationInfoWrapper>>
+
+    suspend fun getFolderEblanApplicationInfoWrapper(id: String): FolderEblanApplicationInfoWrapper?
+
+    suspend fun getFolderEblanApplicationInfoWrappers(): List<FolderEblanApplicationInfoWrapper>
+
+    suspend fun getFolderEblanApplicationInfoWrappersWithFolderId(): List<FolderEblanApplicationInfoWrapper>
+
+    suspend fun upsertFolderEblanApplicationInfos(folderEblanApplicationInfos: List<FolderEblanApplicationInfo>)
+
+    suspend fun updateFolderEblanApplicationInfo(folderEblanApplicationInfo: FolderEblanApplicationInfo)
+
+    suspend fun deleteFolderEblanApplicationInfo(folderEblanApplicationInfo: FolderEblanApplicationInfo)
+
+    suspend fun deleteFolderEblanApplicationInfos(folderEblanApplicationInfos: List<FolderEblanApplicationInfo>)
+
+    suspend fun insertFolderEblanApplicationInfo(folderEblanApplicationInfo: FolderEblanApplicationInfo)
+
+    suspend fun updateFolderEblanApplicationInfos(folderEblanApplicationInfos: List<FolderEblanApplicationInfo>)
+
+    suspend fun insertFolderEblanApplicationInfos(folderEblanApplicationInfos: List<FolderEblanApplicationInfo>)
+
+    suspend fun upsertFolderEblanApplicationInfo(folderEblanApplicationInfo: FolderEblanApplicationInfo)
+}

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/AddPackageUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/AddPackageUseCase.kt
@@ -146,6 +146,7 @@ class AddPackageUseCase @Inject constructor(
                 lastUpdateTime = lastUpdateTime,
                 index = -1,
                 flags = flags,
+                folderId = null,
             ),
         )
 


### PR DESCRIPTION
Closes #773 

- Introduced `FolderEblanApplicationInfo` and its wrapper across domain, repository, and Room layers to support nested application organization.
- Added a `folderId` property to `EblanApplicationInfo` (model and entity) to facilitate grouping applications within folders.
- Created `FolderEblanApplicationInfoDao`, `FolderEblanApplicationInfoRepository`, and associated entities/mappers to handle folder data persistence.
- Refactored multiple repositories (including `EblanApplicationInfo`, `ShortcutInfo`, and various `GridItem` repositories) to use implicit `it` parameters in lambda expressions for cleaner code.
- Updated `RepositoryModule` to bind the new `FolderEblanApplicationInfoRepository`.
- Simplified custom icon and label handling in `DefaultGridRepository` and `DefaultEblanApplicationInfoRepository` using Kotlin scope functions.
- Updated `AddPackageUseCase` to support the new `folderId` field when adding new packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added folder-based organization system for applications, enabling users to group applications into folders for better management.

* **Refactor**
  * Simplified lambda expressions across repository files for improved code clarity.
  * Updated database schema to version 16 with new folder support.

* **Chores**
  * Updated IDE configuration for JDK compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->