### PR TITLE
Add isVisibleOverlay property to GridItem and related entities

### DIFF
--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/ApplicationInfoGridItemMapper.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/ApplicationInfoGridItemMapper.kt
@@ -44,6 +44,7 @@ internal fun ApplicationInfoGridItemEntity.asModel(): ApplicationInfoGridItem = 
     swipeDown = swipeDown,
     index = index,
     folderId = folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun ApplicationInfoGridItem.asEntity(): ApplicationInfoGridItemEntity = ApplicationInfoGridItemEntity(
@@ -68,6 +69,7 @@ internal fun ApplicationInfoGridItem.asEntity(): ApplicationInfoGridItemEntity =
     swipeDown = swipeDown,
     index = index,
     folderId = folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun GridItem.asApplicationInfoGridItem(data: GridItemData.ApplicationInfo): ApplicationInfoGridItem = ApplicationInfoGridItem(
@@ -92,4 +94,5 @@ internal fun GridItem.asApplicationInfoGridItem(data: GridItemData.ApplicationIn
     swipeDown = swipeDown,
     index = data.index,
     folderId = data.folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/FolderGridItemMapper.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/FolderGridItemMapper.kt
@@ -57,6 +57,7 @@ internal fun FolderGridItemEntity.asModel(): FolderGridItem = FolderGridItem(
     swipeDown = swipeDown,
     index = index,
     folderId = folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun FolderGridItem.asEntity(): FolderGridItemEntity = FolderGridItemEntity(
@@ -76,6 +77,7 @@ internal fun FolderGridItem.asEntity(): FolderGridItemEntity = FolderGridItemEnt
     swipeDown = swipeDown,
     index = index,
     folderId = folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun GridItem.asFolderGridItem(data: GridItemData.Folder): FolderGridItem = FolderGridItem(
@@ -95,4 +97,5 @@ internal fun GridItem.asFolderGridItem(data: GridItemData.Folder): FolderGridIte
     swipeDown = swipeDown,
     index = data.index,
     folderId = data.folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/ShortcutConfigGridItemMapper.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/ShortcutConfigGridItemMapper.kt
@@ -49,6 +49,7 @@ internal fun ShortcutConfigGridItemEntity.asModel(): ShortcutConfigGridItem = Sh
     swipeDown = swipeDown,
     index = index,
     folderId = folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun ShortcutConfigGridItem.asEntity(): ShortcutConfigGridItemEntity = ShortcutConfigGridItemEntity(
@@ -78,6 +79,7 @@ internal fun ShortcutConfigGridItem.asEntity(): ShortcutConfigGridItemEntity = S
     swipeDown = swipeDown,
     index = index,
     folderId = folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun GridItem.asShortcutConfigGridItem(data: GridItemData.ShortcutConfig): ShortcutConfigGridItem = ShortcutConfigGridItem(
@@ -107,4 +109,5 @@ internal fun GridItem.asShortcutConfigGridItem(data: GridItemData.ShortcutConfig
     swipeDown = swipeDown,
     index = data.index,
     folderId = data.folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/ShortcutInfoGridItemMapper.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/ShortcutInfoGridItemMapper.kt
@@ -47,6 +47,7 @@ internal fun ShortcutInfoGridItemEntity.asModel(): ShortcutInfoGridItem = Shortc
     swipeDown = swipeDown,
     index = index,
     folderId = folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun ShortcutInfoGridItem.asEntity(): ShortcutInfoGridItemEntity = ShortcutInfoGridItemEntity(
@@ -74,6 +75,7 @@ internal fun ShortcutInfoGridItem.asEntity(): ShortcutInfoGridItemEntity = Short
     swipeDown = swipeDown,
     index = index,
     folderId = folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun GridItem.asShortcutInfoGridItem(data: GridItemData.ShortcutInfo): ShortcutInfoGridItem = ShortcutInfoGridItem(
@@ -101,4 +103,5 @@ internal fun GridItem.asShortcutInfoGridItem(data: GridItemData.ShortcutInfo): S
     swipeDown = swipeDown,
     index = data.index,
     folderId = data.folderId,
+    isVisibleOverlay = isVisibleOverlay,
 )

--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/WidgetGridItemMapper.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/WidgetGridItemMapper.kt
@@ -49,6 +49,7 @@ internal fun WidgetGridItemEntity.asModel(): WidgetGridItem = WidgetGridItem(
     override = override,
     serialNumber = serialNumber,
     gridItemSettings = gridItemSettings,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun WidgetGridItem.asEntity(): WidgetGridItemEntity = WidgetGridItemEntity(
@@ -78,6 +79,7 @@ internal fun WidgetGridItem.asEntity(): WidgetGridItemEntity = WidgetGridItemEnt
     override = override,
     serialNumber = serialNumber,
     gridItemSettings = gridItemSettings,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun GridItem.asWidgetGridItem(data: GridItemData.Widget): WidgetGridItem = WidgetGridItem(
@@ -107,4 +109,5 @@ internal fun GridItem.asWidgetGridItem(data: GridItemData.Widget): WidgetGridIte
     override = override,
     serialNumber = data.serialNumber,
     gridItemSettings = gridItemSettings,
+    isVisibleOverlay = isVisibleOverlay,
 )

--- a/data/room/schemas/com.eblan.launcher.data.room.EblanDatabase/18.json
+++ b/data/room/schemas/com.eblan.launcher.data.room.EblanDatabase/18.json
@@ -1,0 +1,1697 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "83873dafc05fcbd7c13332c936659b27",
+    "entities": [
+      {
+        "tableName": "EblanApplicationInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`componentName` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `icon` TEXT, `label` TEXT NOT NULL, `customIcon` TEXT, `customLabel` TEXT, `isHidden` INTEGER NOT NULL DEFAULT 0, `lastUpdateTime` INTEGER NOT NULL DEFAULT 0, `index` INTEGER NOT NULL DEFAULT -1, `flags` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`componentName`, `serialNumber`))",
+        "fields": [
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customIcon",
+            "columnName": "customIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customLabel",
+            "columnName": "customLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isHidden",
+            "columnName": "isHidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "componentName",
+            "serialNumber"
+          ]
+        }
+      },
+      {
+        "tableName": "EblanAppWidgetProviderInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`componentName` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `configure` TEXT, `packageName` TEXT NOT NULL, `targetCellWidth` INTEGER NOT NULL, `targetCellHeight` INTEGER NOT NULL, `minWidth` INTEGER NOT NULL, `minHeight` INTEGER NOT NULL, `resizeMode` INTEGER NOT NULL, `minResizeWidth` INTEGER NOT NULL, `minResizeHeight` INTEGER NOT NULL, `maxResizeWidth` INTEGER NOT NULL, `maxResizeHeight` INTEGER NOT NULL, `preview` TEXT, `applicationLabel` TEXT NOT NULL, `applicationIcon` TEXT, `lastUpdateTime` INTEGER NOT NULL DEFAULT 0, `label` TEXT, `description` TEXT, PRIMARY KEY(`componentName`))",
+        "fields": [
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configure",
+            "columnName": "configure",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCellWidth",
+            "columnName": "targetCellWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCellHeight",
+            "columnName": "targetCellHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minWidth",
+            "columnName": "minWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minHeight",
+            "columnName": "minHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resizeMode",
+            "columnName": "resizeMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minResizeWidth",
+            "columnName": "minResizeWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minResizeHeight",
+            "columnName": "minResizeHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxResizeWidth",
+            "columnName": "maxResizeWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxResizeHeight",
+            "columnName": "maxResizeHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preview",
+            "columnName": "preview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationLabel",
+            "columnName": "applicationLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "applicationIcon",
+            "columnName": "applicationIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "componentName"
+          ]
+        }
+      },
+      {
+        "tableName": "EblanShortcutInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`shortcutId` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `shortLabel` TEXT NOT NULL, `longLabel` TEXT NOT NULL, `icon` TEXT, `shortcutQueryFlag` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `lastChangedTimestamp` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`shortcutId`, `serialNumber`, `packageName`))",
+        "fields": [
+          {
+            "fieldPath": "shortcutId",
+            "columnName": "shortcutId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortLabel",
+            "columnName": "shortLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longLabel",
+            "columnName": "longLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortcutQueryFlag",
+            "columnName": "shortcutQueryFlag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChangedTimestamp",
+            "columnName": "lastChangedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "shortcutId",
+            "serialNumber",
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "ApplicationInfoGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `componentName` TEXT NOT NULL, `packageName` TEXT NOT NULL, `icon` TEXT, `label` TEXT NOT NULL, `override` INTEGER NOT NULL, `serialNumber` INTEGER NOT NULL, `customIcon` TEXT, `customLabel` TEXT, `index` INTEGER NOT NULL, `folderId` TEXT, `isVisibleOverlay` INTEGER NOT NULL, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, `doubleTap_eblanActionType` TEXT NOT NULL, `doubleTap_serialNumber` INTEGER NOT NULL, `doubleTap_componentName` TEXT NOT NULL, `swipeUp_eblanActionType` TEXT NOT NULL, `swipeUp_serialNumber` INTEGER NOT NULL, `swipeUp_componentName` TEXT NOT NULL, `swipeDown_eblanActionType` TEXT NOT NULL, `swipeDown_serialNumber` INTEGER NOT NULL, `swipeDown_componentName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customIcon",
+            "columnName": "customIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customLabel",
+            "columnName": "customLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isVisibleOverlay",
+            "columnName": "isVisibleOverlay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.eblanActionType",
+            "columnName": "doubleTap_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.serialNumber",
+            "columnName": "doubleTap_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.componentName",
+            "columnName": "doubleTap_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.eblanActionType",
+            "columnName": "swipeUp_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.serialNumber",
+            "columnName": "swipeUp_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.componentName",
+            "columnName": "swipeUp_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.eblanActionType",
+            "columnName": "swipeDown_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.serialNumber",
+            "columnName": "swipeDown_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.componentName",
+            "columnName": "swipeDown_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ApplicationInfoGridItemEntity_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ApplicationInfoGridItemEntity_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "WidgetGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `appWidgetId` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `componentName` TEXT NOT NULL, `configure` TEXT, `minWidth` INTEGER NOT NULL, `minHeight` INTEGER NOT NULL, `resizeMode` INTEGER NOT NULL, `minResizeWidth` INTEGER NOT NULL, `minResizeHeight` INTEGER NOT NULL, `maxResizeWidth` INTEGER NOT NULL, `maxResizeHeight` INTEGER NOT NULL, `targetCellHeight` INTEGER NOT NULL, `targetCellWidth` INTEGER NOT NULL, `preview` TEXT, `label` TEXT NOT NULL, `icon` TEXT, `override` INTEGER NOT NULL, `serialNumber` INTEGER NOT NULL, `isVisibleOverlay` INTEGER NOT NULL, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appWidgetId",
+            "columnName": "appWidgetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configure",
+            "columnName": "configure",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "minWidth",
+            "columnName": "minWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minHeight",
+            "columnName": "minHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resizeMode",
+            "columnName": "resizeMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minResizeWidth",
+            "columnName": "minResizeWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minResizeHeight",
+            "columnName": "minResizeHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxResizeWidth",
+            "columnName": "maxResizeWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxResizeHeight",
+            "columnName": "maxResizeHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCellHeight",
+            "columnName": "targetCellHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetCellWidth",
+            "columnName": "targetCellWidth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preview",
+            "columnName": "preview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isVisibleOverlay",
+            "columnName": "isVisibleOverlay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ShortcutInfoGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `shortcutId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `shortLabel` TEXT NOT NULL, `longLabel` TEXT NOT NULL, `icon` TEXT, `override` INTEGER NOT NULL, `serialNumber` INTEGER NOT NULL, `isEnabled` INTEGER NOT NULL, `eblanApplicationInfoIcon` TEXT, `customIcon` TEXT, `customShortLabel` TEXT, `index` INTEGER NOT NULL, `folderId` TEXT, `isVisibleOverlay` INTEGER NOT NULL, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, `doubleTap_eblanActionType` TEXT NOT NULL, `doubleTap_serialNumber` INTEGER NOT NULL, `doubleTap_componentName` TEXT NOT NULL, `swipeUp_eblanActionType` TEXT NOT NULL, `swipeUp_serialNumber` INTEGER NOT NULL, `swipeUp_componentName` TEXT NOT NULL, `swipeDown_eblanActionType` TEXT NOT NULL, `swipeDown_serialNumber` INTEGER NOT NULL, `swipeDown_componentName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortcutId",
+            "columnName": "shortcutId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortLabel",
+            "columnName": "shortLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longLabel",
+            "columnName": "longLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eblanApplicationInfoIcon",
+            "columnName": "eblanApplicationInfoIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customIcon",
+            "columnName": "customIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customShortLabel",
+            "columnName": "customShortLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isVisibleOverlay",
+            "columnName": "isVisibleOverlay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.eblanActionType",
+            "columnName": "doubleTap_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.serialNumber",
+            "columnName": "doubleTap_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.componentName",
+            "columnName": "doubleTap_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.eblanActionType",
+            "columnName": "swipeUp_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.serialNumber",
+            "columnName": "swipeUp_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.componentName",
+            "columnName": "swipeUp_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.eblanActionType",
+            "columnName": "swipeDown_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.serialNumber",
+            "columnName": "swipeDown_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.componentName",
+            "columnName": "swipeDown_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ShortcutInfoGridItemEntity_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ShortcutInfoGridItemEntity_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "FolderGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `label` TEXT NOT NULL, `override` INTEGER NOT NULL, `icon` TEXT, `index` INTEGER NOT NULL, `folderId` TEXT, `isVisibleOverlay` INTEGER NOT NULL, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, `doubleTap_eblanActionType` TEXT NOT NULL, `doubleTap_serialNumber` INTEGER NOT NULL, `doubleTap_componentName` TEXT NOT NULL, `swipeUp_eblanActionType` TEXT NOT NULL, `swipeUp_serialNumber` INTEGER NOT NULL, `swipeUp_componentName` TEXT NOT NULL, `swipeDown_eblanActionType` TEXT NOT NULL, `swipeDown_serialNumber` INTEGER NOT NULL, `swipeDown_componentName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isVisibleOverlay",
+            "columnName": "isVisibleOverlay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.eblanActionType",
+            "columnName": "doubleTap_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.serialNumber",
+            "columnName": "doubleTap_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.componentName",
+            "columnName": "doubleTap_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.eblanActionType",
+            "columnName": "swipeUp_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.serialNumber",
+            "columnName": "swipeUp_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.componentName",
+            "columnName": "swipeUp_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.eblanActionType",
+            "columnName": "swipeDown_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.serialNumber",
+            "columnName": "swipeDown_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.componentName",
+            "columnName": "swipeDown_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_FolderGridItemEntity_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_FolderGridItemEntity_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "EblanIconPackInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `icon` TEXT, `label` TEXT, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "EblanShortcutConfigEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`componentName` TEXT NOT NULL, `packageName` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `activityIcon` TEXT, `activityLabel` TEXT, `applicationIcon` TEXT, `applicationLabel` TEXT, PRIMARY KEY(`componentName`, `serialNumber`))",
+        "fields": [
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityIcon",
+            "columnName": "activityIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activityLabel",
+            "columnName": "activityLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationIcon",
+            "columnName": "applicationIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationLabel",
+            "columnName": "applicationLabel",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "componentName",
+            "serialNumber"
+          ]
+        }
+      },
+      {
+        "tableName": "ShortcutConfigGridItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page` INTEGER NOT NULL, `startColumn` INTEGER NOT NULL, `startRow` INTEGER NOT NULL, `columnSpan` INTEGER NOT NULL, `rowSpan` INTEGER NOT NULL, `associate` TEXT NOT NULL, `componentName` TEXT NOT NULL, `packageName` TEXT NOT NULL, `activityIcon` TEXT, `activityLabel` TEXT, `applicationIcon` TEXT, `applicationLabel` TEXT, `override` INTEGER NOT NULL, `serialNumber` INTEGER NOT NULL, `shortcutIntentName` TEXT, `shortcutIntentIcon` TEXT, `shortcutIntentUri` TEXT, `customIcon` TEXT, `customLabel` TEXT, `index` INTEGER NOT NULL, `folderId` TEXT, `isVisibleOverlay` INTEGER NOT NULL, `iconSize` INTEGER NOT NULL, `textColor` TEXT NOT NULL, `textSize` INTEGER NOT NULL, `showLabel` INTEGER NOT NULL, `singleLineLabel` INTEGER NOT NULL, `horizontalAlignment` TEXT NOT NULL, `verticalArrangement` TEXT NOT NULL, `customTextColor` INTEGER NOT NULL, `customBackgroundColor` INTEGER NOT NULL, `padding` INTEGER NOT NULL, `cornerRadius` INTEGER NOT NULL, `doubleTap_eblanActionType` TEXT NOT NULL, `doubleTap_serialNumber` INTEGER NOT NULL, `doubleTap_componentName` TEXT NOT NULL, `swipeUp_eblanActionType` TEXT NOT NULL, `swipeUp_serialNumber` INTEGER NOT NULL, `swipeUp_componentName` TEXT NOT NULL, `swipeDown_eblanActionType` TEXT NOT NULL, `swipeDown_serialNumber` INTEGER NOT NULL, `swipeDown_componentName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startColumn",
+            "columnName": "startColumn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startRow",
+            "columnName": "startRow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "columnSpan",
+            "columnName": "columnSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowSpan",
+            "columnName": "rowSpan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associate",
+            "columnName": "associate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityIcon",
+            "columnName": "activityIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activityLabel",
+            "columnName": "activityLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationIcon",
+            "columnName": "applicationIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "applicationLabel",
+            "columnName": "applicationLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "override",
+            "columnName": "override",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortcutIntentName",
+            "columnName": "shortcutIntentName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortcutIntentIcon",
+            "columnName": "shortcutIntentIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortcutIntentUri",
+            "columnName": "shortcutIntentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customIcon",
+            "columnName": "customIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customLabel",
+            "columnName": "customLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isVisibleOverlay",
+            "columnName": "isVisibleOverlay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.iconSize",
+            "columnName": "iconSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textColor",
+            "columnName": "textColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.textSize",
+            "columnName": "textSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.showLabel",
+            "columnName": "showLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.singleLineLabel",
+            "columnName": "singleLineLabel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.horizontalAlignment",
+            "columnName": "horizontalAlignment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.verticalArrangement",
+            "columnName": "verticalArrangement",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customTextColor",
+            "columnName": "customTextColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.customBackgroundColor",
+            "columnName": "customBackgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.padding",
+            "columnName": "padding",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridItemSettings.cornerRadius",
+            "columnName": "cornerRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.eblanActionType",
+            "columnName": "doubleTap_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.serialNumber",
+            "columnName": "doubleTap_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "doubleTap.componentName",
+            "columnName": "doubleTap_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.eblanActionType",
+            "columnName": "swipeUp_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.serialNumber",
+            "columnName": "swipeUp_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeUp.componentName",
+            "columnName": "swipeUp_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.eblanActionType",
+            "columnName": "swipeDown_eblanActionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.serialNumber",
+            "columnName": "swipeDown_serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swipeDown.componentName",
+            "columnName": "swipeDown_componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ShortcutConfigGridItemEntity_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ShortcutConfigGridItemEntity_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "EblanApplicationInfoTagCrossRefEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`componentName` TEXT NOT NULL, `serialNumber` INTEGER NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`componentName`, `serialNumber`, `id`), FOREIGN KEY(`componentName`, `serialNumber`) REFERENCES `EblanApplicationInfoEntity`(`componentName`, `serialNumber`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`id`) REFERENCES `EblanApplicationInfoTagEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "componentName",
+            "columnName": "componentName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serialNumber",
+            "columnName": "serialNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "componentName",
+            "serialNumber",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_EblanApplicationInfoTagCrossRefEntity_id",
+            "unique": false,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_EblanApplicationInfoTagCrossRefEntity_id` ON `${TABLE_NAME}` (`id`)"
+          },
+          {
+            "name": "index_EblanApplicationInfoTagCrossRefEntity_componentName_serialNumber",
+            "unique": false,
+            "columnNames": [
+              "componentName",
+              "serialNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_EblanApplicationInfoTagCrossRefEntity_componentName_serialNumber` ON `${TABLE_NAME}` (`componentName`, `serialNumber`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "EblanApplicationInfoEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "componentName",
+              "serialNumber"
+            ],
+            "referencedColumns": [
+              "componentName",
+              "serialNumber"
+            ]
+          },
+          {
+            "table": "EblanApplicationInfoTagEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "EblanApplicationInfoTagEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '83873dafc05fcbd7c13332c936659b27')"
+    ]
+  }
+}

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/EblanDatabase.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/EblanDatabase.kt
@@ -63,7 +63,7 @@ import com.eblan.launcher.data.room.migration.AutoMigration9To10
         EblanApplicationInfoTagCrossRefEntity::class,
         EblanApplicationInfoTagEntity::class,
     ],
-    version = 17,
+    version = 18,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/ApplicationInfoGridItemEntity.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/ApplicationInfoGridItemEntity.kt
@@ -53,4 +53,5 @@ data class ApplicationInfoGridItemEntity(
     @Embedded(prefix = "swipeDown_") val swipeDown: EblanAction,
     val index: Int,
     val folderId: String?,
+    val isVisibleOverlay: Boolean,
 )

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/FolderGridItemEntity.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/FolderGridItemEntity.kt
@@ -48,4 +48,5 @@ data class FolderGridItemEntity(
     @Embedded(prefix = "swipeDown_") val swipeDown: EblanAction,
     val index: Int,
     val folderId: String?,
+    val isVisibleOverlay: Boolean,
 )

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/ShortcutConfigGridItemEntity.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/ShortcutConfigGridItemEntity.kt
@@ -58,4 +58,5 @@ data class ShortcutConfigGridItemEntity(
     @Embedded(prefix = "swipeDown_") val swipeDown: EblanAction,
     val index: Int,
     val folderId: String?,
+    val isVisibleOverlay: Boolean,
 )

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/ShortcutInfoGridItemEntity.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/ShortcutInfoGridItemEntity.kt
@@ -56,4 +56,5 @@ data class ShortcutInfoGridItemEntity(
     @Embedded(prefix = "swipeDown_") val swipeDown: EblanAction,
     val index: Int,
     val folderId: String?,
+    val isVisibleOverlay: Boolean,
 )

--- a/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/WidgetGridItemEntity.kt
+++ b/data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/WidgetGridItemEntity.kt
@@ -52,4 +52,5 @@ data class WidgetGridItemEntity(
     val override: Boolean,
     val serialNumber: Long,
     @Embedded val gridItemSettings: GridItemSettings,
+    val isVisibleOverlay: Boolean,
 )

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ApplicationInfoGridItem.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ApplicationInfoGridItem.kt
@@ -39,4 +39,5 @@ data class ApplicationInfoGridItem(
     val swipeDown: EblanAction,
     val index: Int,
     val folderId: String?,
+    val isVisibleOverlay: Boolean,
 )

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/FolderGridItem.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/FolderGridItem.kt
@@ -34,4 +34,5 @@ data class FolderGridItem(
     val swipeDown: EblanAction,
     val index: Int,
     val folderId: String?,
+    val isVisibleOverlay: Boolean,
 )

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/GridItem.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/GridItem.kt
@@ -31,6 +31,7 @@ data class GridItem(
     val doubleTap: EblanAction,
     val swipeUp: EblanAction,
     val swipeDown: EblanAction,
+    val isVisibleOverlay: Boolean,
 )
 
 enum class Associate {

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ShortcutConfigGridItem.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ShortcutConfigGridItem.kt
@@ -44,4 +44,5 @@ data class ShortcutConfigGridItem(
     val swipeDown: EblanAction,
     val index: Int,
     val folderId: String?,
+    val isVisibleOverlay: Boolean,
 )

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ShortcutInfoGridItem.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ShortcutInfoGridItem.kt
@@ -42,4 +42,5 @@ data class ShortcutInfoGridItem(
     val swipeDown: EblanAction,
     val index: Int,
     val folderId: String?,
+    val isVisibleOverlay: Boolean,
 )

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/WidgetGridItem.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/WidgetGridItem.kt
@@ -44,4 +44,5 @@ data class WidgetGridItem(
     val icon: String?,
     val override: Boolean,
     val gridItemSettings: GridItemSettings,
+    val isVisibleOverlay: Boolean,
 )

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
@@ -85,6 +85,7 @@ internal suspend fun ApplicationInfoGridItem.asGridItem(
         doubleTap = doubleTap,
         swipeUp = swipeUp,
         swipeDown = swipeDown,
+        isVisibleOverlay = isVisibleOverlay,
     )
 }
 
@@ -132,6 +133,7 @@ internal fun WidgetGridItem.asGridItem(): GridItem = GridItem(
         serialNumber = 0L,
         componentName = "",
     ),
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun ShortcutInfoGridItem.asGridItem(): GridItem = GridItem(
@@ -161,6 +163,7 @@ internal fun ShortcutInfoGridItem.asGridItem(): GridItem = GridItem(
     doubleTap = doubleTap,
     swipeUp = swipeUp,
     swipeDown = swipeDown,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal fun ShortcutConfigGridItem.asGridItem(): GridItem = GridItem(
@@ -192,6 +195,7 @@ internal fun ShortcutConfigGridItem.asGridItem(): GridItem = GridItem(
     doubleTap = doubleTap,
     swipeUp = swipeUp,
     swipeDown = swipeDown,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 /**
@@ -222,6 +226,7 @@ internal fun FolderGridItem.asIconGridItem(): GridItem = GridItem(
     doubleTap = doubleTap,
     swipeUp = swipeUp,
     swipeDown = swipeDown,
+    isVisibleOverlay = isVisibleOverlay,
 )
 
 internal suspend fun FolderGridItemWrapper.asGridItem(
@@ -316,6 +321,7 @@ internal suspend fun FolderGridItemWrapper.asGridItem(
         doubleTap = folderGridItem.doubleTap,
         swipeUp = folderGridItem.swipeUp,
         swipeDown = folderGridItem.swipeDown,
+        isVisibleOverlay = folderGridItem.isVisibleOverlay,
     )
 }
 
@@ -409,6 +415,7 @@ private suspend fun FolderGridItemWrapper.asPreviewGridItem(
         doubleTap = folderGridItem.doubleTap,
         swipeUp = folderGridItem.swipeUp,
         swipeDown = folderGridItem.swipeDown,
+        isVisibleOverlay = folderGridItem.isVisibleOverlay,
     )
 }
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
@@ -85,6 +85,8 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
                         )
                     }
                 }
+            } else {
+                gridRepository.updateGridItem(gridItem = movingGridItem.copy(isVisibleOverlay = false))
             }
         }
     }
@@ -130,7 +132,12 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
             else -> error("Unsupported addMovingGridItemIntoFolder")
         }
 
-        gridRepository.updateGridItem(gridItem = movingGridItem.copy(data = newData))
+        gridRepository.updateGridItem(
+            gridItem = movingGridItem.copy(
+                data = newData,
+                isVisibleOverlay = false,
+            ),
+        )
     }
 
     @OptIn(ExperimentalUuidApi::class)
@@ -207,7 +214,10 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
         gridRepository.upsertGridItems(
             gridItems = listOf(
                 conflictingGridItem.copy(data = conflictingData),
-                movingGridItem.copy(data = movingData),
+                movingGridItem.copy(
+                    data = movingData,
+                    isVisibleOverlay = false,
+                ),
                 conflictingGridItem.copy(
                     id = id,
                     data = GridItemData.Folder(

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
@@ -48,8 +48,6 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
 
             val movingGridItem = moveGridItemResult.movingGridItem
 
-            gridRepository.updateGridItem(gridItem = movingGridItem)
-
             if (conflictingGridItem != null) {
                 when (conflictingGridItem.data) {
                     is GridItemData.Folder -> {

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/LauncherAppsUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/LauncherAppsUtil.kt
@@ -586,6 +586,7 @@ internal suspend fun addNewApplicationToHomeScreen(
         doubleTap = eblanAction,
         swipeUp = eblanAction,
         swipeDown = eblanAction,
+        isVisibleOverlay = false,
     )
 
     val newGridItem = findAvailableRegionByPage(
@@ -622,6 +623,7 @@ internal suspend fun addNewApplicationToHomeScreen(
                 swipeDown = newGridItem.swipeDown,
                 index = data.index,
                 folderId = data.folderId,
+                isVisibleOverlay = newGridItem.isVisibleOverlay,
             ),
         )
     }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
@@ -525,6 +525,7 @@ class SyncDataUseCase @Inject constructor(
                     swipeDown = eblanAction,
                     index = -1,
                     folderId = null,
+                    isVisibleOverlay = false,
                 ),
             )
         }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinShortcutToHomeScreenUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinShortcutToHomeScreenUseCase.kt
@@ -117,6 +117,7 @@ class AddPinShortcutToHomeScreenUseCase @Inject constructor(
             doubleTap = eblanAction,
             swipeUp = eblanAction,
             swipeDown = eblanAction,
+            isVisibleOverlay = false,
         )
 
         val gridItems = getGridItemsUseCase()

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinWidgetToHomeScreenUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinWidgetToHomeScreenUseCase.kt
@@ -163,6 +163,7 @@ class AddPinWidgetToHomeScreenUseCase @Inject constructor(
             doubleTap = eblanAction,
             swipeUp = eblanAction,
             swipeDown = eblanAction,
+            isVisibleOverlay = false,
         )
 
         val gridItems = getGridItemsUseCase().filter {

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/GetPinGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/GetPinGridItemUseCase.kt
@@ -117,6 +117,7 @@ class GetPinGridItemUseCase @Inject constructor(
                         serialNumber = 0L,
                         componentName = "",
                     ),
+                    isVisibleOverlay = false,
                 )
             }
 
@@ -178,6 +179,7 @@ class GetPinGridItemUseCase @Inject constructor(
                         serialNumber = 0L,
                         componentName = "",
                     ),
+                    isVisibleOverlay = false,
                 )
             }
         }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -168,6 +168,7 @@ internal fun HomeRoute(
         onUpdateMoveGridItemResult = viewModel::updateMoveGridItemResult,
         onUpdateResizeGridItem = viewModel::updateResizeGridItem,
         onResetGridAfterMoveGridItem = viewModel::resetGridAfterMoveGridItem,
+        onUpdateGridItem = viewModel::updateGridItem,
     )
 }
 
@@ -267,6 +268,7 @@ internal fun HomeScreen(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateResizeGridItem: (GridItem) -> Unit,
     onResetGridAfterMoveGridItem: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val paddingValues = WindowInsets.safeDrawing.asPaddingValues()
 
@@ -336,6 +338,7 @@ internal fun HomeScreen(
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                 onUpdateResizeGridItem = onUpdateResizeGridItem,
                 onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
+                onUpdateGridItem = onUpdateGridItem,
             )
         }
     }
@@ -440,6 +443,7 @@ private fun Success(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateResizeGridItem: (GridItem) -> Unit,
     onResetGridAfterMoveGridItem: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val activity = LocalActivity.current
 
@@ -518,6 +522,7 @@ private fun Success(
                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                     onUpdateResizeGridItem = onUpdateResizeGridItem,
                     onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
+                    onUpdateGridItem = onUpdateGridItem,
                 )
             }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -147,8 +147,8 @@ internal fun HomeRoute(
         onMoveFolderGridItemOutsideFolder = viewModel::moveFolderGridItemOutsideFolder,
         onMoveGridItem = viewModel::moveGridItem,
         onResetConfigureResultCode = onResetConfigureResultCode,
-        onResetGridAfterMove = viewModel::resetGridAfterMove,
-        onResetGridAfterMoveFolder = viewModel::resetGridAfterMoveFolder,
+        onUpdateGridItemsAfterMove = viewModel::updateGridItemsAfterMove,
+        onUpdateGridItemsAfterMoveFolder = viewModel::resetGridAfterMoveFolder,
         onResetGridAfterResize = viewModel::resetGridAfterResize,
         onResetPinGridItem = viewModel::resetPinGridItem,
         onResizeGridItem = viewModel::resizeGridItem,
@@ -167,6 +167,7 @@ internal fun HomeRoute(
         onUpdateIsVisibleOverlay = viewModel::updateIsVisibleOverlay,
         onUpdateMoveGridItemResult = viewModel::updateMoveGridItemResult,
         onUpdateResizeGridItem = viewModel::updateResizeGridItem,
+        onResetGridAfterMoveGridItem = viewModel::resetGridAfterMoveGridItem,
     )
 }
 
@@ -230,8 +231,8 @@ internal fun HomeScreen(
         gridHeight: Int,
     ) -> Unit,
     onResetConfigureResultCode: () -> Unit,
-    onResetGridAfterMove: (MoveGridItemResult) -> Unit,
-    onResetGridAfterMoveFolder: () -> Unit,
+    onUpdateGridItemsAfterMove: (MoveGridItemResult) -> Unit,
+    onUpdateGridItemsAfterMoveFolder: () -> Unit,
     onResetGridAfterResize: () -> Unit,
     onResetPinGridItem: () -> Unit,
     onResizeGridItem: (
@@ -265,6 +266,7 @@ internal fun HomeScreen(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateResizeGridItem: (GridItem) -> Unit,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val paddingValues = WindowInsets.safeDrawing.asPaddingValues()
 
@@ -313,8 +315,8 @@ internal fun HomeScreen(
                 onMoveFolderGridItemOutsideFolder = onMoveFolderGridItemOutsideFolder,
                 onMoveGridItem = onMoveGridItem,
                 onResetConfigureResultCode = onResetConfigureResultCode,
-                onResetGridAfterMove = onResetGridAfterMove,
-                onResetGridAfterMoveFolder = onResetGridAfterMoveFolder,
+                onUpdateGridItemsAfterMove = onUpdateGridItemsAfterMove,
+                onUpdateGridItemsAfterMoveFolder = onUpdateGridItemsAfterMoveFolder,
                 onResetGridAfterResize = onResetGridAfterResize,
                 onResetPinGridItem = onResetPinGridItem,
                 onResizeGridItem = onResizeGridItem,
@@ -333,6 +335,7 @@ internal fun HomeScreen(
                 onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                 onUpdateResizeGridItem = onUpdateResizeGridItem,
+                onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
             )
         }
     }
@@ -401,8 +404,8 @@ private fun Success(
         gridHeight: Int,
     ) -> Unit,
     onResetConfigureResultCode: () -> Unit,
-    onResetGridAfterMove: (MoveGridItemResult) -> Unit,
-    onResetGridAfterMoveFolder: () -> Unit,
+    onUpdateGridItemsAfterMove: (MoveGridItemResult) -> Unit,
+    onUpdateGridItemsAfterMoveFolder: () -> Unit,
     onResetGridAfterResize: () -> Unit,
     onResetPinGridItem: () -> Unit,
     onResizeGridItem: (
@@ -436,6 +439,7 @@ private fun Success(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateResizeGridItem: (GridItem) -> Unit,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val activity = LocalActivity.current
 
@@ -482,8 +486,8 @@ private fun Success(
                     onDeleteGridItem = onDeleteGridItem,
                     onResetGridAfterDeleteGridItem = onResetGridAfterDeleteGridItem,
                     onDragCancelAfterMove = onCancelGrid,
-                    onDragEndAfterMove = onResetGridAfterMove,
-                    onDragEndAfterMoveFolder = onResetGridAfterMoveFolder,
+                    onDragEndAfterMove = onUpdateGridItemsAfterMove,
+                    onDragEndAfterMoveFolder = onUpdateGridItemsAfterMoveFolder,
                     onEditApplicationInfo = onEditApplicationInfo,
                     onEditGridItem = onEditGridItem,
                     onEditPage = onEditPage,
@@ -513,6 +517,7 @@ private fun Success(
                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                     onUpdateResizeGridItem = onUpdateResizeGridItem,
+                    onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
                 )
             }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -685,4 +685,10 @@ internal class HomeViewModel @Inject constructor(
             null
         }
     }
+
+    fun updateGridItem(gridItem: GridItem) {
+        viewModelScope.launch {
+            gridRepository.updateGridItem(gridItem = gridItem)
+        }
+    }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -336,25 +336,11 @@ internal class HomeViewModel @Inject constructor(
         }
     }
 
-    fun resetGridAfterMove(moveGridItemResult: MoveGridItemResult) {
+    fun updateGridItemsAfterMove(moveGridItemResult: MoveGridItemResult) {
         viewModelScope.launch {
             moveGridItemJob?.cancelAndJoin()
 
             updateGridItemsAfterMoveUseCase(moveGridItemResult = moveGridItemResult)
-
-            delay(100L.milliseconds)
-
-            _isVisibleOverlay.update {
-                false
-            }
-
-            _moveGridItemResult.update {
-                null
-            }
-
-            _gridItemSource.update {
-                null
-            }
         }
     }
 
@@ -472,7 +458,7 @@ internal class HomeViewModel @Inject constructor(
 
             gridRepository.insertGridItem(gridItem = movingGridItem.copy(data = data))
 
-            resetGridAfterMove(moveGridItemResult = moveGridItemResult)
+            updateGridItemsAfterMove(moveGridItemResult = moveGridItemResult)
         }
     }
 
@@ -683,6 +669,20 @@ internal class HomeViewModel @Inject constructor(
     fun deleteFolderPopupEntry(folderPopupEntry: FolderPopupEntry) {
         _folderPopupEntries.update {
             it - folderPopupEntry
+        }
+    }
+
+    fun resetGridAfterMoveGridItem() {
+        _isVisibleOverlay.update {
+            false
+        }
+
+        _moveGridItemResult.update {
+            null
+        }
+
+        _gridItemSource.update {
+            null
         }
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
@@ -416,6 +416,7 @@ internal fun handleDragEblanApplicationInfoItem(
                 doubleTap = eblanAction,
                 swipeUp = eblanAction,
                 swipeDown = eblanAction,
+                isVisibleOverlay = false,
             )
 
             onUpdateGridItemSource(GridItemSource.New)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
@@ -84,6 +84,7 @@ internal suspend fun onLongPress(
     ) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     onUpdateGridItemSource(GridItemSource.Existing)
 
@@ -110,6 +111,8 @@ internal suspend fun onLongPress(
     )
 
     onUpdateIsVisibleOverlay(true)
+
+    onUpdateGridItem(gridItem.copy(isVisibleOverlay = true))
 }
 
 internal fun handleAnimateScrollToPage(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -143,6 +143,7 @@ internal fun InteractiveGridItem(
         folderPopupEntry: FolderPopupEntry,
         movingGridItem: GridItem,
     ) -> Unit,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val isSelected =
         moveGridItemResult != null && moveGridItemResult.movingGridItem.id == gridItem.id
@@ -195,6 +196,7 @@ internal fun InteractiveGridItem(
                 onUpdateOverlayBounds = onUpdateOverlayBounds,
                 onUpdateSharedElementKey = onUpdateSharedElementKey,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
             )
         }
 
@@ -220,6 +222,7 @@ internal fun InteractiveGridItem(
                 onUpdateOverlayBounds = onUpdateOverlayBounds,
                 onUpdateSharedElementKey = onUpdateSharedElementKey,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
             )
         }
 
@@ -250,6 +253,7 @@ internal fun InteractiveGridItem(
                 onUpdateOverlayBounds = onUpdateOverlayBounds,
                 onUpdateSharedElementKey = onUpdateSharedElementKey,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
             )
         }
 
@@ -283,6 +287,7 @@ internal fun InteractiveGridItem(
                 onUpdateSharedElementKey = onUpdateSharedElementKey,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                 onShowFolderWhenDragging = onShowFolderWhenDragging,
+                onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
             )
         }
 
@@ -312,6 +317,7 @@ internal fun InteractiveGridItem(
                 onUpdateOverlayBounds = onUpdateOverlayBounds,
                 onUpdateSharedElementKey = onUpdateSharedElementKey,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
             )
         }
     }
@@ -354,6 +360,7 @@ private fun InteractiveApplicationInfoGridItem(
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val launcherApps = LocalLauncherApps.current
 
@@ -405,6 +412,12 @@ private fun InteractiveApplicationInfoGridItem(
             onUpdateIsDragging(true)
 
             onUpdateIsCloseGridItemPopup(true)
+        }
+    }
+
+    LaunchedEffect(key1 = gridItem) {
+        if (gridItem.isVisibleOverlay) {
+            onResetGridAfterMoveGridItem()
         }
     }
 
@@ -587,6 +600,7 @@ private fun InteractiveWidgetGridItem(
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val appWidgetHost = LocalAppWidgetHost.current
 
@@ -621,6 +635,12 @@ private fun InteractiveWidgetGridItem(
             onUpdateIsDragging(true)
 
             onUpdateIsCloseGridItemPopup(true)
+        }
+    }
+
+    LaunchedEffect(key1 = gridItem) {
+        if (gridItem.isVisibleOverlay) {
+            onResetGridAfterMoveGridItem()
         }
     }
 
@@ -767,6 +787,7 @@ private fun InteractiveShortcutInfoGridItem(
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val launcherApps = LocalLauncherApps.current
 
@@ -812,6 +833,12 @@ private fun InteractiveShortcutInfoGridItem(
             onUpdateIsDragging(true)
 
             onUpdateIsCloseGridItemPopup(true)
+        }
+    }
+
+    LaunchedEffect(key1 = gridItem) {
+        if (gridItem.isVisibleOverlay) {
+            onResetGridAfterMoveGridItem()
         }
     }
 
@@ -1007,6 +1034,7 @@ private fun InteractiveFolderGridItem(
         folderPopupEntry: FolderPopupEntry,
         movingGridItem: GridItem,
     ) -> Unit,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val launcherApps = LocalLauncherApps.current
 
@@ -1054,6 +1082,12 @@ private fun InteractiveFolderGridItem(
             onUpdateIsDragging(true)
 
             onUpdateIsCloseGridItemPopup(true)
+        }
+    }
+
+    LaunchedEffect(key1 = gridItem) {
+        if (gridItem.isVisibleOverlay) {
+            onResetGridAfterMoveGridItem()
         }
     }
 
@@ -1269,6 +1303,7 @@ private fun InteractiveShortcutConfigGridItem(
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val launcherApps = LocalLauncherApps.current
 
@@ -1346,6 +1381,12 @@ private fun InteractiveShortcutConfigGridItem(
             onUpdateIsDragging(true)
 
             onUpdateIsCloseGridItemPopup(true)
+        }
+    }
+
+    LaunchedEffect(key1 = gridItem) {
+        if (gridItem.isVisibleOverlay) {
+            onResetGridAfterMoveGridItem()
         }
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -144,6 +144,7 @@ internal fun InteractiveGridItem(
         movingGridItem: GridItem,
     ) -> Unit,
     onResetGridAfterMoveGridItem: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val isSelected =
         moveGridItemResult != null && moveGridItemResult.movingGridItem.id == gridItem.id
@@ -197,6 +198,7 @@ internal fun InteractiveGridItem(
                 onUpdateSharedElementKey = onUpdateSharedElementKey,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                 onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
+                onUpdateGridItem = onUpdateGridItem,
             )
         }
 
@@ -223,6 +225,7 @@ internal fun InteractiveGridItem(
                 onUpdateSharedElementKey = onUpdateSharedElementKey,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                 onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
+                onUpdateGridItem = onUpdateGridItem,
             )
         }
 
@@ -254,6 +257,7 @@ internal fun InteractiveGridItem(
                 onUpdateSharedElementKey = onUpdateSharedElementKey,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                 onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
+                onUpdateGridItem = onUpdateGridItem,
             )
         }
 
@@ -288,6 +292,7 @@ internal fun InteractiveGridItem(
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                 onShowFolderWhenDragging = onShowFolderWhenDragging,
                 onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
+                onUpdateGridItem = onUpdateGridItem,
             )
         }
 
@@ -318,6 +323,7 @@ internal fun InteractiveGridItem(
                 onUpdateSharedElementKey = onUpdateSharedElementKey,
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                 onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
+                onUpdateGridItem = onUpdateGridItem,
             )
         }
     }
@@ -361,6 +367,7 @@ private fun InteractiveApplicationInfoGridItem(
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onResetGridAfterMoveGridItem: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val launcherApps = LocalLauncherApps.current
 
@@ -415,8 +422,13 @@ private fun InteractiveApplicationInfoGridItem(
         }
     }
 
-    LaunchedEffect(key1 = gridItem) {
-        if (gridItem.isVisibleOverlay) {
+    LaunchedEffect(
+        key1 = drag,
+        key2 = gridItem,
+    ) {
+        if ((drag == Drag.Cancel || drag == Drag.End) &&
+            gridItem.isVisibleOverlay
+        ) {
             onResetGridAfterMoveGridItem()
         }
     }
@@ -454,6 +466,7 @@ private fun InteractiveApplicationInfoGridItem(
                                     onShowGridItemPopup = onShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                                    onUpdateGridItem = onUpdateGridItem,
                                 )
                             }
                         }
@@ -601,6 +614,7 @@ private fun InteractiveWidgetGridItem(
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onResetGridAfterMoveGridItem: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val appWidgetHost = LocalAppWidgetHost.current
 
@@ -638,8 +652,13 @@ private fun InteractiveWidgetGridItem(
         }
     }
 
-    LaunchedEffect(key1 = gridItem) {
-        if (gridItem.isVisibleOverlay) {
+    LaunchedEffect(
+        key1 = drag,
+        key2 = gridItem,
+    ) {
+        if ((drag == Drag.Cancel || drag == Drag.End) &&
+            gridItem.isVisibleOverlay
+        ) {
             onResetGridAfterMoveGridItem()
         }
     }
@@ -706,6 +725,7 @@ private fun InteractiveWidgetGridItem(
                                     onShowGridItemPopup = onShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                                    onUpdateGridItem = onUpdateGridItem,
                                 )
                             }
 
@@ -736,6 +756,7 @@ private fun InteractiveWidgetGridItem(
                                         onShowGridItemPopup = onShowGridItemPopup,
                                         onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                         onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                                        onUpdateGridItem = onUpdateGridItem,
                                     )
                                 }
                             }
@@ -788,6 +809,7 @@ private fun InteractiveShortcutInfoGridItem(
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onResetGridAfterMoveGridItem: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val launcherApps = LocalLauncherApps.current
 
@@ -836,8 +858,13 @@ private fun InteractiveShortcutInfoGridItem(
         }
     }
 
-    LaunchedEffect(key1 = gridItem) {
-        if (gridItem.isVisibleOverlay) {
+    LaunchedEffect(
+        key1 = drag,
+        key2 = gridItem,
+    ) {
+        if ((drag == Drag.Cancel || drag == Drag.End) &&
+            gridItem.isVisibleOverlay
+        ) {
             onResetGridAfterMoveGridItem()
         }
     }
@@ -875,6 +902,7 @@ private fun InteractiveShortcutInfoGridItem(
                                     onShowGridItemPopup = onShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                                    onUpdateGridItem = onUpdateGridItem,
                                 )
                             }
                         }
@@ -1035,6 +1063,7 @@ private fun InteractiveFolderGridItem(
         movingGridItem: GridItem,
     ) -> Unit,
     onResetGridAfterMoveGridItem: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val launcherApps = LocalLauncherApps.current
 
@@ -1085,8 +1114,13 @@ private fun InteractiveFolderGridItem(
         }
     }
 
-    LaunchedEffect(key1 = gridItem) {
-        if (gridItem.isVisibleOverlay) {
+    LaunchedEffect(
+        key1 = drag,
+        key2 = gridItem,
+    ) {
+        if ((drag == Drag.Cancel || drag == Drag.End) &&
+            gridItem.isVisibleOverlay
+        ) {
             onResetGridAfterMoveGridItem()
         }
     }
@@ -1139,6 +1173,7 @@ private fun InteractiveFolderGridItem(
                                     onShowGridItemPopup = onShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                                    onUpdateGridItem = onUpdateGridItem,
                                 )
                             }
                         }
@@ -1250,6 +1285,8 @@ private fun InteractiveFolderGridItem(
                             parent = sharedElementKey.parent,
                             moveGridItemResult = moveGridItemResult,
                             textColor = textColor,
+                            drag = drag,
+                            onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
                         )
                     },
                 )
@@ -1304,6 +1341,7 @@ private fun InteractiveShortcutConfigGridItem(
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onResetGridAfterMoveGridItem: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val launcherApps = LocalLauncherApps.current
 
@@ -1384,8 +1422,13 @@ private fun InteractiveShortcutConfigGridItem(
         }
     }
 
-    LaunchedEffect(key1 = gridItem) {
-        if (gridItem.isVisibleOverlay) {
+    LaunchedEffect(
+        key1 = drag,
+        key2 = gridItem,
+    ) {
+        if ((drag == Drag.Cancel || drag == Drag.End) &&
+            gridItem.isVisibleOverlay
+        ) {
             onResetGridAfterMoveGridItem()
         }
     }
@@ -1423,6 +1466,7 @@ private fun InteractiveShortcutConfigGridItem(
                                     onShowGridItemPopup = onShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
+                                    onUpdateGridItem = onUpdateGridItem,
                                 )
                             }
                         }
@@ -1527,6 +1571,8 @@ private fun PreviewFolderGridItem(
     parent: SharedElementKey.Parent,
     moveGridItemResult: MoveGridItemResult?,
     textColor: Color,
+    drag: Drag,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val context = LocalContext.current
 
@@ -1558,6 +1604,17 @@ private fun PreviewFolderGridItem(
                     this
                 }
             }
+
+        LaunchedEffect(
+            key1 = drag,
+            key2 = gridItem,
+        ) {
+            if ((drag == Drag.Cancel || drag == Drag.End) &&
+                gridItem.isVisibleOverlay
+            ) {
+                onResetGridAfterMoveGridItem()
+            }
+        }
 
         when (val data = gridItem.data) {
             is GridItemData.ApplicationInfo -> {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -218,6 +218,7 @@ internal fun PagerScreen(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateResizeGridItem: (GridItem) -> Unit,
     onResetGridAfterMoveGridItem: () -> Unit,
+    onUpdateGridItem: (GridItem) -> Unit,
 ) {
     val context = LocalContext.current
 
@@ -741,6 +742,7 @@ internal fun PagerScreen(
                             onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                             onShowFolderWhenDragging = onShowFolderWhenDragging,
                             onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
+                            onUpdateGridItem = onUpdateGridItem,
                         )
                     },
                 )
@@ -864,6 +866,7 @@ internal fun PagerScreen(
                             onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                             onShowFolderWhenDragging = onShowFolderWhenDragging,
                             onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
+                            onUpdateGridItem = onUpdateGridItem,
                         )
                     },
                 )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -217,6 +217,7 @@ internal fun PagerScreen(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateResizeGridItem: (GridItem) -> Unit,
+    onResetGridAfterMoveGridItem: () -> Unit,
 ) {
     val context = LocalContext.current
 
@@ -739,6 +740,7 @@ internal fun PagerScreen(
                             onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                             onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                             onShowFolderWhenDragging = onShowFolderWhenDragging,
+                            onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
                         )
                     },
                 )
@@ -861,6 +863,7 @@ internal fun PagerScreen(
                             onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                             onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                             onShowFolderWhenDragging = onShowFolderWhenDragging,
+                            onResetGridAfterMoveGridItem = onResetGridAfterMoveGridItem,
                         )
                     },
                 )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
@@ -533,6 +533,7 @@ private fun EblanShortcutConfigItem(
                                 doubleTap = eblanAction,
                                 swipeUp = eblanAction,
                                 swipeDown = eblanAction,
+                                isVisibleOverlay = false,
                             )
 
                             onUpdateGridItemSource(GridItemSource.New)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutinfo/ShortcutInfoScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutinfo/ShortcutInfoScreen.kt
@@ -237,6 +237,7 @@ private fun ShortcutInfoMenuItem(
                                         doubleTap = eblanAction,
                                         swipeUp = eblanAction,
                                         swipeDown = eblanAction,
+                                        isVisibleOverlay = false,
                                     )
 
                                     onUpdateGridItemSource(GridItemSource.New)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreenHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreenHelper.kt
@@ -85,5 +85,6 @@ internal fun getWidgetGridItem(
         doubleTap = eblanAction,
         swipeUp = eblanAction,
         swipeDown = eblanAction,
+        isVisibleOverlay = false,
     )
 }


### PR DESCRIPTION
This commit introduces a new `isVisibleOverlay` boolean property to the `GridItem` model and its corresponding entities across various data layers. This property is intended to manage the visibility of overlay elements associated with grid items.

The `isVisibleOverlay` property is initialized to `false` in several use cases, including `AddPinWidgetToHomeScreenUseCase`, `GetPinGridItemUseCase`, `SyncDataUseCase`, `LauncherAppsUtil`, `WidgetScreenHelper`, `EblanApplicationInfoGridItem`, `ShortcutInfoScreen`, `WidgetGridItem`, `ShortcutConfigGridItem`, `FolderGridItem`, `ApplicationInfoGridItem`, `ShortcutInfoGridItem`, and `ShortcutConfigGridItemMapper`.

The `UpdateGridItemsAfterMoveUseCase` now explicitly sets `isVisibleOverlay` to `false` when updating grid items during move operations, ensuring overlays are hidden after a move. The `PagerScreen` and `InteractiveGridItem` have been updated to handle `onResetGridAfterMoveGridItem` events, which are triggered when `isVisibleOverlay` becomes true, to reset the grid state.

Additionally, the database version has been incremented to 18 to accommodate these schema changes.

Affected files:
- domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ApplicationInfoGridItem.kt
- domain/model/src/main/kotlin/com/eblan/launcher/domain/model/FolderGridItem.kt
- domain/model/src/main/kotlin/com/eblan/launcher/domain/model/GridItem.kt
- domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ShortcutConfigGridItem.kt
- domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ShortcutInfoGridItem.kt
- domain/model/src/main/kotlin/com/eblan/launcher/domain/model/WidgetGridItem.kt
- data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/ApplicationInfoGridItemEntity.kt
- data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/FolderGridItemEntity.kt
- data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/ShortcutConfigGridItemEntity.kt
- data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/ShortcutInfoGridItemEntity.kt
- data/room/src/main/kotlin/com/eblan/launcher/data/room/entity/WidgetGridItemEntity.kt
- data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/ApplicationInfoGridItemMapper.kt
- data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/FolderGridItemMapper.kt
- data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/ShortcutConfigGridItemMapper.kt
- data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/ShortcutInfoGridItemMapper.kt
- data/repository/src/main/kotlin/com/eblan/launcher/data/repository/mapper/WidgetGridItemMapper.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/LauncherAppsUtil.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinShortcutToHomeScreenUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinWidgetToHomeScreenUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/GetPinGridItemUseCase.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutinfo/ShortcutInfoScreen.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreenHelper.kt
- data/room/src/main/kotlin/com/eblan/launcher/data/room/EblanDatabase.kt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistence for overlay visibility across home screen items, widgets, folders, and shortcuts.
  * Improved drag-and-drop flow so moved items and related overlays update more reliably afterward.
* **Bug Fixes**
  * Fixed cases where overlay state could be reset or lost when creating, pinning, or saving items.
  * Improved post-move and drag-cancel/end cleanup so overlays return to the expected visual state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->