### PR TITLE
feat: Refactor edit page screen for drag and drop functionality to lazy row

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/CachePageItemsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/CachePageItemsUseCase.kt
@@ -21,7 +21,6 @@ import com.eblan.launcher.domain.common.Dispatcher
 import com.eblan.launcher.domain.common.EblanDispatchers
 import com.eblan.launcher.domain.grid.isGridItemSpanWithinBounds
 import com.eblan.launcher.domain.model.Associate
-import com.eblan.launcher.domain.model.EditPageData
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.PageItem
 import com.eblan.launcher.domain.repository.UserDataRepository
@@ -37,7 +36,7 @@ class CachePageItemsUseCase @Inject constructor(
     suspend operator fun invoke(
         gridItems: List<GridItem>,
         associate: Associate,
-    ): EditPageData = withContext(defaultDispatcher) {
+    ): List<PageItem> = withContext(defaultDispatcher) {
         val userData = userDataRepository.userDataFlow.first()
 
         val columns = when (associate) {
@@ -63,16 +62,11 @@ class CachePageItemsUseCase @Inject constructor(
             ) && it.associate == associate
         }.groupBy { it.page }
 
-        val pageItems = (0 until pageCount).map {
+        (0 until pageCount).map {
             PageItem(
                 id = it,
                 gridItems = gridItemsByPage[it] ?: emptyList(),
             )
         }
-
-        EditPageData(
-            associate = associate,
-            pageItems = pageItems,
-        )
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
@@ -51,7 +51,6 @@ import com.eblan.launcher.domain.model.EblanShortcutConfig
 import com.eblan.launcher.domain.model.EblanShortcutInfo
 import com.eblan.launcher.domain.model.EblanShortcutInfoByGroup
 import com.eblan.launcher.domain.model.EblanUser
-import com.eblan.launcher.domain.model.EditPageData
 import com.eblan.launcher.domain.model.FolderPopup
 import com.eblan.launcher.domain.model.FolderPopupEntry
 import com.eblan.launcher.domain.model.GetEblanApplicationInfosByLabelAndTag
@@ -65,7 +64,8 @@ import com.eblan.launcher.feature.home.dialog.TextDialog
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.model.HomeUiState
 import com.eblan.launcher.feature.home.model.Screen
-import com.eblan.launcher.feature.home.screen.editpage.EditPageScreen
+import com.eblan.launcher.feature.home.screen.editpage.EditDockGridPageScreen
+import com.eblan.launcher.feature.home.screen.editpage.EditGridPageScreen
 import com.eblan.launcher.feature.home.screen.loading.LoadingScreen
 import com.eblan.launcher.feature.home.screen.pager.PagerScreen
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -90,7 +90,7 @@ internal fun HomeRoute(
 
     val movedGridItemResult by viewModel.movedGridItemResult.collectAsStateWithLifecycle()
 
-    val editPageData by viewModel.editPageData.collectAsStateWithLifecycle()
+    val pageItems by viewModel.pageItems.collectAsStateWithLifecycle()
 
     val pinGridItem by viewModel.pinGridItem.collectAsStateWithLifecycle()
 
@@ -122,7 +122,7 @@ internal fun HomeRoute(
         eblanApplicationInfoTags = eblanApplicationInfoTags,
         eblanShortcutConfigs = eblanShortcutConfigs,
         eblanShortcutInfosGroup = eblanShortcutInfosGroup,
-        editPageData = editPageData,
+        pageItems = pageItems,
         folderPopups = folderPopups,
         getEblanApplicationInfosByLabelAndTag = getEblanApplicationInfos,
         homeUiState = homeUiState,
@@ -180,7 +180,7 @@ internal fun HomeScreen(
     eblanApplicationInfoTags: List<EblanApplicationInfoTag>,
     eblanShortcutConfigs: Map<EblanUser, Map<EblanApplicationInfoGroup, List<EblanShortcutConfig>>>,
     eblanShortcutInfosGroup: Map<EblanShortcutInfoByGroup, List<EblanShortcutInfo>>,
-    editPageData: EditPageData?,
+    pageItems: List<PageItem>?,
     folderPopups: List<FolderPopup>,
     getEblanApplicationInfosByLabelAndTag: GetEblanApplicationInfosByLabelAndTag,
     homeUiState: HomeUiState,
@@ -285,7 +285,7 @@ internal fun HomeScreen(
                 eblanApplicationInfoTags = eblanApplicationInfoTags,
                 eblanShortcutConfigs = eblanShortcutConfigs,
                 eblanShortcutInfosGroup = eblanShortcutInfosGroup,
-                editPageData = editPageData,
+                pageItems = pageItems,
                 folderPopups = folderPopups,
                 getEblanApplicationInfosByLabelAndTag = getEblanApplicationInfosByLabelAndTag,
                 homeData = homeUiState.homeData,
@@ -348,7 +348,7 @@ private fun Success(
     eblanApplicationInfoTags: List<EblanApplicationInfoTag>,
     eblanShortcutConfigs: Map<EblanUser, Map<EblanApplicationInfoGroup, List<EblanShortcutConfig>>>,
     eblanShortcutInfosGroup: Map<EblanShortcutInfoByGroup, List<EblanShortcutInfo>>,
-    editPageData: EditPageData?,
+    pageItems: List<PageItem>?,
     folderPopups: List<FolderPopup>,
     getEblanApplicationInfosByLabelAndTag: GetEblanApplicationInfosByLabelAndTag,
     homeData: HomeData,
@@ -520,13 +520,26 @@ private fun Success(
                 LoadingScreen()
             }
 
-            Screen.EditPage -> {
-                EditPageScreen(
-                    editPageData = editPageData,
+            Screen.EditGridPage -> {
+                EditGridPageScreen(
+                    pageItems = pageItems,
                     hasShortcutHostPermission = homeData.hasShortcutHostPermission,
                     homeSettings = homeData.userData.homeSettings,
                     paddingValues = paddingValues,
+                    screenWidth = screenWidth,
                     screenHeight = screenHeight,
+                    textColor = homeData.textColor,
+                    onSaveEditPage = onSaveEditPage,
+                    onUpdateScreen = onUpdateScreen,
+                )
+            }
+
+            Screen.EditDockGridPage -> {
+                EditDockGridPageScreen(
+                    pageItems = pageItems,
+                    hasShortcutHostPermission = homeData.hasShortcutHostPermission,
+                    homeSettings = homeData.userData.homeSettings,
+                    paddingValues = paddingValues,
                     textColor = homeData.textColor,
                     onSaveEditPage = onSaveEditPage,
                     onUpdateScreen = onUpdateScreen,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -26,7 +26,6 @@ import com.eblan.launcher.domain.framework.PackageManagerWrapper
 import com.eblan.launcher.domain.model.AppDrawerSettings
 import com.eblan.launcher.domain.model.Associate
 import com.eblan.launcher.domain.model.EblanApplicationInfo
-import com.eblan.launcher.domain.model.EditPageData
 import com.eblan.launcher.domain.model.FolderPopupEntry
 import com.eblan.launcher.domain.model.GetEblanApplicationInfosByLabelAndTag
 import com.eblan.launcher.domain.model.GridItem
@@ -125,9 +124,9 @@ internal class HomeViewModel @Inject constructor(
 
     private val defaultDelay = 500L
 
-    private val _editPageData = MutableStateFlow<EditPageData?>(null)
+    private val _pageItems = MutableStateFlow<List<PageItem>?>(null)
 
-    val editPageData = _editPageData.asStateFlow()
+    val pageItems = _pageItems.asStateFlow()
 
     private var moveGridItemJob: Job? = null
 
@@ -273,7 +272,7 @@ internal class HomeViewModel @Inject constructor(
                 Screen.Loading
             }
 
-            _editPageData.update {
+            _pageItems.update {
                 cachePageItemsUseCase(
                     gridItems = gridItems,
                     associate = associate,
@@ -283,7 +282,10 @@ internal class HomeViewModel @Inject constructor(
             delay(defaultDelay.milliseconds)
 
             _screen.update {
-                Screen.EditPage
+                when (associate) {
+                    Associate.Grid -> Screen.EditGridPage
+                    Associate.Dock -> Screen.EditDockGridPage
+                }
             }
         }
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/model/Screen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/model/Screen.kt
@@ -20,5 +20,6 @@ package com.eblan.launcher.feature.home.model
 enum class Screen {
     Pager,
     Loading,
-    EditPage,
+    EditGridPage,
+    EditDockGridPage,
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
@@ -39,7 +39,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -68,7 +70,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.util.Consumer
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.Associate
-import com.eblan.launcher.domain.model.EditPageData
 import com.eblan.launcher.domain.model.HomeSettings
 import com.eblan.launcher.domain.model.PageItem
 import com.eblan.launcher.domain.model.TextColor
@@ -79,12 +80,13 @@ import com.eblan.launcher.common.R as commonR
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-internal fun EditPageScreen(
+internal fun EditGridPageScreen(
     modifier: Modifier = Modifier,
-    editPageData: EditPageData?,
+    pageItems: List<PageItem>?,
     hasShortcutHostPermission: Boolean,
     homeSettings: HomeSettings,
     paddingValues: PaddingValues,
+    screenWidth: Int,
     screenHeight: Int,
     textColor: TextColor,
     onSaveEditPage: (
@@ -95,36 +97,212 @@ internal fun EditPageScreen(
     ) -> Unit,
     onUpdateScreen: (Screen) -> Unit,
 ) {
-    requireNotNull(editPageData)
+    requireNotNull(pageItems)
 
     val density = LocalDensity.current
 
     val layoutDirection = LocalLayoutDirection.current
 
+    val leftPadding = with(density) {
+        paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
+    }
+
     val topPadding = with(density) {
         paddingValues.calculateTopPadding().roundToPx()
+    }
+
+    val rightPadding = with(density) {
+        paddingValues.calculateRightPadding(layoutDirection).roundToPx()
     }
 
     val bottomPadding = with(density) {
         paddingValues.calculateBottomPadding().roundToPx()
     }
 
+    val horizontalPadding = leftPadding + rightPadding
+
     val verticalPadding = topPadding + bottomPadding
 
-    val gridHeight = screenHeight - verticalPadding
+    val gridWidthDp = with(density) {
+        (screenWidth - horizontalPadding).toDp()
+    }
 
-    var currentPageItems by remember { mutableStateOf(editPageData.pageItems) }
+    val gridHeightDp = with(density) {
+        (screenHeight - verticalPadding).toDp()
+    }
+
+    var currentPageItems by remember { mutableStateOf(pageItems) }
 
     val pageItemsToDelete = remember { mutableStateListOf<PageItem>() }
 
-    var selectedId by remember {
-        mutableIntStateOf(
-            when (editPageData.associate) {
-                Associate.Grid -> homeSettings.initialPage
-                Associate.Dock -> homeSettings.dockInitialPage
+    var selectedId by remember { mutableIntStateOf(homeSettings.initialPage) }
+
+    val lazyListState = rememberLazyListState()
+
+    val lazyRowDragDropState =
+        rememberLazyRowDragDropState(lazyListState = lazyListState) { from, to ->
+            currentPageItems = currentPageItems.toMutableList().apply {
+                add(
+                    index = to,
+                    element = removeAt(from),
+                )
+            }
+        }
+
+    val activity = LocalActivity.current as ComponentActivity
+
+    val scope = rememberCoroutineScope()
+
+    val columns = homeSettings.columns
+
+    val rows = homeSettings.rows
+
+    var expanded by remember { mutableStateOf(false) }
+
+    DisposableEffect(key1 = activity) {
+        val listener = Consumer<Intent> { intent ->
+            scope.launch {
+                handleActionMainIntent(
+                    intent = intent,
+                    onUpdateScreen = onUpdateScreen,
+                )
+            }
+        }
+
+        activity.addOnNewIntentListener(listener)
+
+        onDispose {
+            activity.removeOnNewIntentListener(listener)
+        }
+    }
+
+    BackHandler {
+        onUpdateScreen(Screen.Pager)
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        LazyRow(
+            modifier = Modifier
+                .dragRowContainer(lazyRowDragDropState = lazyRowDragDropState)
+                .matchParentSize(),
+            contentPadding = paddingValues,
+            state = lazyListState,
+        ) {
+            itemsIndexed(
+                items = currentPageItems,
+                key = { _, pageItem -> pageItem.id },
+            ) { index, pageItem ->
+                DraggableRowItem(
+                    modifier = Modifier
+                        .size(
+                            width = gridWidthDp,
+                            height = gridHeightDp,
+                        )
+                        .padding(10.dp),
+                    lazyRowDragDropState = lazyRowDragDropState,
+                    index = index,
+                ) {
+                    GridLayout(
+                        modifier = Modifier
+                            .weight(1f)
+                            .background(
+                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f),
+                                shape = RoundedCornerShape(8.dp),
+                            ),
+                        columns = columns,
+                        gridItems = pageItem.gridItems,
+                        rows = rows,
+                        content = {
+                            GridItemContent(
+                                gridItem = it,
+                                gridItemSettings = homeSettings.gridItemSettings,
+                                hasShortcutHostPermission = hasShortcutHostPermission,
+                                statusBarNotifications = emptyMap(),
+                                textColor = textColor,
+                            )
+                        },
+                    )
+
+                    PageButtons(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .padding(5.dp),
+                        pageItem = pageItem,
+                        selectedId = selectedId,
+                        onDeleteClick = {
+                            currentPageItems = currentPageItems.toMutableList().apply {
+                                removeIf { currentPageItem ->
+                                    currentPageItem.id == pageItem.id
+                                }
+                            }
+
+                            pageItemsToDelete.add(pageItem)
+                        },
+                        onHomeClick = {
+                            selectedId = pageItem.id
+                        },
+                    )
+                }
+            }
+        }
+
+        ExpandableFloatingActionButton(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(
+                    end = paddingValues.calculateEndPadding(layoutDirection),
+                    bottom = paddingValues.calculateBottomPadding(),
+                ),
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+            onAdd = {
+                currentPageItems = currentPageItems.toMutableList().apply {
+                    add(PageItem(id = maxOf { it.id } + 1, gridItems = emptyList()))
+                }
+            },
+            onSave = {
+                onSaveEditPage(
+                    selectedId,
+                    currentPageItems,
+                    pageItemsToDelete,
+                    Associate.Grid,
+                )
+
+                expanded = false
+            },
+            onCancel = {
+                onUpdateScreen(Screen.Pager)
             },
         )
     }
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+internal fun EditDockGridPageScreen(
+    modifier: Modifier = Modifier,
+    pageItems: List<PageItem>?,
+    hasShortcutHostPermission: Boolean,
+    homeSettings: HomeSettings,
+    paddingValues: PaddingValues,
+    textColor: TextColor,
+    onSaveEditPage: (
+        id: Int,
+        pageItems: List<PageItem>,
+        pageItemsToDelete: List<PageItem>,
+        associate: Associate,
+    ) -> Unit,
+    onUpdateScreen: (Screen) -> Unit,
+) {
+    requireNotNull(pageItems)
+
+    val layoutDirection = LocalLayoutDirection.current
+
+    var currentPageItems by remember { mutableStateOf(pageItems) }
+
+    val pageItemsToDelete = remember { mutableStateListOf<PageItem>() }
+
+    var selectedId by remember { mutableIntStateOf(homeSettings.dockInitialPage) }
 
     val lazyListState = rememberLazyListState()
 
@@ -142,23 +320,11 @@ internal fun EditPageScreen(
 
     val scope = rememberCoroutineScope()
 
-    val columns = when (editPageData.associate) {
-        Associate.Grid -> homeSettings.columns
-        Associate.Dock -> homeSettings.dockColumns
-    }
+    val columns = homeSettings.dockColumns
 
-    val rows = when (editPageData.associate) {
-        Associate.Grid -> homeSettings.rows
-        Associate.Dock -> homeSettings.dockRows
-    }
+    val rows = homeSettings.dockRows
 
-    val cardHeight = when (editPageData.associate) {
-        Associate.Grid -> with(density) {
-            gridHeight.toDp() - homeSettings.dockHeight.dp
-        }
-
-        Associate.Dock -> homeSettings.dockHeight.dp
-    }
+    val cardHeight = homeSettings.dockHeight.dp
 
     var expanded by remember { mutableStateOf(false) }
 
@@ -186,7 +352,7 @@ internal fun EditPageScreen(
     Box(modifier = modifier.fillMaxSize()) {
         LazyColumn(
             modifier = Modifier
-                .dragContainer(lazyColumnDragDropState = lazyColumnDragDropState)
+                .dragColumnContainer(lazyColumnDragDropState = lazyColumnDragDropState)
                 .matchParentSize(),
             state = lazyListState,
             contentPadding = paddingValues,
@@ -195,7 +361,7 @@ internal fun EditPageScreen(
                 items = currentPageItems,
                 key = { _, pageItem -> pageItem.id },
             ) { index, pageItem ->
-                DraggableItem(
+                DraggableColumnItem(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(10.dp),
@@ -271,7 +437,7 @@ internal fun EditPageScreen(
                     selectedId,
                     currentPageItems,
                     pageItemsToDelete,
-                    editPageData.associate,
+                    Associate.Dock,
                 )
 
                 expanded = false
@@ -284,7 +450,7 @@ internal fun EditPageScreen(
 }
 
 @Composable
-private fun PageButtons(
+internal fun PageButtons(
     modifier: Modifier = Modifier,
     pageItem: PageItem,
     selectedId: Int,
@@ -324,7 +490,7 @@ private fun PageButtons(
 }
 
 @Composable
-private fun ExpandableFloatingActionButton(
+internal fun ExpandableFloatingActionButton(
     modifier: Modifier = Modifier,
     expanded: Boolean,
     onExpandedChange: (Boolean) -> Unit,
@@ -389,7 +555,7 @@ private fun ExpandableFloatingActionButton(
     }
 }
 
-private fun handleActionMainIntent(
+internal fun handleActionMainIntent(
     intent: Intent,
     onUpdateScreen: (Screen) -> Unit,
 ) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/LazyColumnDragDropState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/LazyColumnDragDropState.kt
@@ -1,0 +1,206 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.feature.home.screen.editpage
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListItemInfo
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.zIndex
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+@Composable
+internal fun rememberLazyColumnDragDropState(
+    lazyListState: LazyListState,
+    onMove: (Int, Int) -> Unit,
+): LazyColumnDragDropState {
+    val scope = rememberCoroutineScope()
+
+    val state = remember(key1 = lazyListState) {
+        LazyColumnDragDropState(
+            state = lazyListState,
+            onMove = onMove,
+            scope = scope,
+        )
+    }
+
+    LaunchedEffect(key1 = state) {
+        state.scrollChannel
+            .receiveAsFlow()
+            .onEach(lazyListState::scrollBy)
+            .collect()
+    }
+
+    return state
+}
+
+internal class LazyColumnDragDropState(
+    private val state: LazyListState,
+    private val scope: CoroutineScope,
+    private val onMove: (Int, Int) -> Unit,
+) {
+    var draggingItemIndex by mutableStateOf<Int?>(null)
+        private set
+
+    internal val scrollChannel = Channel<Float>()
+
+    private var draggingItemDraggedDelta by mutableFloatStateOf(0f)
+    private var draggingItemInitialOffset by mutableIntStateOf(0)
+    internal val draggingItemOffset: Float
+        get() = draggingItemLayoutInfo?.let { item ->
+            draggingItemInitialOffset + draggingItemDraggedDelta - item.offset
+        } ?: 0f
+
+    private val draggingItemLayoutInfo: LazyListItemInfo?
+        get() = state.layoutInfo.visibleItemsInfo.firstOrNull { it.index == draggingItemIndex }
+
+    internal var previousIndexOfDraggedItem by mutableStateOf<Int?>(null)
+        private set
+
+    internal var previousItemOffset = Animatable(0f)
+        private set
+
+    internal fun onDragStart(offset: Offset) {
+        state.layoutInfo.visibleItemsInfo.firstOrNull { item -> offset.y.toInt() in item.offset..(item.offset + item.size) }
+            ?.also {
+                draggingItemIndex = it.index
+                draggingItemInitialOffset = it.offset
+            }
+    }
+
+    internal fun onDragInterrupted() {
+        if (draggingItemIndex != null) {
+            previousIndexOfDraggedItem = draggingItemIndex
+            val startOffset = draggingItemOffset
+            scope.launch {
+                previousItemOffset.snapTo(startOffset)
+                previousItemOffset.animateTo(
+                    0f,
+                    spring(stiffness = Spring.StiffnessMediumLow, visibilityThreshold = 1f),
+                )
+                previousIndexOfDraggedItem = null
+            }
+        }
+        draggingItemDraggedDelta = 0f
+        draggingItemIndex = null
+        draggingItemInitialOffset = 0
+    }
+
+    internal fun onDrag(offset: Offset) {
+        draggingItemDraggedDelta += offset.y
+
+        val draggingItem = draggingItemLayoutInfo ?: return
+        val startOffset = draggingItem.offset + draggingItemOffset
+        val endOffset = startOffset + draggingItem.size
+        val middleOffset = startOffset + (endOffset - startOffset) / 2f
+
+        val targetItem = state.layoutInfo.visibleItemsInfo.find { item ->
+            middleOffset.toInt() in item.offset..item.offsetEnd && draggingItem.index != item.index
+        }
+        if (targetItem != null) {
+            if (draggingItem.index == state.firstVisibleItemIndex || targetItem.index == state.firstVisibleItemIndex) {
+                state.requestScrollToItem(
+                    state.firstVisibleItemIndex,
+                    state.firstVisibleItemScrollOffset,
+                )
+            }
+            onMove.invoke(draggingItem.index, targetItem.index)
+            draggingItemIndex = targetItem.index
+        } else {
+            val overscroll = when {
+                draggingItemDraggedDelta > 0 -> (endOffset - state.layoutInfo.viewportEndOffset).coerceAtLeast(
+                    0f,
+                )
+
+                draggingItemDraggedDelta < 0 -> (startOffset - state.layoutInfo.viewportStartOffset).coerceAtMost(
+                    0f,
+                )
+
+                else -> 0f
+            }
+            if (overscroll != 0f) {
+                scrollChannel.trySend(overscroll)
+            }
+        }
+    }
+
+    private val LazyListItemInfo.offsetEnd: Int
+        get() = this.offset + this.size
+}
+
+internal fun Modifier.dragColumnContainer(lazyColumnDragDropState: LazyColumnDragDropState): Modifier = pointerInput(key1 = lazyColumnDragDropState) {
+    detectDragGesturesAfterLongPress(
+        onDrag = { change, offset ->
+            change.consume()
+            lazyColumnDragDropState.onDrag(offset = offset)
+        },
+        onDragStart = { lazyColumnDragDropState.onDragStart(it) },
+        onDragEnd = { lazyColumnDragDropState.onDragInterrupted() },
+        onDragCancel = { lazyColumnDragDropState.onDragInterrupted() },
+    )
+}
+
+@Composable
+internal fun LazyItemScope.DraggableColumnItem(
+    modifier: Modifier = Modifier,
+    lazyColumnDragDropState: LazyColumnDragDropState,
+    index: Int,
+    content: @Composable ColumnScope.(isDragging: Boolean) -> Unit,
+) {
+    val dragging = index == lazyColumnDragDropState.draggingItemIndex
+
+    val draggingModifier = if (dragging) {
+        Modifier
+            .zIndex(1f)
+            .graphicsLayer { translationY = lazyColumnDragDropState.draggingItemOffset }
+    } else if (index == lazyColumnDragDropState.previousIndexOfDraggedItem) {
+        Modifier
+            .zIndex(1f)
+            .graphicsLayer {
+                translationY = lazyColumnDragDropState.previousItemOffset.value
+            }
+    } else {
+        Modifier.animateItem(fadeInSpec = null, fadeOutSpec = null)
+    }
+
+    Column(modifier = modifier.then(draggingModifier)) { content(dragging) }
+}

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/LazyRowDropAndDropState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/LazyRowDropAndDropState.kt
@@ -49,28 +49,31 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 @Composable
-internal fun rememberLazyColumnDragDropState(
+internal fun rememberLazyRowDragDropState(
     lazyListState: LazyListState,
     onMove: (Int, Int) -> Unit,
-): LazyColumnDragDropState {
+): LazyRowDragDropState {
     val scope = rememberCoroutineScope()
 
     val state = remember(key1 = lazyListState) {
-        LazyColumnDragDropState(
+        LazyRowDragDropState(
             state = lazyListState,
             onMove = onMove,
             scope = scope,
         )
     }
 
-    LaunchedEffect(key1 = state) {
-        state.scrollChannel.receiveAsFlow().onEach(lazyListState::scrollBy).collect()
+    LaunchedEffect(state) {
+        state.scrollChannel
+            .receiveAsFlow()
+            .onEach(lazyListState::scrollBy)
+            .collect()
     }
 
     return state
 }
 
-internal class LazyColumnDragDropState(
+internal class LazyRowDragDropState(
     private val state: LazyListState,
     private val scope: CoroutineScope,
     private val onMove: (Int, Int) -> Unit,
@@ -97,7 +100,10 @@ internal class LazyColumnDragDropState(
         private set
 
     internal fun onDragStart(offset: Offset) {
-        state.layoutInfo.visibleItemsInfo.firstOrNull { item -> offset.y.toInt() in item.offset..(item.offset + item.size) }
+        state.layoutInfo.visibleItemsInfo
+            .firstOrNull { item ->
+                offset.x.toInt() in item.offset..(item.offset + item.size)
+            }
             ?.also {
                 draggingItemIndex = it.index
                 draggingItemInitialOffset = it.offset
@@ -123,37 +129,45 @@ internal class LazyColumnDragDropState(
     }
 
     internal fun onDrag(offset: Offset) {
-        draggingItemDraggedDelta += offset.y
+        draggingItemDraggedDelta += offset.x
 
         val draggingItem = draggingItemLayoutInfo ?: return
+
         val startOffset = draggingItem.offset + draggingItemOffset
         val endOffset = startOffset + draggingItem.size
         val middleOffset = startOffset + (endOffset - startOffset) / 2f
 
         val targetItem = state.layoutInfo.visibleItemsInfo.find { item ->
-            middleOffset.toInt() in item.offset..item.offsetEnd && draggingItem.index != item.index
+            middleOffset.toInt() in item.offset..item.offsetEnd &&
+                draggingItem.index != item.index
         }
+
         if (targetItem != null) {
-            if (draggingItem.index == state.firstVisibleItemIndex || targetItem.index == state.firstVisibleItemIndex) {
+            if (
+                draggingItem.index == state.firstVisibleItemIndex ||
+                targetItem.index == state.firstVisibleItemIndex
+            ) {
                 state.requestScrollToItem(
                     state.firstVisibleItemIndex,
                     state.firstVisibleItemScrollOffset,
                 )
             }
-            onMove.invoke(draggingItem.index, targetItem.index)
+
+            onMove(draggingItem.index, targetItem.index)
             draggingItemIndex = targetItem.index
         } else {
             val overscroll = when {
-                draggingItemDraggedDelta > 0 -> (endOffset - state.layoutInfo.viewportEndOffset).coerceAtLeast(
-                    0f,
-                )
+                draggingItemDraggedDelta > 0 ->
+                    (endOffset - state.layoutInfo.viewportEndOffset)
+                        .coerceAtLeast(0f)
 
-                draggingItemDraggedDelta < 0 -> (startOffset - state.layoutInfo.viewportStartOffset).coerceAtMost(
-                    0f,
-                )
+                draggingItemDraggedDelta < 0 ->
+                    (startOffset - state.layoutInfo.viewportStartOffset)
+                        .coerceAtMost(0f)
 
                 else -> 0f
             }
+
             if (overscroll != 0f) {
                 scrollChannel.trySend(overscroll)
             }
@@ -164,40 +178,48 @@ internal class LazyColumnDragDropState(
         get() = this.offset + this.size
 }
 
-internal fun Modifier.dragContainer(lazyColumnDragDropState: LazyColumnDragDropState): Modifier = pointerInput(key1 = lazyColumnDragDropState) {
+internal fun Modifier.dragRowContainer(
+    lazyRowDragDropState: LazyRowDragDropState,
+) = pointerInput(lazyRowDragDropState) {
     detectDragGesturesAfterLongPress(
+        onDragStart = lazyRowDragDropState::onDragStart,
+        onDragEnd = lazyRowDragDropState::onDragInterrupted,
+        onDragCancel = lazyRowDragDropState::onDragInterrupted,
         onDrag = { change, offset ->
             change.consume()
-            lazyColumnDragDropState.onDrag(offset = offset)
+            lazyRowDragDropState.onDrag(offset)
         },
-        onDragStart = { lazyColumnDragDropState.onDragStart(it) },
-        onDragEnd = { lazyColumnDragDropState.onDragInterrupted() },
-        onDragCancel = { lazyColumnDragDropState.onDragInterrupted() },
     )
 }
 
 @Composable
-internal fun LazyItemScope.DraggableItem(
+internal fun LazyItemScope.DraggableRowItem(
     modifier: Modifier = Modifier,
-    lazyColumnDragDropState: LazyColumnDragDropState,
+    lazyRowDragDropState: LazyRowDragDropState,
     index: Int,
     content: @Composable ColumnScope.(isDragging: Boolean) -> Unit,
 ) {
-    val dragging = index == lazyColumnDragDropState.draggingItemIndex
+    val dragging = index == lazyRowDragDropState.draggingItemIndex
 
-    val draggingModifier = if (dragging) {
-        Modifier
-            .zIndex(1f)
-            .graphicsLayer { translationY = lazyColumnDragDropState.draggingItemOffset }
-    } else if (index == lazyColumnDragDropState.previousIndexOfDraggedItem) {
-        Modifier
-            .zIndex(1f)
-            .graphicsLayer {
-                translationY = lazyColumnDragDropState.previousItemOffset.value
-            }
-    } else {
-        Modifier.animateItem(fadeInSpec = null, fadeOutSpec = null)
-    }
+    val draggingModifier =
+        if (dragging) {
+            Modifier
+                .zIndex(1f)
+                .graphicsLayer {
+                    translationX = lazyRowDragDropState.draggingItemOffset
+                }
+        } else if (index == lazyRowDragDropState.previousIndexOfDraggedItem) {
+            Modifier
+                .zIndex(1f)
+                .graphicsLayer {
+                    translationX = lazyRowDragDropState.previousItemOffset.value
+                }
+        } else {
+            Modifier.animateItem(
+                fadeInSpec = null,
+                fadeOutSpec = null,
+            )
+        }
 
     Column(modifier = modifier.then(draggingModifier)) { content(dragging) }
 }


### PR DESCRIPTION
Closes #604 

This commit refactors the edit page screen to support drag and drop functionality for both grid and dock pages.

Key changes include:
- Renaming `LazyColumnDragDropState` to `LazyRowDragDropState` and introducing `LazyColumnDragDropState` for column-based dragging.
- Updating `rememberLazyColumnDragDropState` to `rememberLazyRowDragDropState`.
- Renaming `dragContainer` to `dragRowContainer` and `DraggableItem` to `DraggableRowItem` to reflect the row-based drag and drop.
- Introducing `EditGridPageScreen` and `EditDockGridPageScreen` to handle different page types.
- Modifying `HomeScreen.kt` to use the new screen composables and `HomeViewModel.kt` to expose `pageItems` instead of `editPageData`.
- Adjusting `EditPageScreen.kt` to `EditGridPageScreen.kt` and `EditDockGridPageScreen.kt` to correctly handle drag and drop for rows and columns respectively.
- Updating the `CachePageItemsUseCase.kt` to return `List<PageItem>` instead of `EditPageData`.
- Modifying `Screen.kt` to include `EditGridPage` and `EditDockGridPage`.

Affected files:
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/LazyColumnDragDropState.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/LazyRowDropAndDropState.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeScreen.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/model/Screen.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/EditPageScreen.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/CachePageItemsUseCase.kt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate editing experiences for grid pages and dock pages.
  * Enabled drag-and-drop reordering across grid rows and page columns, including automatic scrolling while dragging.
  * Improved page editing navigation with dedicated grid and dock editing screens.

* **Refactor**
  * Updated page caching and home screen state to use page items directly.
  * Replaced the single edit-page mode with separate grid and dock editing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->