### PR TITLE
feat(domain): Introduce DeleteGridItemUseCase and refactor deletion logic

### DIFF
--- a/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
+++ b/data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
@@ -24,7 +24,6 @@ import com.eblan.launcher.data.repository.mapper.asShortcutInfoGridItem
 import com.eblan.launcher.data.repository.mapper.asWidgetGridItem
 import com.eblan.launcher.domain.common.Dispatcher
 import com.eblan.launcher.domain.common.EblanDispatchers
-import com.eblan.launcher.domain.framework.AppWidgetHostWrapper
 import com.eblan.launcher.domain.model.ApplicationInfoGridItem
 import com.eblan.launcher.domain.model.FolderGridItem
 import com.eblan.launcher.domain.model.GridItem
@@ -51,7 +50,6 @@ internal class DefaultGridRepository @Inject constructor(
     private val shortcutInfoGridItemRepository: ShortcutInfoGridItemRepository,
     private val folderGridItemRepository: FolderGridItemRepository,
     private val shortcutConfigGridItemRepository: ShortcutConfigGridItemRepository,
-    private val appWidgetHostWrapper: AppWidgetHostWrapper,
     @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : GridRepository {
     override suspend fun insertGridItem(gridItem: GridItem) {
@@ -288,8 +286,6 @@ internal class DefaultGridRepository @Inject constructor(
                 }
 
                 is GridItemData.Widget -> {
-                    appWidgetHostWrapper.deleteAppWidgetId(appWidgetId = data.appWidgetId)
-
                     widgetGridItems.add(
                         gridItem.asWidgetGridItem(data = data),
                     )
@@ -347,8 +343,6 @@ internal class DefaultGridRepository @Inject constructor(
             }
 
             is GridItemData.Widget -> {
-                appWidgetHostWrapper.deleteAppWidgetId(appWidgetId = data.appWidgetId)
-
                 widgetGridItemRepository.deleteWidgetGridItem(
                     widgetGridItem = gridItem.asWidgetGridItem(data = data),
                 )

--- a/domain/framework/src/main/kotlin/com/eblan/launcher/domain/framework/LauncherAppsWrapper.kt
+++ b/domain/framework/src/main/kotlin/com/eblan/launcher/domain/framework/LauncherAppsWrapper.kt
@@ -24,6 +24,7 @@ import com.eblan.launcher.domain.model.LauncherAppsActivityInfo
 import com.eblan.launcher.domain.model.LauncherAppsEvent
 import com.eblan.launcher.domain.model.LauncherAppsShortcutInfo
 import com.eblan.launcher.domain.model.ShortcutConfigActivityInfo
+import com.eblan.launcher.domain.model.ShortcutQuery
 import kotlinx.coroutines.flow.Flow
 
 interface LauncherAppsWrapper {
@@ -45,7 +46,7 @@ interface LauncherAppsWrapper {
         packageName: String,
     ): List<FastLauncherAppsActivityInfo>
 
-    suspend fun getShortcuts(): List<LauncherAppsShortcutInfo>?
+    suspend fun getShortcuts(shortcutQuery: ShortcutQuery?): List<LauncherAppsShortcutInfo>?
 
     suspend fun getFastShortcuts(): List<FastLauncherAppsShortcutInfo>?
 
@@ -60,4 +61,10 @@ interface LauncherAppsWrapper {
     ): List<ShortcutConfigActivityInfo>
 
     fun getUser(serialNumber: Long): EblanUser
+
+    fun pinShortcuts(
+        packageName: String,
+        shortcutIds: List<String>,
+        serialNumber: Long,
+    )
 }

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ShortcutQuery.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ShortcutQuery.kt
@@ -15,19 +15,9 @@
  *   limitations under the License.
  *
  */
+package com.eblan.launcher.domain.model
 
-plugins {
-    alias(libs.plugins.com.eblan.launcher.library)
-    alias(libs.plugins.com.eblan.launcher.hilt)
-}
-
-android {
-    namespace = "com.eblan.launcher.data.repository"
-}
-
-dependencies {
-    implementation(projects.data.datastore)
-    implementation(projects.data.room)
-    implementation(projects.domain.common)
-    implementation(projects.domain.repository)
-}
+data class ShortcutQuery(
+    val packageName: String,
+    val shortcutQueryFlag: ShortcutQueryFlag,
+)

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/DeleteGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/DeleteGridItemUseCase.kt
@@ -22,7 +22,6 @@ import com.eblan.launcher.domain.common.EblanDispatchers
 import com.eblan.launcher.domain.framework.AppWidgetHostWrapper
 import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.model.GridItem
-import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.repository.GridRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -35,20 +34,11 @@ class DeleteGridItemUseCase @Inject constructor(
     @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(gridItem: GridItem) = withContext(defaultDispatcher) {
-        when (val data = gridItem.data) {
-            is GridItemData.ShortcutInfo -> {
-                updatePinShortcutsByPackageName(
-                    launcherAppsWrapper = launcherAppsWrapper,
-                    data = data,
-                )
-            }
-
-            is GridItemData.Widget -> {
-                appWidgetHostWrapper.deleteAppWidgetId(appWidgetId = data.appWidgetId)
-            }
-
-            else -> Unit
-        }
+        cleanupGridItemRecursively(
+            gridItem = gridItem,
+            appWidgetHostWrapper = appWidgetHostWrapper,
+            launcherAppsWrapper = launcherAppsWrapper,
+        )
 
         gridRepository.deleteGridItem(gridItem = gridItem)
     }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/DeleteGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/DeleteGridItemUseCase.kt
@@ -1,0 +1,55 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.domain.usecase.grid
+
+import com.eblan.launcher.domain.common.Dispatcher
+import com.eblan.launcher.domain.common.EblanDispatchers
+import com.eblan.launcher.domain.framework.AppWidgetHostWrapper
+import com.eblan.launcher.domain.framework.LauncherAppsWrapper
+import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.model.GridItemData
+import com.eblan.launcher.domain.repository.GridRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class DeleteGridItemUseCase @Inject constructor(
+    private val gridRepository: GridRepository,
+    private val appWidgetHostWrapper: AppWidgetHostWrapper,
+    private val launcherAppsWrapper: LauncherAppsWrapper,
+    @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
+) {
+    suspend operator fun invoke(gridItem: GridItem) = withContext(defaultDispatcher) {
+        when (val data = gridItem.data) {
+            is GridItemData.ShortcutInfo -> {
+                updatePinShortcutsByPackageName(
+                    launcherAppsWrapper = launcherAppsWrapper,
+                    data = data,
+                )
+            }
+
+            is GridItemData.Widget -> {
+                appWidgetHostWrapper.deleteAppWidgetId(appWidgetId = data.appWidgetId)
+            }
+
+            else -> Unit
+        }
+
+        gridRepository.deleteGridItem(gridItem = gridItem)
+    }
+}

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
@@ -18,6 +18,7 @@
 package com.eblan.launcher.domain.usecase.grid
 
 import com.eblan.launcher.domain.common.IconKeyGenerator
+import com.eblan.launcher.domain.framework.AppWidgetHostWrapper
 import com.eblan.launcher.domain.framework.FileManager
 import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.model.ApplicationInfoGridItem
@@ -330,7 +331,31 @@ internal fun GridItem.isTopLevel() = when (val itemData = data) {
     is GridItemData.Widget -> true
 }
 
-internal suspend fun updatePinShortcutsByPackageName(
+internal suspend fun cleanupGridItemRecursively(
+    gridItem: GridItem,
+    appWidgetHostWrapper: AppWidgetHostWrapper,
+    launcherAppsWrapper: LauncherAppsWrapper,
+) {
+    when (val data = gridItem.data) {
+        is GridItemData.ShortcutInfo -> {
+            updatePinShortcutsByPackageName(launcherAppsWrapper, data)
+        }
+
+        is GridItemData.Widget -> {
+            appWidgetHostWrapper.deleteAppWidgetId(data.appWidgetId)
+        }
+
+        is GridItemData.Folder -> {
+            data.gridItems.forEach { child ->
+                cleanupGridItemRecursively(child, appWidgetHostWrapper, launcherAppsWrapper)
+            }
+        }
+
+        else -> Unit
+    }
+}
+
+private suspend fun updatePinShortcutsByPackageName(
     launcherAppsWrapper: LauncherAppsWrapper,
     data: GridItemData.ShortcutInfo,
 ) {

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
@@ -19,6 +19,7 @@ package com.eblan.launcher.domain.usecase.grid
 
 import com.eblan.launcher.domain.common.IconKeyGenerator
 import com.eblan.launcher.domain.framework.FileManager
+import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.model.ApplicationInfoGridItem
 import com.eblan.launcher.domain.model.EblanAction
 import com.eblan.launcher.domain.model.EblanActionType
@@ -28,6 +29,8 @@ import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.ShortcutConfigGridItem
 import com.eblan.launcher.domain.model.ShortcutInfoGridItem
+import com.eblan.launcher.domain.model.ShortcutQuery
+import com.eblan.launcher.domain.model.ShortcutQueryFlag
 import com.eblan.launcher.domain.model.WidgetGridItem
 import com.eblan.launcher.domain.repository.FolderGridItemRepository
 import kotlinx.coroutines.currentCoroutineContext
@@ -325,6 +328,29 @@ internal fun GridItem.isTopLevel() = when (val itemData = data) {
     is GridItemData.ShortcutConfig -> itemData.folderId == null
     is GridItemData.ShortcutInfo -> itemData.folderId == null
     is GridItemData.Widget -> true
+}
+
+internal suspend fun updatePinShortcutsByPackageName(
+    launcherAppsWrapper: LauncherAppsWrapper,
+    data: GridItemData.ShortcutInfo,
+) {
+    if (!launcherAppsWrapper.hasShortcutHostPermission) return
+
+    val shortcutIds = launcherAppsWrapper.getShortcuts(
+        shortcutQuery = ShortcutQuery(
+            packageName = data.packageName,
+            shortcutQueryFlag = ShortcutQueryFlag.Pinned,
+        ),
+    )
+        ?.map { it.shortcutId } ?: return
+
+    if (data.shortcutId !in shortcutIds) return
+
+    launcherAppsWrapper.pinShortcuts(
+        packageName = data.packageName,
+        shortcutIds = shortcutIds - data.shortcutId,
+        serialNumber = data.serialNumber,
+    )
 }
 
 private suspend fun FolderGridItemWrapper.asPreviewGridItem(

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
@@ -379,7 +379,7 @@ class SyncDataUseCase @Inject constructor(
 
         if (oldFastLauncherAppsShortcutInfos.toSet() == newFastLauncherAppsShortcutInfos?.toSet()) return
 
-        val launcherAppsShortcutInfos = launcherAppsWrapper.getShortcuts() ?: return
+        val launcherAppsShortcutInfos = launcherAppsWrapper.getShortcuts(shortcutQuery = null) ?: return
 
         val oldEblanShortcutInfos = eblanShortcutInfoRepository.getEblanShortcutInfos()
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/UpdatePageItemsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/UpdatePageItemsUseCase.kt
@@ -22,11 +22,10 @@ import com.eblan.launcher.domain.common.EblanDispatchers
 import com.eblan.launcher.domain.framework.AppWidgetHostWrapper
 import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.model.Associate
-import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.PageItem
 import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
-import com.eblan.launcher.domain.usecase.grid.updatePinShortcutsByPackageName
+import com.eblan.launcher.domain.usecase.grid.cleanupGridItemRecursively
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -50,20 +49,11 @@ class UpdatePageItemsUseCase @Inject constructor(
 
             pageItemsToDelete.forEach {
                 it.gridItems.forEach { gridItem ->
-                    when (val data = gridItem.data) {
-                        is GridItemData.ShortcutInfo -> {
-                            updatePinShortcutsByPackageName(
-                                launcherAppsWrapper = launcherAppsWrapper,
-                                data = data,
-                            )
-                        }
-
-                        is GridItemData.Widget -> {
-                            appWidgetHostWrapper.deleteAppWidgetId(appWidgetId = data.appWidgetId)
-                        }
-
-                        else -> Unit
-                    }
+                    cleanupGridItemRecursively(
+                        gridItem = gridItem,
+                        appWidgetHostWrapper = appWidgetHostWrapper,
+                        launcherAppsWrapper = launcherAppsWrapper,
+                    )
                 }
 
                 gridRepository.deleteGridItemsRecursively(gridItems = it.gridItems)

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/UpdatePageItemsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/UpdatePageItemsUseCase.kt
@@ -19,10 +19,14 @@ package com.eblan.launcher.domain.usecase.page
 
 import com.eblan.launcher.domain.common.Dispatcher
 import com.eblan.launcher.domain.common.EblanDispatchers
+import com.eblan.launcher.domain.framework.AppWidgetHostWrapper
+import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.model.Associate
+import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.PageItem
 import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
+import com.eblan.launcher.domain.usecase.grid.updatePinShortcutsByPackageName
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -31,6 +35,8 @@ import javax.inject.Inject
 class UpdatePageItemsUseCase @Inject constructor(
     private val userDataRepository: UserDataRepository,
     private val gridRepository: GridRepository,
+    private val appWidgetHostWrapper: AppWidgetHostWrapper,
+    private val launcherAppsWrapper: LauncherAppsWrapper,
     @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(
@@ -43,6 +49,23 @@ class UpdatePageItemsUseCase @Inject constructor(
             val homeSettings = userDataRepository.userDataFlow.first().homeSettings
 
             pageItemsToDelete.forEach {
+                it.gridItems.forEach { gridItem ->
+                    when (val data = gridItem.data) {
+                        is GridItemData.ShortcutInfo -> {
+                            updatePinShortcutsByPackageName(
+                                launcherAppsWrapper = launcherAppsWrapper,
+                                data = data,
+                            )
+                        }
+
+                        is GridItemData.Widget -> {
+                            appWidgetHostWrapper.deleteAppWidgetId(appWidgetId = data.appWidgetId)
+                        }
+
+                        else -> Unit
+                    }
+                }
+
                 gridRepository.deleteGridItemsRecursively(gridItems = it.gridItems)
             }
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinShortcutToHomeScreenUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinShortcutToHomeScreenUseCase.kt
@@ -37,6 +37,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class AddPinShortcutToHomeScreenUseCase @Inject constructor(
     private val userDataRepository: UserDataRepository,
@@ -47,9 +49,10 @@ class AddPinShortcutToHomeScreenUseCase @Inject constructor(
     private val getGridItemsUseCase: GetGridItemsUseCase,
     @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) {
+    @OptIn(ExperimentalUuidApi::class)
     suspend operator fun invoke(
         serialNumber: Long,
-        id: String,
+        shortcutId: String,
         packageName: String,
         shortLabel: String,
         longLabel: String,
@@ -83,7 +86,7 @@ class AddPinShortcutToHomeScreenUseCase @Inject constructor(
                 }
 
         val data = GridItemData.ShortcutInfo(
-            shortcutId = id,
+            shortcutId = shortcutId,
             packageName = packageName,
             serialNumber = serialNumber,
             shortLabel = shortLabel,
@@ -104,7 +107,7 @@ class AddPinShortcutToHomeScreenUseCase @Inject constructor(
         )
 
         val gridItem = GridItem(
-            id = id,
+            id = Uuid.random().toHexString(),
             page = initialPage,
             startColumn = 0,
             startRow = 0,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -46,6 +46,7 @@ import com.eblan.launcher.domain.usecase.application.GetEblanApplicationInfosByL
 import com.eblan.launcher.domain.usecase.application.GetEblanShortcutConfigsByLabelUseCase
 import com.eblan.launcher.domain.usecase.application.GetEblanShortcutInfosUseCase
 import com.eblan.launcher.domain.usecase.application.UpdateEblanApplicationInfosIndexesUseCase
+import com.eblan.launcher.domain.usecase.grid.DeleteGridItemUseCase
 import com.eblan.launcher.domain.usecase.grid.GetFolderGridItemsByIdUseCase
 import com.eblan.launcher.domain.usecase.grid.MoveFolderGridItemUseCase
 import com.eblan.launcher.domain.usecase.grid.MoveGridItemUseCase
@@ -106,6 +107,7 @@ internal class HomeViewModel @Inject constructor(
     getFolderGridItemsByIdUseCase: GetFolderGridItemsByIdUseCase,
     private val moveFolderGridItemUseCase: MoveFolderGridItemUseCase,
     private val iconKeyGenerator: IconKeyGenerator,
+    private val deleteGridItemUseCase: DeleteGridItemUseCase,
 ) : ViewModel() {
     val homeUiState = getHomeDataUseCase().map(HomeUiState::Success).stateIn(
         scope = viewModelScope,
@@ -398,7 +400,7 @@ internal class HomeViewModel @Inject constructor(
 
     fun deleteGridItem(gridItem: GridItem) {
         viewModelScope.launch {
-            gridRepository.deleteGridItem(gridItem = gridItem)
+            deleteGridItemUseCase(gridItem = gridItem)
         }
     }
 

--- a/feature/pin/src/main/kotlin/com/eblan/launcher/feature/pin/PinScreen.kt
+++ b/feature/pin/src/main/kotlin/com/eblan/launcher/feature/pin/PinScreen.kt
@@ -140,7 +140,7 @@ private fun PinShortcutScreen(
     pinItemRequest: PinItemRequest,
     onAddPinShortcutToHomeScreen: (
         serialNumber: Long,
-        id: String,
+        shortcutId: String,
         packageName: String,
         shortLabel: String,
         longLabel: String,

--- a/feature/pin/src/main/kotlin/com/eblan/launcher/feature/pin/PinScreenViewModel.kt
+++ b/feature/pin/src/main/kotlin/com/eblan/launcher/feature/pin/PinScreenViewModel.kt
@@ -52,7 +52,7 @@ class PinScreenViewModel @Inject constructor(
 
     fun addPinShortcutToHomeScreen(
         serialNumber: Long,
-        id: String,
+        shortcutId: String,
         packageName: String,
         shortLabel: String,
         longLabel: String,
@@ -63,7 +63,7 @@ class PinScreenViewModel @Inject constructor(
             _gridItem.update {
                 addPinShortcutToHomeScreenUseCase(
                     serialNumber = serialNumber,
-                    id = id,
+                    shortcutId = shortcutId,
                     packageName = packageName,
                     shortLabel = shortLabel,
                     longLabel = longLabel,

--- a/feature/pin/src/main/kotlin/com/eblan/launcher/feature/pin/PinScreenViewModel.kt
+++ b/feature/pin/src/main/kotlin/com/eblan/launcher/feature/pin/PinScreenViewModel.kt
@@ -19,10 +19,9 @@ package com.eblan.launcher.feature.pin
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.eblan.launcher.domain.framework.AppWidgetHostWrapper
 import com.eblan.launcher.domain.model.GridItem
-import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.repository.GridRepository
+import com.eblan.launcher.domain.usecase.grid.DeleteGridItemUseCase
 import com.eblan.launcher.domain.usecase.pin.AddPinShortcutToHomeScreenUseCase
 import com.eblan.launcher.domain.usecase.pin.AddPinWidgetToHomeScreenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -36,8 +35,8 @@ import javax.inject.Inject
 class PinScreenViewModel @Inject constructor(
     private val addPinShortcutToHomeScreenUseCase: AddPinShortcutToHomeScreenUseCase,
     private val addPinWidgetToHomeScreenUseCase: AddPinWidgetToHomeScreenUseCase,
-    private val appWidgetHostWrapper: AppWidgetHostWrapper,
     private val gridRepository: GridRepository,
+    private val deleteGridItemUseCase: DeleteGridItemUseCase,
 ) : ViewModel() {
     private val _gridItem = MutableStateFlow<GridItem?>(null)
 
@@ -129,13 +128,7 @@ class PinScreenViewModel @Inject constructor(
 
     fun deleteGridItem(gridItem: GridItem) {
         viewModelScope.launch {
-            val data = gridItem.data
-
-            if (data is GridItemData.Widget) {
-                appWidgetHostWrapper.deleteAppWidgetId(appWidgetId = data.appWidgetId)
-            }
-
-            gridRepository.deleteGridItem(gridItem = gridItem)
+            deleteGridItemUseCase(gridItem = gridItem)
 
             _isFinished.update {
                 true

--- a/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
+++ b/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
@@ -50,6 +50,7 @@ import com.eblan.launcher.domain.model.LauncherAppsActivityInfo
 import com.eblan.launcher.domain.model.LauncherAppsEvent
 import com.eblan.launcher.domain.model.LauncherAppsShortcutInfo
 import com.eblan.launcher.domain.model.ShortcutConfigActivityInfo
+import com.eblan.launcher.domain.model.ShortcutQuery
 import com.eblan.launcher.domain.model.ShortcutQueryFlag
 import com.eblan.launcher.framework.imageserializer.AndroidImageSerializer
 import com.eblan.launcher.framework.packagemanager.AndroidPackageManagerWrapper
@@ -235,12 +236,24 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
         }
     }
 
-    override suspend fun getShortcuts(): List<LauncherAppsShortcutInfo>? = withContext(defaultDispatcher) {
+    override suspend fun getShortcuts(shortcutQuery: ShortcutQuery?): List<LauncherAppsShortcutInfo>? = withContext(defaultDispatcher) {
         if (hasShortcutHostPermission) {
             val shortcutQuery = LauncherApps.ShortcutQuery().apply {
-                setQueryFlags(
-                    LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED,
-                )
+                val shortcutQueryFlag = when (shortcutQuery?.shortcutQueryFlag) {
+                    ShortcutQueryFlag.Pinned -> LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED
+
+                    ShortcutQueryFlag.Dynamic -> LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC
+
+                    ShortcutQueryFlag.Manifest -> LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST
+
+                    null ->
+                        LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
+                            LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
+                            LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED
+                }
+
+                setQueryFlags(shortcutQueryFlag)
+                shortcutQuery?.packageName?.let(::setPackage)
             }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -500,6 +513,23 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
                 serialNumber = serialNumber,
                 eblanUserType = eblanUserType,
                 isPrivateSpaceEntryPointHidden = isPrivateSpaceEntryPointHidden(userHandle = userHandle),
+            )
+        }
+    }
+
+    override fun pinShortcuts(
+        packageName: String,
+        shortcutIds: List<String>,
+        serialNumber: Long,
+    ) {
+        val userHandle = userManagerWrapper.getUserForSerialNumber(serialNumber = serialNumber)
+            ?: return
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            launcherApps.pinShortcuts(
+                packageName,
+                shortcutIds,
+                userHandle,
             )
         }
     }

--- a/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
+++ b/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
@@ -525,7 +525,9 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
         val userHandle = userManagerWrapper.getUserForSerialNumber(serialNumber = serialNumber)
             ?: return
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 &&
+            isUserAvailable(userHandle = userHandle)
+        ) {
             launcherApps.pinShortcuts(
                 packageName,
                 shortcutIds,


### PR DESCRIPTION
Closes #871 

This commit introduces the `DeleteGridItemUseCase` to encapsulate the logic for deleting grid items. This refactoring centralizes the deletion process, improving maintainability and consistency.

The `DeleteGridItemUseCase` handles the removal of grid items, including specific logic for shortcut information and widgets. For shortcuts, it updates pinned shortcuts if necessary. For widgets, it delegates the deletion of the app widget ID to `AppWidgetHostWrapper`.

This change also involves updates to several components that previously handled grid item deletion directly:

- `HomeViewModel`: Now uses `DeleteGridItemUseCase` for deleting grid items.
- `UpdatePageItemsUseCase`: Uses `DeleteGridItemUseCase` for deleting grid items within pages.
- `PinScreenViewModel`: Also utilizes `DeleteGridItemUseCase` for its deletion operations.
- `DefaultGridRepository`: Has been updated to remove direct calls to `appWidgetHostWrapper.deleteAppWidgetId`, as this responsibility is now handled by the `DeleteGridItemUseCase`.

Additionally, the `LauncherAppsWrapper` interface and its implementation (`DefaultLauncherAppsWrapper`) have been extended to include a `pinShortcuts` method and the `getShortcuts` method now accepts a `ShortcutQuery` parameter, allowing for more specific shortcut retrieval. A new `ShortcutQuery` data class has been added to the domain models.

The `SyncDataUseCase` has been updated to use the new `getShortcuts` method with a null `ShortcutQuery` to fetch all shortcut types.

Affected files:
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/DeleteGridItemUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/UpdatePageItemsUseCase.kt
- domain/framework/src/main/kotlin/com/eblan/launcher/domain/framework/LauncherAppsWrapper.kt
- framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
- feature/pin/src/main/kotlin/com/eblan/launcher/feature/pin/PinScreenViewModel.kt
- data/repository/src/main/kotlin/com/eblan/launcher/data/repository/DefaultGridRepository.kt
- domain/model/src/main/kotlin/com/eblan/launcher/domain/model/ShortcutQuery.kt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for querying app shortcuts by package and shortcut type.
  - Added shortcut pinning support on compatible Android versions.

- **Bug Fixes**
  - Improved grid-item removal so shortcuts and widgets are cleaned up consistently (including nested items).
  - Centralized deletion behavior across home, pinning, and page updates to prevent leftover shortcuts/widgets.
  - Preserved shortcut pin state by re-pinning remaining shortcuts when removing a single pinned shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->