### PR TITLE
Remove filtering of folderId in the Grid repository

### DIFF
--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultApplicationInfoGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultApplicationInfoGridItemRepository.kt
@@ -47,22 +47,7 @@ internal class DefaultApplicationInfoGridItemRepository @Inject constructor(
         userDataRepository.userDataFlow,
         applicationInfoGridItemDao.getApplicationInfoGridItemEntitiesFlow(),
     ) { userData, entities ->
-        entities.filter {
-            it.folderId == null
-        }.map {
-            it.asGridItem(
-                fileManager = fileManager,
-                iconKeyGenerator = iconKeyGenerator,
-                iconPackInfoPackageName = userData.generalSettings.iconPackInfoPackageName,
-            )
-        }
-    }.flowOn(ioDispatcher)
-
-    override val gridItemsWithFolderIdFlow = combine(
-        userDataRepository.userDataFlow,
-        applicationInfoGridItemDao.getApplicationInfoGridItemEntitiesFlow(),
-    ) { userData, applicationInfoGridItems ->
-        applicationInfoGridItems.map {
+        entities.map {
             it.asGridItem(
                 fileManager = fileManager,
                 iconKeyGenerator = iconKeyGenerator,
@@ -72,21 +57,6 @@ internal class DefaultApplicationInfoGridItemRepository @Inject constructor(
     }.flowOn(ioDispatcher)
 
     override suspend fun getGridItems(): List<GridItem> = withContext(ioDispatcher) {
-        val iconPackInfoPackageName =
-            userDataRepository.userDataFlow.first().generalSettings.iconPackInfoPackageName
-
-        applicationInfoGridItemDao.getApplicationInfoGridItemEntities().filter {
-            it.folderId == null
-        }.map {
-            it.asGridItem(
-                fileManager = fileManager,
-                iconKeyGenerator = iconKeyGenerator,
-                iconPackInfoPackageName = iconPackInfoPackageName,
-            )
-        }
-    }
-
-    override suspend fun getGridItemsWithFolderId(): List<GridItem> = withContext(ioDispatcher) {
         val iconPackInfoPackageName =
             userDataRepository.userDataFlow.first().generalSettings.iconPackInfoPackageName
 

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultFolderGridItemRepository.kt
@@ -29,29 +29,14 @@ import javax.inject.Inject
 internal class DefaultFolderGridItemRepository @Inject constructor(private val folderGridItemDao: FolderGridItemDao) : FolderGridItemRepository {
     override val folderGridItemWrappersFlow =
         folderGridItemDao.getFolderGridItemWrapperEntitiesFlow().map { entities ->
-            entities.filter {
-                it.folderGridItemEntity.folderId == null
-            }.map {
-                it.asFolderGridItemWrapper()
-            }
-        }
-
-    override val folderGridItemWrappersWithFolderIdFlow =
-        folderGridItemDao.getFolderGridItemWrapperEntitiesFlow().map { entities ->
             entities.map {
                 it.asFolderGridItemWrapper()
             }
         }
 
-    override suspend fun getFolderGridItemWrapper(id: String): FolderGridItemWrapper? = folderGridItemDao.getFolderGridItemWrapperEntity(id = id)?.asFolderGridItemWrapper()
+    override suspend fun getFolderGridItemWrapperById(id: String): FolderGridItemWrapper? = folderGridItemDao.getFolderGridItemWrapperEntity(id = id)?.asFolderGridItemWrapper()
 
-    override suspend fun getFolderGridItemWrappers(): List<FolderGridItemWrapper> = folderGridItemDao.getFolderGridItemWrapperEntities().filter {
-        it.folderGridItemEntity.folderId == null
-    }.map {
-        it.asFolderGridItemWrapper()
-    }
-
-    override suspend fun getFolderGridItemWrappersWithFolderId(): List<FolderGridItemWrapper> = folderGridItemDao.getFolderGridItemWrapperEntities().map {
+    override suspend fun getFolderGridItemWrappers(): List<FolderGridItemWrapper> = folderGridItemDao.getFolderGridItemWrapperEntities().map {
         it.asFolderGridItemWrapper()
     }
 

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
@@ -65,22 +65,10 @@ internal class DefaultGridRepository @Inject constructor(
         applicationInfoGridItems + widgetGridItems + shortcutInfoGridItems + shortcutConfigGridItems
     }
 
-    override val gridItemsWithFolderIdFlow: Flow<List<GridItem>> = combine(
-        applicationInfoGridItemRepository.gridItemsWithFolderIdFlow,
-        shortcutInfoGridItemRepository.gridItemsWithFolderIdFlow,
-        shortcutConfigGridItemRepository.gridItemsWithFolderIdFlow,
-    ) { applicationInfoGridItems, shortcutInfoGridItems, shortcutConfigGridItems ->
-        applicationInfoGridItems + shortcutInfoGridItems + shortcutConfigGridItems
-    }
-
     override suspend fun getGridItems(): List<GridItem> = applicationInfoGridItemRepository.getGridItems() +
         widgetGridItemRepository.getGridItems() +
         shortcutInfoGridItemRepository.getGridItems() +
         shortcutConfigGridItemRepository.getGridItems()
-
-    override suspend fun getGridItemsWithFolderId(): List<GridItem> = applicationInfoGridItemRepository.getGridItemsWithFolderId() +
-        shortcutInfoGridItemRepository.getGridItemsWithFolderId() +
-        shortcutConfigGridItemRepository.getGridItemsWithFolderId()
 
     override suspend fun insertGridItem(gridItem: GridItem) {
         when (val data = gridItem.data) {

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutConfigGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutConfigGridItemRepository.kt
@@ -32,27 +32,12 @@ internal class DefaultShortcutConfigGridItemRepository @Inject constructor(priva
     override val gridItemsFlow =
         shortcutConfigGridItemDao.getShortcutConfigGridItemEntitiesFlow()
             .map { entities ->
-                entities.filter {
-                    it.folderId == null
-                }.map {
+                entities.map {
                     it.asGridItem()
                 }
             }
 
-    override val gridItemsWithFolderIdFlow =
-        shortcutConfigGridItemDao.getShortcutConfigGridItemEntitiesFlow().map { entities ->
-            entities.map {
-                it.asGridItem()
-            }
-        }
-
-    override suspend fun getGridItems(): List<GridItem> = shortcutConfigGridItemDao.getShortcutConfigGridItemEntities().filter {
-        it.folderId == null
-    }.map {
-        it.asGridItem()
-    }
-
-    override suspend fun getGridItemsWithFolderId(): List<GridItem> = shortcutConfigGridItemDao.getShortcutConfigGridItemEntities().map {
+    override suspend fun getGridItems(): List<GridItem> = shortcutConfigGridItemDao.getShortcutConfigGridItemEntities().map {
         it.asGridItem()
     }
 

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutInfoGridItemRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultShortcutInfoGridItemRepository.kt
@@ -31,27 +31,12 @@ import javax.inject.Inject
 internal class DefaultShortcutInfoGridItemRepository @Inject constructor(private val shortcutInfoGridItemDao: ShortcutInfoGridItemDao) : ShortcutInfoGridItemRepository {
     override val gridItemsFlow =
         shortcutInfoGridItemDao.getShortcutInfoGridItemEntitiesFlow().map { entities ->
-            entities.filter {
-                it.folderId == null
-            }.map {
-                it.asGridItem()
-            }
-        }
-
-    override val gridItemsWithFolderIdFlow =
-        shortcutInfoGridItemDao.getShortcutInfoGridItemEntitiesFlow().map { entities ->
             entities.map {
                 it.asGridItem()
             }
         }
 
-    override suspend fun getGridItems(): List<GridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntities().filter {
-        it.folderId == null
-    }.map {
-        it.asGridItem()
-    }
-
-    override suspend fun getGridItemsWithFolderId(): List<GridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntities().map {
+    override suspend fun getGridItems(): List<GridItem> = shortcutInfoGridItemDao.getShortcutInfoGridItemEntities().map {
         it.asGridItem()
     }
 

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ApplicationInfoGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ApplicationInfoGridItemRepository.kt
@@ -25,11 +25,7 @@ import kotlinx.coroutines.flow.Flow
 interface ApplicationInfoGridItemRepository {
     val gridItemsFlow: Flow<List<GridItem>>
 
-    val gridItemsWithFolderIdFlow: Flow<List<GridItem>>
-
     suspend fun getGridItems(): List<GridItem>
-
-    suspend fun getGridItemsWithFolderId(): List<GridItem>
 
     suspend fun getApplicationInfoGridItems(): List<ApplicationInfoGridItem>
 

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/FolderGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/FolderGridItemRepository.kt
@@ -24,13 +24,9 @@ import kotlinx.coroutines.flow.Flow
 interface FolderGridItemRepository {
     val folderGridItemWrappersFlow: Flow<List<FolderGridItemWrapper>>
 
-    val folderGridItemWrappersWithFolderIdFlow: Flow<List<FolderGridItemWrapper>>
-
-    suspend fun getFolderGridItemWrapper(id: String): FolderGridItemWrapper?
+    suspend fun getFolderGridItemWrapperById(id: String): FolderGridItemWrapper?
 
     suspend fun getFolderGridItemWrappers(): List<FolderGridItemWrapper>
-
-    suspend fun getFolderGridItemWrappersWithFolderId(): List<FolderGridItemWrapper>
 
     suspend fun upsertFolderGridItems(folderGridItems: List<FolderGridItem>)
 

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/GridRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/GridRepository.kt
@@ -23,11 +23,7 @@ import kotlinx.coroutines.flow.Flow
 interface GridRepository {
     val gridItemsFlow: Flow<List<GridItem>>
 
-    val gridItemsWithFolderIdFlow: Flow<List<GridItem>>
-
     suspend fun getGridItems(): List<GridItem>
-
-    suspend fun getGridItemsWithFolderId(): List<GridItem>
 
     suspend fun insertGridItem(gridItem: GridItem)
 

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutConfigGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutConfigGridItemRepository.kt
@@ -25,11 +25,7 @@ import kotlinx.coroutines.flow.Flow
 interface ShortcutConfigGridItemRepository {
     val gridItemsFlow: Flow<List<GridItem>>
 
-    val gridItemsWithFolderIdFlow: Flow<List<GridItem>>
-
     suspend fun getGridItems(): List<GridItem>
-
-    suspend fun getGridItemsWithFolderId(): List<GridItem>
 
     suspend fun getShortcutConfigGridItems(): List<ShortcutConfigGridItem>
 

--- a/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutInfoGridItemRepository.kt
+++ b/domain/repository/src/main/kotlin/com/eblan/launcher/domain/repository/ShortcutInfoGridItemRepository.kt
@@ -25,11 +25,7 @@ import kotlinx.coroutines.flow.Flow
 interface ShortcutInfoGridItemRepository {
     val gridItemsFlow: Flow<List<GridItem>>
 
-    val gridItemsWithFolderIdFlow: Flow<List<GridItem>>
-
     suspend fun getGridItems(): List<GridItem>
-
-    suspend fun getGridItemsWithFolderId(): List<GridItem>
 
     suspend fun getShortcutInfoGridItems(): List<ShortcutInfoGridItem>
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetFolderGridItemsByIdUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetFolderGridItemsByIdUseCase.kt
@@ -43,7 +43,7 @@ class GetFolderGridItemsByIdUseCase @Inject constructor(
     ): Flow<List<FolderPopup>> = combine(
         userDataRepository.userDataFlow,
         folderPopupEntriesFlow,
-        folderGridItemRepository.folderGridItemWrappersWithFolderIdFlow,
+        folderGridItemRepository.folderGridItemWrappersFlow,
     ) { userData, folderPopupEntries, folderGridItemWrappers ->
         folderPopupEntries.mapNotNull { folderPopupEntry ->
             folderGridItemWrappers.firstOrNull {

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetFolderGridItemsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetFolderGridItemsUseCase.kt
@@ -39,15 +39,16 @@ class GetFolderGridItemsUseCase @Inject constructor(
     suspend operator fun invoke(): List<GridItem> = withContext(ioDispatcher) {
         val userData = userDataRepository.userDataFlow.first()
 
-        folderGridItemRepository.getFolderGridItemWrappers().map {
-            it.asGridItem(
-                folderGridItemRepository = folderGridItemRepository,
-                maxFolderColumns = userData.homeSettings.maxFolderColumns,
-                maxFolderRows = userData.homeSettings.maxFolderRows,
-                fileManager = fileManager,
-                iconKeyGenerator = iconKeyGenerator,
-                iconPackInfoPackageName = userData.generalSettings.iconPackInfoPackageName,
-            )
-        }
+        folderGridItemRepository.getFolderGridItemWrappers()
+            .filterNot { it.folderGridItem.folderId != null }.map {
+                it.asGridItem(
+                    folderGridItemRepository = folderGridItemRepository,
+                    maxFolderColumns = userData.homeSettings.maxFolderColumns,
+                    maxFolderRows = userData.homeSettings.maxFolderRows,
+                    fileManager = fileManager,
+                    iconKeyGenerator = iconKeyGenerator,
+                    iconPackInfoPackageName = userData.generalSettings.iconPackInfoPackageName,
+                )
+            }
     }
 }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetGridItemByIdUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetGridItemByIdUseCase.kt
@@ -31,7 +31,7 @@ class GetGridItemByIdUseCase @Inject constructor(
     @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(id: String): GridItem? = withContext(defaultDispatcher) {
-        gridRepository.getGridItemsWithFolderId().plus(getFolderGridItemsUseCase())
+        gridRepository.getGridItems().plus(getFolderGridItemsUseCase())
             .find {
                 it.id == id
             }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
@@ -44,7 +44,7 @@ internal suspend fun FolderGridItemWrapper.asGridItem(
 ): GridItem {
     val childFolderGridItems =
         folderGridItems.map {
-            folderGridItemRepository.getFolderGridItemWrapper(
+            folderGridItemRepository.getFolderGridItemWrapperById(
                 id = it.id,
             )?.asPreviewGridItem(
                 maxFolderColumns = maxFolderColumns,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined repository interfaces by removing folder-scoped grid item retrieval variants and consolidating filtering logic to use cases. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->