### PR TITLE
refactor(home): stabilize LaunchedEffect dependencies using rememberUpdatedState

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
@@ -31,7 +31,6 @@ import kotlin.uuid.Uuid
 
 class UpdateGridItemsAfterMoveUseCase @Inject constructor(
     private val gridRepository: GridRepository,
-    private val getFolderGridItemsUseCase: GetFolderGridItemsUseCase,
     @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(moveGridItemResult: MoveGridItemResult) {
@@ -62,10 +61,6 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
                         )
                     }
                 }
-
-                gridRepository.getGridItems()
-
-                getFolderGridItemsUseCase()
             }
         }
     }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
@@ -182,19 +182,18 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
             else -> error("Unsupported createNewFolder")
         }
 
-        val folderGridItems = listOf(
-            conflictingGridItem.copy(data = conflictingData),
-            movingGridItem.copy(data = movingData),
-        )
+        gridRepository.updateGridItem(gridItem = conflictingGridItem.copy(data = conflictingData))
 
-        gridRepository.upsertGridItem(
+        gridRepository.updateGridItem(gridItem = movingGridItem.copy(data = movingData))
+
+        gridRepository.insertGridItem(
             gridItem = conflictingGridItem.copy(
                 id = id,
                 data = GridItemData.Folder(
                     id = id,
                     label = "New Folder",
-                    gridItems = folderGridItems,
-                    gridItemsByPage = mapOf(0 to folderGridItems),
+                    gridItems = emptyList(),
+                    gridItemsByPage = emptyMap(),
                     icon = null,
                     columns = 1,
                     rows = 2,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -47,6 +47,7 @@ import com.eblan.launcher.domain.usecase.application.GetEblanShortcutConfigsByLa
 import com.eblan.launcher.domain.usecase.application.GetEblanShortcutInfosUseCase
 import com.eblan.launcher.domain.usecase.application.UpdateEblanApplicationInfosIndexesUseCase
 import com.eblan.launcher.domain.usecase.grid.GetFolderGridItemsByIdUseCase
+import com.eblan.launcher.domain.usecase.grid.GetFolderGridItemsUseCase
 import com.eblan.launcher.domain.usecase.grid.MoveFolderGridItemUseCase
 import com.eblan.launcher.domain.usecase.grid.MoveGridItemUseCase
 import com.eblan.launcher.domain.usecase.grid.ResizeGridItemUseCase
@@ -106,6 +107,7 @@ internal class HomeViewModel @Inject constructor(
     getFolderGridItemsByIdUseCase: GetFolderGridItemsByIdUseCase,
     private val moveFolderGridItemUseCase: MoveFolderGridItemUseCase,
     private val iconKeyGenerator: IconKeyGenerator,
+    private val getFolderGridItemsUseCase: GetFolderGridItemsUseCase,
 ) : ViewModel() {
     val homeUiState = getHomeDataUseCase().map(HomeUiState::Success).stateIn(
         scope = viewModelScope,
@@ -343,6 +345,12 @@ internal class HomeViewModel @Inject constructor(
             moveGridItemJob?.cancelAndJoin()
 
             updateGridItemsAfterMoveUseCase(moveGridItemResult = moveGridItemResult)
+
+            if (moveGridItemResult.conflictingGridItem != null) {
+                gridRepository.getGridItems()
+
+                getFolderGridItemsUseCase()
+            }
 
             _isVisibleOverlay.update {
                 false

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
@@ -192,6 +192,8 @@ internal suspend fun handleDragFolderGridItem(
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpsertFolderPopupEntry: (FolderPopupEntry) -> Unit,
 ) {
+    delay(50L.milliseconds)
+
     if (drag != Drag.Dragging ||
         isScrollInProgress ||
         !isVisibleOverlay.value ||
@@ -203,8 +205,6 @@ internal suspend fun handleDragFolderGridItem(
     ) {
         return
     }
-
-    delay(50L.milliseconds)
 
     val leftPadding = with(density) {
         paddingValues.calculateLeftPadding(layoutDirection).roundToPx()

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
@@ -20,6 +20,7 @@ package com.eblan.launcher.feature.home.screen.folder
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.State
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.unit.Density
@@ -90,13 +91,13 @@ internal suspend fun onLongPressFolderGridItem(
 internal fun handleAnimateScrollToPage(
     density: Density,
     drag: Drag,
-    isVisibleOverlay: Boolean,
-    lockMovement: Boolean,
+    isVisibleOverlay: State<Boolean>,
+    lockMovement: State<Boolean>,
     moveGridItemResult: MoveGridItemResult?,
     dragIntOffset: IntOffset,
     folderGridItem: GridItem,
     folderPopupIntOffset: IntOffset,
-    isDragging: Boolean,
+    isDragging: State<Boolean>,
     paddingValues: PaddingValues,
     screenWidth: Int,
     layoutDirection: LayoutDirection,
@@ -105,9 +106,9 @@ internal fun handleAnimateScrollToPage(
     onUpdateFolderPageDirection: (PageDirection?) -> Unit,
 ) {
     if (drag != Drag.Dragging ||
-        !isVisibleOverlay ||
-        !isDragging ||
-        lockMovement ||
+        !isVisibleOverlay.value ||
+        !isDragging.value ||
+        lockMovement.value ||
         moveGridItemResult == null ||
         !isLast
     ) {
@@ -162,11 +163,11 @@ internal suspend fun handleDragFolderGridItem(
     dragIntOffset: IntOffset,
     currentPage: Int,
     folderGridItem: GridItem?,
-    folderPopupIntOffset: IntOffset,
-    isDragging: Boolean,
-    isVisibleOverlay: Boolean,
+    folderPopupIntOffset: State<IntOffset>,
+    isDragging: State<Boolean>,
+    isVisibleOverlay: State<Boolean>,
     isScrollInProgress: Boolean,
-    lockMovement: Boolean,
+    lockMovement: State<Boolean>,
     paddingValues: PaddingValues,
     screenHeight: Int,
     screenWidth: Int,
@@ -174,7 +175,7 @@ internal suspend fun handleDragFolderGridItem(
     layoutDirection: LayoutDirection,
     folderCellWidth: Int,
     folderCellHeight: Int,
-    folderPopupEntry: FolderPopupEntry,
+    folderPopupEntry: State<FolderPopupEntry>,
     isLastFolderGridItem: Boolean,
     onMoveFolderGridItem: (
         conflictingGridItem: GridItem,
@@ -193,9 +194,9 @@ internal suspend fun handleDragFolderGridItem(
 ) {
     if (drag != Drag.Dragging ||
         isScrollInProgress ||
-        !isVisibleOverlay ||
-        !isDragging ||
-        lockMovement ||
+        !isVisibleOverlay.value ||
+        !isDragging.value ||
+        lockMovement.value ||
         moveGridItemResult == null ||
         folderGridItem == null ||
         !isLastFolderGridItem
@@ -270,11 +271,11 @@ internal suspend fun handleDragFolderGridItem(
         ).coerceAtLeast(minimumValue = topPadding)
 
     val endIntOffset = IntOffset(
-        x = folderPopupIntOffset.x.coerceIn(
+        x = folderPopupIntOffset.value.x.coerceIn(
             minimumValue = leftPadding,
             maximumValue = maximumX,
         ),
-        y = folderPopupIntOffset.y.coerceIn(
+        y = folderPopupIntOffset.value.y.coerceIn(
             minimumValue = topPadding,
             maximumValue = maximumY,
         ),
@@ -308,6 +309,6 @@ internal suspend fun handleDragFolderGridItem(
             currentPage,
         )
     } else {
-        onUpsertFolderPopupEntry(folderPopupEntry.copy(isCloseFolder = true))
+        onUpsertFolderPopupEntry(folderPopupEntry.value.copy(isCloseFolder = true))
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDropGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDropGridItemHelper.kt
@@ -17,13 +17,14 @@
  */
 package com.eblan.launcher.feature.home.screen.folder
 
+import androidx.compose.runtime.State
 import com.eblan.launcher.feature.home.model.Drag
 
 internal fun handleDropFolderGridItem(
     drag: Drag,
-    isDragging: Boolean,
-    lockMovement: Boolean,
-    isVisibleOverlay: Boolean,
+    isDragging: State<Boolean>,
+    lockMovement: State<Boolean>,
+    isVisibleOverlay: State<Boolean>,
     isLast: Boolean,
     onDragCancelAfterMoveFolder: () -> Unit,
     onDragEndAfterMoveFolder: () -> Unit,
@@ -38,13 +39,13 @@ internal fun handleDropFolderGridItem(
         return
     }
 
-    if (isVisibleOverlay && !isDragging) {
+    if (isVisibleOverlay.value && !isDragging.value) {
         onUpdateIsVisibleOverlay(false)
 
         return
     }
 
-    if (lockMovement) {
+    if (lockMovement.value) {
         onUpdateIsVisibleOverlay(false)
 
         onUpdateIsDragging(false)
@@ -54,7 +55,7 @@ internal fun handleDropFolderGridItem(
         return
     }
 
-    if (isVisibleOverlay) {
+    if (isVisibleOverlay.value) {
         onDragEndAfterMoveFolder()
 
         onUpdateIsDragging(false)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -274,14 +275,13 @@ internal fun SharedTransitionScope.FolderScreen(
 
     val isLastFolderGridItem = lastFolderPopup?.gridItem == folderGridItem
 
-    val currentDrag by rememberUpdatedState(drag)
-    val currentIsDragging by rememberUpdatedState(isDragging)
-    val currentIsVisibleOverlay by rememberUpdatedState(isVisibleOverlay)
-    val currentMoveGridItemResult by rememberUpdatedState(moveGridItemResult)
-    val currentLockMovement by rememberUpdatedState(lockMovement)
-    val currentFolderPopupEntry by rememberUpdatedState(folderPopup.folderPopupEntry)
-    val currentFolderPopupIntOffset by rememberUpdatedState(folderPopupIntOffset)
-    val currentCurrentPage by rememberUpdatedState(folderGridHorizontalPagerState.currentPage)
+    val currentDrag = rememberUpdatedState(drag)
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsVisibleOverlay = rememberUpdatedState(isVisibleOverlay)
+    val currentMoveGridItemResult = rememberUpdatedState(moveGridItemResult)
+    val currentLockMovement = rememberUpdatedState(lockMovement)
+    val currentFolderPopupEntry = rememberUpdatedState(folderPopup.folderPopupEntry)
+    val currentFolderPopupIntOffset = rememberUpdatedState(folderPopupIntOffset)
 
     LaunchedEffect(key1 = Unit) {
         progress.animateTo(targetValue = 1f)
@@ -293,10 +293,10 @@ internal fun SharedTransitionScope.FolderScreen(
 
     LaunchedEffect(key1 = folderPopup) {
         handleFolderPopup(
-            currentDrag = currentDrag,
-            currentIsDragging = currentIsDragging,
-            currentIsVisibleOverlay = currentIsVisibleOverlay,
-            currentMoveGridItemResult = currentMoveGridItemResult,
+            drag = currentDrag,
+            isDragging = currentIsDragging,
+            isVisibleOverlay = currentIsVisibleOverlay,
+            moveGridItemResult = currentMoveGridItemResult,
             folderPopup = folderPopup,
             progress = progress,
             onAnimateToScrollToPage = folderGridHorizontalPagerState::animateScrollToPage,
@@ -317,7 +317,7 @@ internal fun SharedTransitionScope.FolderScreen(
             density = density,
             drag = drag,
             dragIntOffset = dragIntOffset,
-            currentPage = currentCurrentPage,
+            currentPage = folderGridHorizontalPagerState.currentPage,
             folderGridItem = folderGridItem,
             folderPopupIntOffset = currentFolderPopupIntOffset,
             isDragging = currentIsDragging,
@@ -571,10 +571,10 @@ internal fun FolderTitle(
 }
 
 private suspend fun handleFolderPopup(
-    currentDrag: Drag,
-    currentIsDragging: Boolean,
-    currentIsVisibleOverlay: Boolean,
-    currentMoveGridItemResult: MoveGridItemResult?,
+    drag: State<Drag>,
+    isDragging: State<Boolean>,
+    isVisibleOverlay: State<Boolean>,
+    moveGridItemResult: State<MoveGridItemResult?>,
     folderPopup: FolderPopup,
     progress: Animatable<Float, AnimationVector1D>,
     onAnimateToScrollToPage: suspend (Int) -> Unit,
@@ -587,11 +587,11 @@ private suspend fun handleFolderPopup(
 
         progress.animateTo(targetValue = 0f)
 
-        val gridItem = currentMoveGridItemResult?.movingGridItem
+        val gridItem = moveGridItemResult.value?.movingGridItem
 
-        if (currentDrag == Drag.Dragging &&
-            currentIsDragging &&
-            currentIsVisibleOverlay &&
+        if (drag.value == Drag.Dragging &&
+            isDragging.value &&
+            isVisibleOverlay.value &&
             gridItem != null
         ) {
             onUpdateSharedElementKey(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -24,6 +24,7 @@ import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -49,6 +50,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -272,6 +274,15 @@ internal fun SharedTransitionScope.FolderScreen(
 
     val isLastFolderGridItem = lastFolderPopup?.gridItem == folderGridItem
 
+    val currentDrag by rememberUpdatedState(drag)
+    val currentIsDragging by rememberUpdatedState(isDragging)
+    val currentIsVisibleOverlay by rememberUpdatedState(isVisibleOverlay)
+    val currentMoveGridItemResult by rememberUpdatedState(moveGridItemResult)
+    val currentLockMovement by rememberUpdatedState(lockMovement)
+    val currentFolderPopupEntry by rememberUpdatedState(folderPopup.folderPopupEntry)
+    val currentFolderPopupIntOffset by rememberUpdatedState(folderPopupIntOffset)
+    val currentCurrentPage by rememberUpdatedState(folderGridHorizontalPagerState.currentPage)
+
     LaunchedEffect(key1 = Unit) {
         progress.animateTo(targetValue = 1f)
     }
@@ -280,61 +291,39 @@ internal fun SharedTransitionScope.FolderScreen(
         onUpsertFolderPopupEntry(folderPopup.folderPopupEntry.copy(isCloseFolder = true))
     }
 
-    LaunchedEffect(
-        folderPopup,
-        drag,
-        isDragging,
-        isVisibleOverlay,
-        moveGridItemResult,
-    ) {
-        if (folderPopup.folderPopupEntry.isCloseFolder) {
-            folderGridHorizontalPagerState.animateScrollToPage(0)
-
-            progress.animateTo(targetValue = 0f)
-
-            val gridItem = moveGridItemResult?.movingGridItem
-
-            if (drag == Drag.Dragging &&
-                isDragging &&
-                isVisibleOverlay &&
-                gridItem != null
-            ) {
-                onUpdateSharedElementKey(
-                    SharedElementKey(
-                        id = gridItem.id,
-                        parent = SharedElementKey.Parent.Grid,
-                    ),
-                )
-
-                onMoveFolderGridItemOutsideFolder(gridItem)
-            }
-
-            onDeleteFolderPopupEntry(folderPopup.folderPopupEntry)
-        }
+    LaunchedEffect(key1 = folderPopup) {
+        handleFolderPopup(
+            currentDrag = currentDrag,
+            currentIsDragging = currentIsDragging,
+            currentIsVisibleOverlay = currentIsVisibleOverlay,
+            currentMoveGridItemResult = currentMoveGridItemResult,
+            folderPopup = folderPopup,
+            progress = progress,
+            onAnimateToScrollToPage = folderGridHorizontalPagerState::animateScrollToPage,
+            onDeleteFolderPopupEntry = onDeleteFolderPopupEntry,
+            onMoveFolderGridItemOutsideFolder = onMoveFolderGridItemOutsideFolder,
+            onUpdateSharedElementKey = onUpdateSharedElementKey,
+        )
     }
 
     LaunchedEffect(
         drag,
         dragIntOffset,
         folderGridItem,
-        isDragging,
-        isVisibleOverlay,
-        lockMovement,
         moveGridItemResult,
         isLastFolderGridItem,
-        folderPopup,
     ) {
         handleDragFolderGridItem(
             density = density,
             drag = drag,
             dragIntOffset = dragIntOffset,
-            currentPage = folderGridHorizontalPagerState.currentPage,
+            currentPage = currentCurrentPage,
             folderGridItem = folderGridItem,
-            folderPopupIntOffset = folderPopupIntOffset,
-            isDragging = isDragging,
-            isVisibleOverlay = isVisibleOverlay,
+            folderPopupIntOffset = currentFolderPopupIntOffset,
+            isDragging = currentIsDragging,
+            isVisibleOverlay = currentIsVisibleOverlay,
             isScrollInProgress = folderGridHorizontalPagerState.isScrollInProgress,
-            lockMovement = lockMovement,
+            lockMovement = currentLockMovement,
             paddingValues = paddingValues,
             screenHeight = screenHeight,
             screenWidth = screenWidth,
@@ -342,7 +331,7 @@ internal fun SharedTransitionScope.FolderScreen(
             layoutDirection = layoutDirection,
             folderCellWidth = folderCellWidth,
             folderCellHeight = folderCellHeight,
-            folderPopupEntry = folderPopup.folderPopupEntry,
+            folderPopupEntry = currentFolderPopupEntry,
             isLastFolderGridItem = isLastFolderGridItem,
             onMoveFolderGridItem = onMoveFolderGridItem,
             onUpdateSharedElementKey = onUpdateSharedElementKey,
@@ -351,16 +340,14 @@ internal fun SharedTransitionScope.FolderScreen(
     }
 
     LaunchedEffect(
-        drag,
-        isDragging,
-        isVisibleOverlay,
-        isLastFolderGridItem,
+        key1 = drag,
+        key2 = isLastFolderGridItem,
     ) {
         handleDropFolderGridItem(
             drag = drag,
-            isDragging = isDragging,
-            lockMovement = lockMovement,
-            isVisibleOverlay = isVisibleOverlay,
+            isDragging = currentIsDragging,
+            lockMovement = currentLockMovement,
+            isVisibleOverlay = currentIsVisibleOverlay,
             isLast = isLastFolderGridItem,
             onDragCancelAfterMoveFolder = onDragCancelAfterMoveFolder,
             onDragEndAfterMoveFolder = onDragEndAfterMoveFolder,
@@ -372,7 +359,8 @@ internal fun SharedTransitionScope.FolderScreen(
     LaunchedEffect(key1 = pageDirection) {
         handlePageDirection(
             pageDirection = pageDirection,
-            pagerState = folderGridHorizontalPagerState,
+            currentPage = folderGridHorizontalPagerState.currentPage,
+            onAnimateScrollToPage = folderGridHorizontalPagerState::animateScrollToPage,
         )
     }
 
@@ -384,23 +372,21 @@ internal fun SharedTransitionScope.FolderScreen(
 
     LaunchedEffect(
         drag,
-        isVisibleOverlay,
-        moveGridItemResult,
         dragIntOffset,
+        moveGridItemResult,
         folderGridItem,
-        isDragging,
         isLastFolderGridItem,
     ) {
         handleAnimateScrollToPage(
             density = density,
             drag = drag,
-            isVisibleOverlay = isVisibleOverlay,
-            lockMovement = lockMovement,
+            isVisibleOverlay = currentIsVisibleOverlay,
+            lockMovement = currentLockMovement,
             moveGridItemResult = moveGridItemResult,
             dragIntOffset = dragIntOffset,
             folderGridItem = folderGridItem,
             folderPopupIntOffset = folderPopupIntOffset,
-            isDragging = isDragging,
+            isDragging = currentIsDragging,
             paddingValues = paddingValues,
             screenWidth = screenWidth,
             layoutDirection = layoutDirection,
@@ -581,5 +567,43 @@ internal fun FolderTitle(
                 )
             }
         }
+    }
+}
+
+private suspend fun handleFolderPopup(
+    currentDrag: Drag,
+    currentIsDragging: Boolean,
+    currentIsVisibleOverlay: Boolean,
+    currentMoveGridItemResult: MoveGridItemResult?,
+    folderPopup: FolderPopup,
+    progress: Animatable<Float, AnimationVector1D>,
+    onAnimateToScrollToPage: suspend (Int) -> Unit,
+    onDeleteFolderPopupEntry: (FolderPopupEntry) -> Unit,
+    onMoveFolderGridItemOutsideFolder: (GridItem) -> Unit,
+    onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
+) {
+    if (folderPopup.folderPopupEntry.isCloseFolder) {
+        onAnimateToScrollToPage(0)
+
+        progress.animateTo(targetValue = 0f)
+
+        val gridItem = currentMoveGridItemResult?.movingGridItem
+
+        if (currentDrag == Drag.Dragging &&
+            currentIsDragging &&
+            currentIsVisibleOverlay &&
+            gridItem != null
+        ) {
+            onUpdateSharedElementKey(
+                SharedElementKey(
+                    id = gridItem.id,
+                    parent = SharedElementKey.Parent.Grid,
+                ),
+            )
+
+            onMoveFolderGridItemOutsideFolder(gridItem)
+        }
+
+        onDeleteFolderPopupEntry(folderPopup.folderPopupEntry)
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -327,18 +328,16 @@ private fun SharedTransitionScope.InteractiveFolderApplicationInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
-    LaunchedEffect(
-        drag,
-        hasInteraction,
-        isDragging,
-        isCloseFolderGridItemPopup,
-    ) {
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsCloseFolderGridItemPopup = rememberUpdatedState(isCloseFolderGridItemPopup)
+
+    LaunchedEffect(key1 = drag) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
             scale = scale,
-            isDragging = isDragging,
-            isCloseGridItemPopup = isCloseFolderGridItemPopup,
+            isDragging = currentIsDragging,
+            isCloseGridItemPopup = currentIsCloseFolderGridItemPopup,
             onUpdateIsDragging = onUpdateIsDragging,
             onUpdateIsCloseGridItemPopup = onUpdateIsCloseFolderGridItemPopup,
         )
@@ -554,18 +553,16 @@ private fun SharedTransitionScope.InteractiveFolderShortcutInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
-    LaunchedEffect(
-        drag,
-        hasInteraction,
-        isDragging,
-        isCloseFolderGridItemPopup,
-    ) {
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsCloseFolderGridItemPopup = rememberUpdatedState(isCloseFolderGridItemPopup)
+
+    LaunchedEffect(key1 = drag) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
             scale = scale,
-            isDragging = isDragging,
-            isCloseGridItemPopup = isCloseFolderGridItemPopup,
+            isDragging = currentIsDragging,
+            isCloseGridItemPopup = currentIsCloseFolderGridItemPopup,
             onUpdateIsDragging = onUpdateIsDragging,
             onUpdateIsCloseGridItemPopup = onUpdateIsCloseFolderGridItemPopup,
         )
@@ -809,18 +806,16 @@ private fun SharedTransitionScope.InteractiveFolderShortcutConfigGridItem(
 
     val scale = remember { Animatable(1f) }
 
-    LaunchedEffect(
-        drag,
-        hasInteraction,
-        isDragging,
-        isCloseFolderGridItemPopup,
-    ) {
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsCloseFolderGridItemPopup = rememberUpdatedState(isCloseFolderGridItemPopup)
+
+    LaunchedEffect(key1 = drag) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
             scale = scale,
-            isDragging = isDragging,
-            isCloseGridItemPopup = isCloseFolderGridItemPopup,
+            isDragging = currentIsDragging,
+            isCloseGridItemPopup = currentIsCloseFolderGridItemPopup,
             onUpdateIsDragging = onUpdateIsDragging,
             onUpdateIsCloseGridItemPopup = onUpdateIsCloseFolderGridItemPopup,
         )
@@ -1006,18 +1001,16 @@ private fun SharedTransitionScope.InteractiveNestedFolderGridItem(
 
     val scale = remember { Animatable(1f) }
 
-    LaunchedEffect(
-        drag,
-        hasInteraction,
-        isDragging,
-        isCloseFolderGridItemPopup,
-    ) {
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsCloseFolderGridItemPopup = rememberUpdatedState(isCloseFolderGridItemPopup)
+
+    LaunchedEffect(key1 = drag) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
             scale = scale,
-            isDragging = isDragging,
-            isCloseGridItemPopup = isCloseFolderGridItemPopup,
+            isDragging = currentIsDragging,
+            isCloseGridItemPopup = currentIsCloseFolderGridItemPopup,
             onUpdateIsDragging = onUpdateIsDragging,
             onUpdateIsCloseGridItemPopup = onUpdateIsCloseFolderGridItemPopup,
         )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
@@ -102,7 +102,7 @@ internal fun handleAnimateScrollToPage(
     associate: Associate?,
     density: Density,
     dragIntOffset: IntOffset,
-    gridItemSource: GridItemSource?,
+    gridItemSource: State<GridItemSource?>,
     isDragging: Boolean,
     paddingValues: PaddingValues,
     screenWidth: Int,
@@ -110,7 +110,9 @@ internal fun handleAnimateScrollToPage(
     onUpdateDockPageDirection: (PageDirection?) -> Unit,
     onUpdateGridPageDirection: (PageDirection?) -> Unit,
 ) {
-    if (gridItemSource == null || !isDragging) return
+    val currentGridItemSource = gridItemSource.value ?: return
+
+    if (!isDragging) return
 
     val leftPadding = with(density) {
         paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
@@ -130,7 +132,7 @@ internal fun handleAnimateScrollToPage(
 
     val dragX = dragIntOffset.x - leftPadding
 
-    when (gridItemSource) {
+    when (currentGridItemSource) {
         is GridItemSource.Existing, is GridItemSource.New, is GridItemSource.Pin -> {
             animateScrollToPage(
                 associate = associate,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
@@ -182,6 +182,8 @@ internal suspend fun handleDragGridItem(
     onUpdateAssociate: (Associate) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
+    delay(50L.milliseconds)
+
     if (drag != Drag.Dragging ||
         isGridScrollInProgress ||
         isDockScrollInProgress ||
@@ -191,8 +193,6 @@ internal suspend fun handleDragGridItem(
     ) {
         return
     }
-
-    delay(50L.milliseconds)
 
     val leftPadding = with(density) {
         paddingValues.calculateLeftPadding(layoutDirection).roundToPx()

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
@@ -20,6 +20,7 @@ package com.eblan.launcher.feature.home.screen.pager
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.State
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.unit.Density
@@ -144,7 +145,7 @@ internal fun handleAnimateScrollToPage(
 }
 
 internal suspend fun handleDragGridItem(
-    gridItems: List<GridItem>,
+    gridItems: State<List<GridItem>>,
     columns: Int,
     gridCurrentPage: Int,
     dockGridCurrentPage: Int,
@@ -154,9 +155,9 @@ internal suspend fun handleDragGridItem(
     dockRows: Int,
     drag: Drag,
     dragIntOffset: IntOffset,
-    gridItemSource: GridItemSource?,
+    gridItemSource: State<GridItemSource?>,
     isDragging: Boolean,
-    isVisibleOverlay: Boolean,
+    isVisibleOverlay: State<Boolean>,
     isGridScrollInProgress: Boolean,
     isDockScrollInProgress: Boolean,
     lockMovement: Boolean,
@@ -164,7 +165,7 @@ internal suspend fun handleDragGridItem(
     rows: Int,
     screenHeight: Int,
     screenWidth: Int,
-    moveGridItemResult: MoveGridItemResult?,
+    moveGridItemResult: State<MoveGridItemResult?>,
     layoutDirection: LayoutDirection,
     onMoveGridItem: (
         gridItems: List<GridItem>,
@@ -182,11 +183,9 @@ internal suspend fun handleDragGridItem(
     if (drag != Drag.Dragging ||
         isGridScrollInProgress ||
         isDockScrollInProgress ||
-        gridItemSource == null ||
-        !isVisibleOverlay ||
+        !isVisibleOverlay.value ||
         !isDragging ||
-        lockMovement ||
-        moveGridItemResult == null
+        lockMovement
     ) {
         return
     }
@@ -231,7 +230,7 @@ internal suspend fun handleDragGridItem(
 
     val isOnDock = dockHeightPx > 0 && localDragY > safeDrawingHeight - dockHeightPx
 
-    when (gridItemSource) {
+    when (val currentGridItemSource = gridItemSource.value ?: return) {
         is GridItemSource.Existing,
         is GridItemSource.New,
         is GridItemSource.Pin,
@@ -245,7 +244,7 @@ internal suspend fun handleDragGridItem(
                     dockRows = dockRows,
                     dragX = localDragX,
                     dragY = localDragY,
-                    gridItemSource = gridItemSource,
+                    gridItemSource = currentGridItemSource,
                     safeDrawingHeight = safeDrawingHeight,
                     safeDrawingWidth = safeDrawingWidth,
                     moveGridItemResult = moveGridItemResult,
@@ -261,7 +260,7 @@ internal suspend fun handleDragGridItem(
                     dockHeightPx = dockHeightPx,
                     dragX = localDragX,
                     dragY = localDragY,
-                    gridItemSource = gridItemSource,
+                    gridItemSource = currentGridItemSource,
                     pageIndicatorHeightPx = pageIndicatorHeightPx,
                     rows = rows,
                     safeDrawingHeight = safeDrawingHeight,
@@ -277,7 +276,7 @@ internal suspend fun handleDragGridItem(
 }
 
 private fun dragGridItem(
-    gridItems: List<GridItem>,
+    gridItems: State<List<GridItem>>,
     columns: Int,
     currentPage: Int,
     dockHeightPx: Int,
@@ -288,7 +287,7 @@ private fun dragGridItem(
     rows: Int,
     safeDrawingHeight: Int,
     safeDrawingWidth: Int,
-    moveGridItemResult: MoveGridItemResult,
+    moveGridItemResult: State<MoveGridItemResult?>,
     onMoveGridItem: (
         gridItems: List<GridItem>,
         movingGridItem: GridItem,
@@ -302,7 +301,7 @@ private fun dragGridItem(
     onUpdateAssociate: (Associate) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
-    val gridItem = moveGridItemResult.movingGridItem
+    val gridItem = moveGridItemResult.value?.movingGridItem ?: return
 
     onUpdateAssociate(Associate.Grid)
 
@@ -342,7 +341,7 @@ private fun dragGridItem(
 
     if (isGridItemSpanWithinBounds) {
         onMoveGridItem(
-            gridItems,
+            gridItems.value,
             moveGridItem,
             dragX,
             dragY,
@@ -355,7 +354,7 @@ private fun dragGridItem(
 }
 
 private fun dragDockGridItem(
-    gridItems: List<GridItem>,
+    gridItems: State<List<GridItem>>,
     currentPage: Int,
     dockColumns: Int,
     dockHeightPx: Int,
@@ -365,7 +364,7 @@ private fun dragDockGridItem(
     gridItemSource: GridItemSource,
     safeDrawingHeight: Int,
     safeDrawingWidth: Int,
-    moveGridItemResult: MoveGridItemResult,
+    moveGridItemResult: State<MoveGridItemResult?>,
     onMoveGridItem: (
         gridItems: List<GridItem>,
         movingGridItem: GridItem,
@@ -379,7 +378,7 @@ private fun dragDockGridItem(
     onUpdateAssociate: (Associate) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
-    val gridItem = moveGridItemResult.movingGridItem
+    val gridItem = moveGridItemResult.value?.movingGridItem ?: return
 
     onUpdateAssociate(Associate.Dock)
 
@@ -418,7 +417,7 @@ private fun dragDockGridItem(
         )
     ) {
         onMoveGridItem(
-            gridItems,
+            gridItems.value,
             moveGridItem,
             dragX,
             dockY,
@@ -431,14 +430,14 @@ private fun dragDockGridItem(
 }
 
 internal suspend fun handleConflictingGridItem(
-    drag: Drag,
-    isDragging: Boolean,
-    isVisibleOverlay: Boolean,
+    drag: State<Drag>,
+    isDragging: State<Boolean>,
+    isVisibleOverlay: State<Boolean>,
     moveGridItemResult: MoveGridItemResult?,
-    lockMovement: Boolean,
+    lockMovement: State<Boolean>,
     intOffset: IntOffset,
     intSize: IntSize,
-    gridItem: GridItem,
+    gridItem: State<GridItem>,
     onShowFolderWhenDragging: (
         folderPopupEntry: FolderPopupEntry,
         movingGridItem: GridItem,
@@ -449,13 +448,7 @@ internal suspend fun handleConflictingGridItem(
 
     val conflictingData = conflictingGridItem.data as? GridItemData.Folder ?: return
 
-    if (drag != Drag.Dragging ||
-        !moveGridItemResult.isSuccess ||
-        !isVisibleOverlay ||
-        !isDragging ||
-        lockMovement ||
-        conflictingGridItem.id != gridItem.id
-    ) {
+    if (drag.value != Drag.Dragging || !moveGridItemResult.isSuccess || !isVisibleOverlay.value || !isDragging.value || lockMovement.value || conflictingGridItem.id != gridItem.value.id) {
         return
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DropGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DropGridItemHelper.kt
@@ -32,6 +32,7 @@ import android.os.Process
 import android.widget.Toast
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.IntentSenderRequest
+import androidx.compose.runtime.State
 import com.eblan.launcher.domain.common.IconKeyGenerator
 import com.eblan.launcher.domain.framework.FileManager
 import com.eblan.launcher.domain.model.GridItem
@@ -54,11 +55,11 @@ internal suspend fun handleDropGridItem(
     androidUserManagerWrapper: AndroidUserManagerWrapper,
     context: Context,
     drag: Drag,
-    gridItemSource: GridItemSource?,
+    gridItemSource: State<GridItemSource?>,
     isDragging: Boolean,
-    moveGridItemResult: MoveGridItemResult?,
+    moveGridItemResult: State<MoveGridItemResult?>,
     lockMovement: Boolean,
-    isVisibleOverlay: Boolean,
+    isVisibleOverlay: State<Boolean>,
     onResetGridAfterDeleteGridItem: (GridItem) -> Unit,
     onDragCancelAfterMove: () -> Unit,
     onDragEndAfterMove: (MoveGridItemResult) -> Unit,
@@ -70,12 +71,11 @@ internal suspend fun handleDropGridItem(
     onUpdateWidgetGridItem: (GridItem) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
 ) {
-    if (drag == Drag.None ||
-        drag == Drag.Start ||
-        drag == Drag.Dragging ||
-        gridItemSource == null ||
-        moveGridItemResult == null
-    ) {
+    val currentGridItemSource = gridItemSource.value ?: return
+
+    val currentMoveGridItemResult = moveGridItemResult.value ?: return
+
+    if (drag == Drag.None || drag == Drag.Start || drag == Drag.Dragging) {
         return
     }
 
@@ -93,12 +93,11 @@ internal suspend fun handleDropGridItem(
         ).show()
     }
 
-    val isLongPress = isVisibleOverlay && !isDragging
+    val isLongPress = isVisibleOverlay.value && !isDragging
 
-    val isMoveGridItemResultFailed =
-        drag == Drag.Cancel || !moveGridItemResult.isSuccess
+    val isMoveGridItemResultFailed = drag == Drag.Cancel || !currentMoveGridItemResult.isSuccess
 
-    when (gridItemSource) {
+    when (currentGridItemSource) {
         is GridItemSource.Existing -> {
             if (isLongPress) {
                 onUpdateIsVisibleOverlay(false)
@@ -106,24 +105,24 @@ internal suspend fun handleDropGridItem(
                 return
             }
 
-            if (isVisibleOverlay && isMoveGridItemResultFailed) return cancelWithToast()
+            if (isVisibleOverlay.value && isMoveGridItemResultFailed) return cancelWithToast()
 
             if (lockMovement) return cancelWithToast()
 
-            if (isVisibleOverlay) {
-                onDragEndAfterMove(moveGridItemResult)
+            if (isVisibleOverlay.value) {
+                onDragEndAfterMove(currentMoveGridItemResult)
 
                 onUpdateIsDragging(false)
             }
         }
 
         is GridItemSource.New -> {
-            if (isVisibleOverlay && isDragging && isMoveGridItemResultFailed) return cancelWithToast()
+            if (isVisibleOverlay.value && isDragging && isMoveGridItemResultFailed) return cancelWithToast()
 
             if (lockMovement) return cancelWithToast()
 
-            if (isVisibleOverlay && isDragging) {
-                val movingGridItem = moveGridItemResult.movingGridItem
+            if (isVisibleOverlay.value && isDragging) {
+                val movingGridItem = currentMoveGridItemResult.movingGridItem
 
                 when (val data = movingGridItem.data) {
                     is GridItemData.Widget -> {
@@ -158,7 +157,7 @@ internal suspend fun handleDropGridItem(
                     is GridItemData.Folder,
                     is GridItemData.ShortcutInfo,
                     -> {
-                        onDragEndAfterMove(moveGridItemResult)
+                        onDragEndAfterMove(currentMoveGridItemResult)
 
                         onUpdateIsDragging(false)
                     }
@@ -167,18 +166,18 @@ internal suspend fun handleDropGridItem(
         }
 
         is GridItemSource.Pin -> {
-            if (isVisibleOverlay && isDragging && isMoveGridItemResultFailed) return cancelWithToast()
+            if (isVisibleOverlay.value && isDragging && isMoveGridItemResultFailed) return cancelWithToast()
 
             if (lockMovement) return cancelWithToast()
 
-            if (isVisibleOverlay && isDragging) {
-                val movingGridItem = moveGridItemResult.movingGridItem
+            if (isVisibleOverlay.value && isDragging) {
+                val movingGridItem = currentMoveGridItemResult.movingGridItem
 
                 when (val data = movingGridItem.data) {
                     is GridItemData.ShortcutInfo -> onDragEndPinShortcut(
                         gridItem = movingGridItem,
-                        moveGridItemResult = moveGridItemResult,
-                        pinItemRequest = gridItemSource.pinItemRequest,
+                        moveGridItemResult = currentMoveGridItemResult,
+                        pinItemRequest = currentGridItemSource.pinItemRequest,
                         onDeleteGridItem = onResetGridAfterDeleteGridItem,
                         onDragEndAfterMove = onDragEndAfterMove,
                         onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
@@ -239,7 +238,7 @@ internal fun handleAppWidgetLauncherResult(
 }
 
 internal fun handleConfigureLauncherResultEffect(
-    moveGridItemResult: MoveGridItemResult?,
+    moveGridItemResult: State<MoveGridItemResult?>,
     resultCode: Int?,
     updatedGridItem: GridItem?,
     onDeleteGridItem: (GridItem) -> Unit,
@@ -248,14 +247,14 @@ internal fun handleConfigureLauncherResultEffect(
 ) {
     if (resultCode == null) return
 
-    requireNotNull(moveGridItemResult)
+    val currentMoveGridItemResult = requireNotNull(moveGridItemResult.value)
 
     requireNotNull(updatedGridItem)
 
     check(updatedGridItem.data is GridItemData.Widget)
 
     if (resultCode == Activity.RESULT_OK) {
-        onDragEndAfterMove(moveGridItemResult.copy(movingGridItem = updatedGridItem))
+        onDragEndAfterMove(currentMoveGridItemResult.copy(movingGridItem = updatedGridItem))
     } else {
         onDeleteGridItem(updatedGridItem)
     }
@@ -270,9 +269,7 @@ internal fun handleDeleteAppWidgetId(
     onResetGridAfterDeleteGridItem: (GridItem) -> Unit,
     onResetAppWidgetId: () -> Unit,
 ) {
-    if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID ||
-        !deleteAppWidgetId
-    ) {
+    if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID || !deleteAppWidgetId) {
         return
     }
 
@@ -290,28 +287,28 @@ internal fun handleDeleteAppWidgetId(
 internal fun handleBoundWidgetEffect(
     activity: Activity?,
     androidAppWidgetHostWrapper: AndroidAppWidgetHostWrapper,
-    gridItemSource: GridItemSource?,
-    moveGridItemResult: MoveGridItemResult?,
+    gridItemSource: State<GridItemSource?>,
+    moveGridItemResult: State<MoveGridItemResult?>,
     updatedWidgetGridItem: GridItem?,
     onDeleteGridItem: (GridItem) -> Unit,
     onDragEndAfterMove: (MoveGridItemResult) -> Unit,
 ) {
     if (updatedWidgetGridItem == null) return
 
-    requireNotNull(gridItemSource)
+    val currentGridItemSource = requireNotNull(gridItemSource.value)
 
-    requireNotNull(moveGridItemResult)
+    val currentMoveGridItemResult = requireNotNull(moveGridItemResult.value)
 
     val data = updatedWidgetGridItem.data as GridItemData.Widget
 
-    when (gridItemSource) {
+    when (currentGridItemSource) {
         is GridItemSource.New -> {
             startAppWidgetConfigureActivityForResult(
                 activity = activity,
                 androidAppWidgetHostWrapper = androidAppWidgetHostWrapper,
                 appWidgetId = data.appWidgetId,
                 configure = data.configure,
-                moveGridItemResult = moveGridItemResult,
+                moveGridItemResult = currentMoveGridItemResult,
                 updatedWidgetGridItem = updatedWidgetGridItem,
                 onDeleteGridItem = onDeleteGridItem,
                 onDragEndAfterMove = onDragEndAfterMove,
@@ -321,8 +318,8 @@ internal fun handleBoundWidgetEffect(
         is GridItemSource.Pin -> {
             bindPinWidget(
                 appWidgetId = data.appWidgetId,
-                moveGridItemResult = moveGridItemResult,
-                pinItemRequest = gridItemSource.pinItemRequest,
+                moveGridItemResult = currentMoveGridItemResult,
+                pinItemRequest = currentGridItemSource.pinItemRequest,
                 updatedWidgetGridItem = updatedWidgetGridItem,
                 onDeleteGridItem = onDeleteGridItem,
                 onDragEndAfterMove = onDragEndAfterMove,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DropGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DropGridItemHelper.kt
@@ -265,7 +265,7 @@ internal fun handleConfigureLauncherResultEffect(
 internal fun handleDeleteAppWidgetId(
     appWidgetId: Int,
     deleteAppWidgetId: Boolean,
-    moveGridItemResult: MoveGridItemResult?,
+    moveGridItemResult: State<MoveGridItemResult?>,
     onResetGridAfterDeleteGridItem: (GridItem) -> Unit,
     onResetAppWidgetId: () -> Unit,
 ) {
@@ -273,9 +273,9 @@ internal fun handleDeleteAppWidgetId(
         return
     }
 
-    requireNotNull(moveGridItemResult)
+    val currentMoveGridItemResult = requireNotNull(moveGridItemResult.value)
 
-    val movingGridItem = moveGridItemResult.movingGridItem
+    val movingGridItem = currentMoveGridItemResult.movingGridItem
 
     check(movingGridItem.data is GridItemData.Widget)
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DropGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DropGridItemHelper.kt
@@ -238,7 +238,7 @@ internal fun handleAppWidgetLauncherResult(
 }
 
 internal fun handleConfigureLauncherResultEffect(
-    moveGridItemResult: State<MoveGridItemResult?>,
+    moveGridItemResult: MoveGridItemResult?,
     resultCode: Int?,
     updatedGridItem: GridItem?,
     onDeleteGridItem: (GridItem) -> Unit,
@@ -247,14 +247,14 @@ internal fun handleConfigureLauncherResultEffect(
 ) {
     if (resultCode == null) return
 
-    val currentMoveGridItemResult = requireNotNull(moveGridItemResult.value)
+    requireNotNull(moveGridItemResult)
 
     requireNotNull(updatedGridItem)
 
     check(updatedGridItem.data is GridItemData.Widget)
 
     if (resultCode == Activity.RESULT_OK) {
-        onDragEndAfterMove(currentMoveGridItemResult.copy(movingGridItem = updatedGridItem))
+        onDragEndAfterMove(moveGridItemResult.copy(movingGridItem = updatedGridItem))
     } else {
         onDeleteGridItem(updatedGridItem)
     }
@@ -265,7 +265,7 @@ internal fun handleConfigureLauncherResultEffect(
 internal fun handleDeleteAppWidgetId(
     appWidgetId: Int,
     deleteAppWidgetId: Boolean,
-    moveGridItemResult: State<MoveGridItemResult?>,
+    moveGridItemResult: MoveGridItemResult?,
     onResetGridAfterDeleteGridItem: (GridItem) -> Unit,
     onResetAppWidgetId: () -> Unit,
 ) {
@@ -273,9 +273,7 @@ internal fun handleDeleteAppWidgetId(
         return
     }
 
-    val currentMoveGridItemResult = requireNotNull(moveGridItemResult.value)
-
-    val movingGridItem = currentMoveGridItemResult.movingGridItem
+    val movingGridItem = requireNotNull(moveGridItemResult?.movingGridItem)
 
     check(movingGridItem.data is GridItemData.Widget)
 
@@ -287,28 +285,28 @@ internal fun handleDeleteAppWidgetId(
 internal fun handleBoundWidgetEffect(
     activity: Activity?,
     androidAppWidgetHostWrapper: AndroidAppWidgetHostWrapper,
-    gridItemSource: State<GridItemSource?>,
-    moveGridItemResult: State<MoveGridItemResult?>,
+    gridItemSource: GridItemSource?,
+    moveGridItemResult: MoveGridItemResult?,
     updatedWidgetGridItem: GridItem?,
     onDeleteGridItem: (GridItem) -> Unit,
     onDragEndAfterMove: (MoveGridItemResult) -> Unit,
 ) {
     if (updatedWidgetGridItem == null) return
 
-    val currentGridItemSource = requireNotNull(gridItemSource.value)
+    requireNotNull(gridItemSource)
 
-    val currentMoveGridItemResult = requireNotNull(moveGridItemResult.value)
+    requireNotNull(moveGridItemResult)
 
     val data = updatedWidgetGridItem.data as GridItemData.Widget
 
-    when (currentGridItemSource) {
+    when (gridItemSource) {
         is GridItemSource.New -> {
             startAppWidgetConfigureActivityForResult(
                 activity = activity,
                 androidAppWidgetHostWrapper = androidAppWidgetHostWrapper,
                 appWidgetId = data.appWidgetId,
                 configure = data.configure,
-                moveGridItemResult = currentMoveGridItemResult,
+                moveGridItemResult = moveGridItemResult,
                 updatedWidgetGridItem = updatedWidgetGridItem,
                 onDeleteGridItem = onDeleteGridItem,
                 onDragEndAfterMove = onDragEndAfterMove,
@@ -318,8 +316,8 @@ internal fun handleBoundWidgetEffect(
         is GridItemSource.Pin -> {
             bindPinWidget(
                 appWidgetId = data.appWidgetId,
-                moveGridItemResult = currentMoveGridItemResult,
-                pinItemRequest = currentGridItemSource.pinItemRequest,
+                moveGridItemResult = moveGridItemResult,
+                pinItemRequest = gridItemSource.pinItemRequest,
                 updatedWidgetGridItem = updatedWidgetGridItem,
                 onDeleteGridItem = onDeleteGridItem,
                 onDragEndAfterMove = onDragEndAfterMove,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -398,18 +399,19 @@ private fun SharedTransitionScope.InteractiveApplicationInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentIsDragging by rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
+
     LaunchedEffect(
-        drag,
-        hasInteraction,
-        isDragging,
-        isCloseGridItemPopup,
+        key1 = drag,
+        key2 = hasInteraction,
     ) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
             scale = scale,
-            isDragging = isDragging,
-            isCloseGridItemPopup = isCloseGridItemPopup,
+            isDragging = currentIsDragging,
+            isCloseGridItemPopup = currentIsCloseGridItemPopup,
             onUpdateIsDragging = onUpdateIsDragging,
             onUpdateIsCloseGridItemPopup = onUpdateIsCloseGridItemPopup,
         )
@@ -618,18 +620,19 @@ private fun SharedTransitionScope.InteractiveWidgetGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentIsDragging by rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
+
     LaunchedEffect(
-        drag,
-        hasInteraction,
-        isDragging,
-        isCloseGridItemPopup,
+        key1 = drag,
+        key2 = hasInteraction,
     ) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
             scale = scale,
-            isDragging = isDragging,
-            isCloseGridItemPopup = isCloseGridItemPopup,
+            isDragging = currentIsDragging,
+            isCloseGridItemPopup = currentIsCloseGridItemPopup,
             onUpdateIsDragging = onUpdateIsDragging,
             onUpdateIsCloseGridItemPopup = onUpdateIsCloseGridItemPopup,
         )
@@ -814,18 +817,19 @@ private fun SharedTransitionScope.InteractiveShortcutInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentIsDragging by rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
+
     LaunchedEffect(
-        drag,
-        hasInteraction,
-        isDragging,
-        isCloseGridItemPopup,
+        key1 = drag,
+        key2 = hasInteraction,
     ) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
             scale = scale,
-            isDragging = isDragging,
-            isCloseGridItemPopup = isCloseGridItemPopup,
+            isDragging = currentIsDragging,
+            isCloseGridItemPopup = currentIsCloseGridItemPopup,
             onUpdateIsDragging = onUpdateIsDragging,
             onUpdateIsCloseGridItemPopup = onUpdateIsCloseGridItemPopup,
         )
@@ -1052,41 +1056,38 @@ private fun SharedTransitionScope.InteractiveFolderGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentDrag by rememberUpdatedState(drag)
+    val currentIsDragging by rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
+    val currentIsVisibleOverlay by rememberUpdatedState(isVisibleOverlay)
+    val currentGridItem by rememberUpdatedState(gridItem)
+    val currentLockMovement by rememberUpdatedState(lockMovement)
+
     LaunchedEffect(
-        drag,
-        hasInteraction,
-        isDragging,
-        isCloseGridItemPopup,
+        key1 = drag,
+        key2 = hasInteraction,
     ) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
             scale = scale,
-            isDragging = isDragging,
-            isCloseGridItemPopup = isCloseGridItemPopup,
+            isDragging = currentIsDragging,
+            isCloseGridItemPopup = currentIsCloseGridItemPopup,
             onUpdateIsDragging = onUpdateIsDragging,
             onUpdateIsCloseGridItemPopup = onUpdateIsCloseGridItemPopup,
         )
     }
 
-    LaunchedEffect(
-        drag,
-        isDragging,
-        isVisibleOverlay,
-        moveGridItemResult,
-        intOffset,
-        intSize,
-        gridItem,
-    ) {
+    LaunchedEffect(key1 = moveGridItemResult) {
         handleConflictingGridItem(
-            drag = drag,
-            isDragging = isDragging,
-            isVisibleOverlay = isVisibleOverlay,
+            drag = currentDrag,
+            isDragging = currentIsDragging,
+            isVisibleOverlay = currentIsVisibleOverlay,
             moveGridItemResult = moveGridItemResult,
-            lockMovement = lockMovement,
+            lockMovement = currentLockMovement,
             intOffset = intOffset,
             intSize = intSize,
-            gridItem = gridItem,
+            gridItem = currentGridItem,
             onShowFolderWhenDragging = onShowFolderWhenDragging,
             onUpdateSharedElementKey = onUpdateSharedElementKey,
         )
@@ -1354,18 +1355,19 @@ private fun SharedTransitionScope.InteractiveShortcutConfigGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentIsDragging by rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
+
     LaunchedEffect(
-        drag,
-        hasInteraction,
-        isDragging,
-        isCloseGridItemPopup,
+        key1 = drag,
+        key2 = hasInteraction,
     ) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
             scale = scale,
-            isDragging = isDragging,
-            isCloseGridItemPopup = isCloseGridItemPopup,
+            isDragging = currentIsDragging,
+            isCloseGridItemPopup = currentIsCloseGridItemPopup,
             onUpdateIsDragging = onUpdateIsDragging,
             onUpdateIsCloseGridItemPopup = onUpdateIsCloseGridItemPopup,
         )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -399,13 +399,10 @@ private fun SharedTransitionScope.InteractiveApplicationInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
-    val currentIsDragging by rememberUpdatedState(isDragging)
-    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup = rememberUpdatedState(isCloseGridItemPopup)
 
-    LaunchedEffect(
-        key1 = drag,
-        key2 = hasInteraction,
-    ) {
+    LaunchedEffect(key1 = drag) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
@@ -620,13 +617,10 @@ private fun SharedTransitionScope.InteractiveWidgetGridItem(
 
     val scale = remember { Animatable(1f) }
 
-    val currentIsDragging by rememberUpdatedState(isDragging)
-    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup = rememberUpdatedState(isCloseGridItemPopup)
 
-    LaunchedEffect(
-        key1 = drag,
-        key2 = hasInteraction,
-    ) {
+    LaunchedEffect(key1 = drag) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
@@ -817,13 +811,10 @@ private fun SharedTransitionScope.InteractiveShortcutInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
-    val currentIsDragging by rememberUpdatedState(isDragging)
-    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup = rememberUpdatedState(isCloseGridItemPopup)
 
-    LaunchedEffect(
-        key1 = drag,
-        key2 = hasInteraction,
-    ) {
+    LaunchedEffect(key1 = drag) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
@@ -1056,17 +1047,14 @@ private fun SharedTransitionScope.InteractiveFolderGridItem(
 
     val scale = remember { Animatable(1f) }
 
-    val currentDrag by rememberUpdatedState(drag)
-    val currentIsDragging by rememberUpdatedState(isDragging)
-    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
-    val currentIsVisibleOverlay by rememberUpdatedState(isVisibleOverlay)
-    val currentGridItem by rememberUpdatedState(gridItem)
-    val currentLockMovement by rememberUpdatedState(lockMovement)
+    val currentDrag = rememberUpdatedState(drag)
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup = rememberUpdatedState(isCloseGridItemPopup)
+    val currentIsVisibleOverlay = rememberUpdatedState(isVisibleOverlay)
+    val currentGridItem = rememberUpdatedState(gridItem)
+    val currentLockMovement = rememberUpdatedState(lockMovement)
 
-    LaunchedEffect(
-        key1 = drag,
-        key2 = hasInteraction,
-    ) {
+    LaunchedEffect(key1 = drag) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,
@@ -1355,13 +1343,10 @@ private fun SharedTransitionScope.InteractiveShortcutConfigGridItem(
 
     val scale = remember { Animatable(1f) }
 
-    val currentIsDragging by rememberUpdatedState(isDragging)
-    val currentIsCloseGridItemPopup by rememberUpdatedState(isCloseGridItemPopup)
+    val currentIsDragging = rememberUpdatedState(isDragging)
+    val currentIsCloseGridItemPopup = rememberUpdatedState(isCloseGridItemPopup)
 
-    LaunchedEffect(
-        key1 = drag,
-        key2 = hasInteraction,
-    ) {
+    LaunchedEffect(key1 = drag) {
         handleDrag(
             drag = drag,
             hasInteraction = hasInteraction,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -453,7 +453,7 @@ internal fun PagerScreen(
 
     LaunchedEffect(key1 = pagerScreenState.deleteAppWidgetId) {
         pagerScreenState.handleDeleteAppWidgetIdEffect(
-            moveGridItemResult = currentMoveGridItemResult,
+            moveGridItemResult = moveGridItemResult,
             onResetGridAfterDeleteGridItem = onResetGridAfterDeleteGridItem,
         )
     }
@@ -462,8 +462,8 @@ internal fun PagerScreen(
         handleBoundWidgetEffect(
             activity = activity,
             androidAppWidgetHostWrapper = androidAppWidgetHostWrapper,
-            gridItemSource = currentGridItemSource,
-            moveGridItemResult = currentMoveGridItemResult,
+            gridItemSource = gridItemSource,
+            moveGridItemResult = moveGridItemResult,
             updatedWidgetGridItem = pagerScreenState.updatedWidgetGridItem,
             onDeleteGridItem = onResetGridAfterDeleteGridItem,
             onDragEndAfterMove = onDragEndAfterMove,
@@ -492,7 +492,7 @@ internal fun PagerScreen(
 
     LaunchedEffect(key1 = configureResultCode) {
         handleConfigureLauncherResultEffect(
-            moveGridItemResult = currentMoveGridItemResult,
+            moveGridItemResult = moveGridItemResult,
             resultCode = configureResultCode,
             updatedGridItem = pagerScreenState.updatedWidgetGridItem,
             onDeleteGridItem = onDeleteGridItem,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -453,7 +453,7 @@ internal fun PagerScreen(
 
     LaunchedEffect(key1 = pagerScreenState.deleteAppWidgetId) {
         pagerScreenState.handleDeleteAppWidgetIdEffect(
-            moveGridItemResult = moveGridItemResult,
+            moveGridItemResult = currentMoveGridItemResult,
             onResetGridAfterDeleteGridItem = onResetGridAfterDeleteGridItem,
         )
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -394,13 +394,10 @@ internal fun PagerScreen(
 
     val lastPopupFolderGridItem = folderPopups.lastOrNull()
 
-    val currentGridItems by rememberUpdatedState(gridItems)
-
-    val currentGridItemSource by rememberUpdatedState(gridItemSource)
-
-    val currentIsVisibleOverlay by rememberUpdatedState(isVisibleOverlay)
-
-    val currentMoveGridItemResult by rememberUpdatedState(moveGridItemResult)
+    val currentGridItems = rememberUpdatedState(gridItems)
+    val currentGridItemSource = rememberUpdatedState(gridItemSource)
+    val currentIsVisibleOverlay = rememberUpdatedState(isVisibleOverlay)
+    val currentMoveGridItemResult = rememberUpdatedState(moveGridItemResult)
 
     LaunchedEffect(key1 = pinGridItem) {
         pagerScreenState.handlePinGridItemEffect(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draganddrop.mimeTypes
@@ -393,6 +394,14 @@ internal fun PagerScreen(
 
     val lastPopupFolderGridItem = folderPopups.lastOrNull()
 
+    val currentGridItems by rememberUpdatedState(gridItems)
+
+    val currentGridItemSource by rememberUpdatedState(gridItemSource)
+
+    val currentIsVisibleOverlay by rememberUpdatedState(isVisibleOverlay)
+
+    val currentMoveGridItemResult by rememberUpdatedState(moveGridItemResult)
+
     LaunchedEffect(key1 = pinGridItem) {
         pagerScreenState.handlePinGridItemEffect(
             pinGridItem = pinGridItem,
@@ -411,16 +420,9 @@ internal fun PagerScreen(
         onStopSyncData = onStopSyncData,
     )
 
-    LaunchedEffect(
-        gridItems,
-        pagerScreenState.dragIntOffset,
-        gridItemSource,
-        isVisibleOverlay,
-        pagerScreenState.isDragging,
-        moveGridItemResult,
-    ) {
+    LaunchedEffect(key1 = pagerScreenState.dragIntOffset) {
         pagerScreenState.handleDragGridItemEffect(
-            gridItems = gridItems,
+            gridItems = currentGridItems,
             gridCurrentPage = gridCurrentPage,
             dockGridCurrentPage = dockGridCurrentPage,
             density = density,
@@ -429,27 +431,22 @@ internal fun PagerScreen(
             isDockScrollInProgress = dockGridHorizontalPagerState.isScrollInProgress,
             lockMovement = lockMovement,
             paddingValues = paddingValues,
-            gridItemSource = gridItemSource,
-            isVisibleOverlay = isVisibleOverlay,
-            moveGridItemResult = moveGridItemResult,
+            gridItemSource = currentGridItemSource,
+            isVisibleOverlay = currentIsVisibleOverlay,
+            moveGridItemResult = currentMoveGridItemResult,
             layoutDirection = layoutDirection,
             onMoveGridItem = onMoveGridItem,
         )
     }
 
-    LaunchedEffect(
-        pagerScreenState.drag,
-        isVisibleOverlay,
-        gridItemSource,
-        moveGridItemResult,
-    ) {
+    LaunchedEffect(key1 = pagerScreenState.drag) {
         pagerScreenState.handleDropGridItemEffect(
-            moveGridItemResult = moveGridItemResult,
+            moveGridItemResult = currentMoveGridItemResult,
             onLaunchShortcutConfigIntent = shortcutConfigLauncher::launch,
             onLaunchShortcutConfigIntentSenderRequest = shortcutConfigIntentSenderLauncher::launch,
             onLaunchWidgetIntent = appWidgetLauncher::launch,
-            gridItemSource = gridItemSource,
-            isVisibleOverlay = isVisibleOverlay,
+            gridItemSource = currentGridItemSource,
+            isVisibleOverlay = currentIsVisibleOverlay,
             onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
             onResetGridAfterDeleteGridItem = onResetGridAfterDeleteGridItem,
             onDragCancelAfterMove = onDragCancelAfterMove,
@@ -468,8 +465,8 @@ internal fun PagerScreen(
         handleBoundWidgetEffect(
             activity = activity,
             androidAppWidgetHostWrapper = androidAppWidgetHostWrapper,
-            gridItemSource = gridItemSource,
-            moveGridItemResult = moveGridItemResult,
+            gridItemSource = currentGridItemSource,
+            moveGridItemResult = currentMoveGridItemResult,
             updatedWidgetGridItem = pagerScreenState.updatedWidgetGridItem,
             onDeleteGridItem = onResetGridAfterDeleteGridItem,
             onDragEndAfterMove = onDragEndAfterMove,
@@ -487,22 +484,18 @@ internal fun PagerScreen(
         )
     }
 
-    LaunchedEffect(
-        pagerScreenState.dragIntOffset,
-        gridItemSource,
-        pagerScreenState.isDragging,
-    ) {
+    LaunchedEffect(key1 = pagerScreenState.dragIntOffset) {
         pagerScreenState.handleAnimateScrollToPageEffect(
             density = density,
             paddingValues = paddingValues,
-            gridItemSource = gridItemSource,
+            gridItemSource = currentGridItemSource,
             layoutDirection = layoutDirection,
         )
     }
 
     LaunchedEffect(key1 = configureResultCode) {
         handleConfigureLauncherResultEffect(
-            moveGridItemResult = moveGridItemResult,
+            moveGridItemResult = currentMoveGridItemResult,
             resultCode = configureResultCode,
             updatedGridItem = pagerScreenState.updatedWidgetGridItem,
             onDeleteGridItem = onDeleteGridItem,
@@ -514,14 +507,16 @@ internal fun PagerScreen(
     LaunchedEffect(key1 = pagerScreenState.gridPageDirection) {
         handlePageDirection(
             pageDirection = pagerScreenState.gridPageDirection,
-            pagerState = gridHorizontalPagerState,
+            currentPage = gridHorizontalPagerState.currentPage,
+            onAnimateScrollToPage = gridHorizontalPagerState::animateScrollToPage,
         )
     }
 
     LaunchedEffect(key1 = pagerScreenState.dockPageDirection) {
         handlePageDirection(
             pageDirection = pagerScreenState.dockPageDirection,
-            pagerState = dockGridHorizontalPagerState,
+            currentPage = dockGridHorizontalPagerState.currentPage,
+            onAnimateScrollToPage = dockGridHorizontalPagerState::animateScrollToPage,
         )
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
@@ -458,7 +458,7 @@ internal class PagerScreenState(
     }
 
     fun handleDeleteAppWidgetIdEffect(
-        moveGridItemResult: MoveGridItemResult?,
+        moveGridItemResult: State<MoveGridItemResult?>,
         onResetGridAfterDeleteGridItem: (GridItem) -> Unit,
     ) {
         handleDeleteAppWidgetId(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
@@ -458,7 +458,7 @@ internal class PagerScreenState(
     }
 
     fun handleDeleteAppWidgetIdEffect(
-        moveGridItemResult: State<MoveGridItemResult?>,
+        moveGridItemResult: MoveGridItemResult?,
         onResetGridAfterDeleteGridItem: (GridItem) -> Unit,
     ) {
         handleDeleteAppWidgetId(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -356,7 +357,7 @@ internal class PagerScreenState(
     }
 
     suspend fun handleDragGridItemEffect(
-        gridItems: List<GridItem>,
+        gridItems: State<List<GridItem>>,
         gridCurrentPage: Int,
         dockGridCurrentPage: Int,
         density: Density,
@@ -365,9 +366,9 @@ internal class PagerScreenState(
         isDockScrollInProgress: Boolean,
         lockMovement: Boolean,
         paddingValues: PaddingValues,
-        gridItemSource: GridItemSource?,
-        isVisibleOverlay: Boolean,
-        moveGridItemResult: MoveGridItemResult?,
+        gridItemSource: State<GridItemSource?>,
+        isVisibleOverlay: State<Boolean>,
+        moveGridItemResult: State<MoveGridItemResult?>,
         layoutDirection: LayoutDirection,
         onMoveGridItem: (
             gridItems: List<GridItem>,
@@ -414,12 +415,12 @@ internal class PagerScreenState(
     }
 
     suspend fun handleDropGridItemEffect(
-        moveGridItemResult: MoveGridItemResult?,
+        moveGridItemResult: State<MoveGridItemResult?>,
         onLaunchShortcutConfigIntent: (Intent) -> Unit,
         onLaunchShortcutConfigIntentSenderRequest: (IntentSenderRequest) -> Unit,
         onLaunchWidgetIntent: (Intent) -> Unit,
-        gridItemSource: GridItemSource?,
-        isVisibleOverlay: Boolean,
+        gridItemSource: State<GridItemSource?>,
+        isVisibleOverlay: State<Boolean>,
         onUpdateIsVisibleOverlay: (Boolean) -> Unit,
         onResetGridAfterDeleteGridItem: (GridItem) -> Unit,
         onDragCancelAfterMove: () -> Unit,
@@ -476,7 +477,7 @@ internal class PagerScreenState(
     fun handleAnimateScrollToPageEffect(
         density: Density,
         paddingValues: PaddingValues,
-        gridItemSource: GridItemSource?,
+        gridItemSource: State<GridItemSource?>,
         layoutDirection: LayoutDirection,
     ) {
         handleAnimateScrollToPage(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/util/HomeUtil.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/util/HomeUtil.kt
@@ -24,6 +24,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.gestures.PressGestureScope
 import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.State
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.domain.model.EblanAction
 import com.eblan.launcher.domain.model.EblanActionType
@@ -132,16 +133,16 @@ internal suspend fun PressGestureScope.onPress(
 internal suspend fun handleDrag(
     drag: Drag,
     hasInteraction: Boolean,
-    isDragging: Boolean,
-    isCloseGridItemPopup: Boolean,
+    isDragging: State<Boolean>,
+    isCloseGridItemPopup: State<Boolean>,
     scale: Animatable<Float, AnimationVector1D>,
     onUpdateIsDragging: (Boolean) -> Unit,
     onUpdateIsCloseGridItemPopup: (Boolean) -> Unit,
 ) {
     if (drag == Drag.Dragging &&
         hasInteraction &&
-        !isDragging &&
-        !isCloseGridItemPopup
+        !isDragging.value &&
+        !isCloseGridItemPopup.value
     ) {
         onUpdateIsDragging(true)
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/util/HomeUtil.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/util/HomeUtil.kt
@@ -153,18 +153,22 @@ internal suspend fun handleDrag(
     }
 }
 
-internal suspend fun handlePageDirection(pageDirection: PageDirection?, pagerState: PagerState) {
+internal suspend fun handlePageDirection(
+    pageDirection: PageDirection?,
+    currentPage: Int,
+    onAnimateScrollToPage: suspend (Int) -> Unit,
+) {
     if (pageDirection == null) return
 
     delay(500L.milliseconds)
 
     when (pageDirection) {
         PageDirection.Left -> {
-            pagerState.animateScrollToPage(page = pagerState.currentPage - 1)
+            onAnimateScrollToPage(currentPage - 1)
         }
 
         PageDirection.Right -> {
-            pagerState.animateScrollToPage(page = pagerState.currentPage + 1)
+            onAnimateScrollToPage(currentPage + 1)
         }
     }
 }


### PR DESCRIPTION
- Replace direct state usage inside LaunchedEffect with rememberUpdatedState snapshots
- Reduce LaunchedEffect key dependencies to prevent unnecessary re-triggers
- Introduce handleFolderPopup to isolate folder close logic
- Refactor handlePageDirection to use currentPage + callback instead of PagerState
- Simplify drag-related effects across grid and pager components
- Improve consistency of state handling in InteractiveGridItem variants
- Reduce recomposition noise and improve effect stability during drag operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved drag-and-drop, folder, and page-scrolling behavior for smoother interactions, fewer stale-state glitches, and more consistent animations.
  * Rewired state handling so long-running UI effects consume up-to-date values, improving responsiveness during drags and scrolls.
  * Adjusted folder persistence so folder creation and item updates are handled more explicitly for consistent folder contents.
* **Bug Fixes**
  * Fixed cases where long-running interactions used outdated state, reducing missed moves, incorrect placements, and animation jitter.
  * Added targeted refresh of folder contents after conflicting moves to keep the UI in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->