### PR TITLE
feat: Add setting to control keyboard visibility in app drawer

### DIFF
--- a/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
+++ b/data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
@@ -19,4 +19,5 @@ message AppDrawerSettingsProto {
   int32 horizontalAppDrawerColumns = 9;
   int32 horizontalAppDrawerRows = 10;
   bool excludeTaggedApps = 11;
+  bool showKeyboard = 12;
 }

--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/UserDataSerializer.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/UserDataSerializer.kt
@@ -93,6 +93,7 @@ class UserDataSerializer @Inject constructor() : Serializer<UserDataProto> {
         horizontalAppDrawerColumns = 5
         horizontalAppDrawerRows = 5
         excludeTaggedApps = false
+        showKeyboard = false
     }.build()
 
     private val defaultGestureSettingsProto = GestureSettingsProto.newBuilder().apply {

--- a/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
+++ b/data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
@@ -79,6 +79,7 @@ internal fun AppDrawerSettingsProto.toAppDrawerSettings(): AppDrawerSettings = A
     horizontalAppDrawerColumns = horizontalAppDrawerColumns,
     horizontalAppDrawerRows = horizontalAppDrawerRows,
     excludeTaggedApps = excludeTaggedApps,
+    showKeyboard = showKeyboard,
 )
 
 internal fun GridItemSettingsProto.toGridItemSettings(): GridItemSettings = GridItemSettings(
@@ -132,6 +133,7 @@ internal fun AppDrawerSettings.toAppDrawerSettingsProto(): AppDrawerSettingsProt
     .setHorizontalAppDrawerColumns(horizontalAppDrawerColumns)
     .setHorizontalAppDrawerRows(horizontalAppDrawerRows)
     .setExcludeTaggedApps(excludeTaggedApps)
+    .setShowKeyboard(showKeyboard)
     .build()
 
 internal fun GeneralSettings.toGeneralSettingsProto(): GeneralSettingsProto = GeneralSettingsProto.newBuilder().setThemeProto(theme.toThemeProto())

--- a/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
+++ b/domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
@@ -28,4 +28,5 @@ data class AppDrawerSettings(
     val horizontalAppDrawerColumns: Int,
     val horizontalAppDrawerRows: Int,
     val excludeTaggedApps: Boolean,
+    val showKeyboard: Boolean,
 )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -51,10 +51,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -293,7 +295,10 @@ internal fun QuiteModeScreen(
             .padding(10.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = stringResource(R.string.work_apps_are_paused), style = MaterialTheme.typography.titleLarge)
+        Text(
+            text = stringResource(R.string.work_apps_are_paused),
+            style = MaterialTheme.typography.titleLarge,
+        )
 
         Spacer(modifier = Modifier.height(10.dp))
 
@@ -414,12 +419,16 @@ internal fun ApplicationScreenEffect(
     showPopupApplicationMenu: Boolean,
     swipeY: Float,
     textFieldState: TextFieldState,
+    showKeyboard: Boolean,
+    focusRequester: FocusRequester,
     onDismiss: () -> Unit,
     onGetEblanApplicationInfosByLabel: (String) -> Unit,
     onGetEblanApplicationInfosByTagId: (Long?) -> Unit,
     onShowPopupApplicationMenu: (Boolean) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(key1 = textFieldState) {
         snapshotFlow { textFieldState.text }.debounce(500L.milliseconds).onEach {
@@ -446,12 +455,22 @@ internal fun ApplicationScreenEffect(
     }
 
     LaunchedEffect(key1 = swipeY) {
-        if (swipeY == screenHeight.toFloat()) {
-            textFieldState.clearText()
+        when (swipeY) {
+            screenHeight.toFloat() -> {
+                textFieldState.clearText()
 
-            horizontalPagerState.scrollToPage(0)
+                horizontalPagerState.scrollToPage(0)
 
-            keyboardController?.hide()
+                focusManager.clearFocus()
+
+                keyboardController?.hide()
+            }
+
+            0f if showKeyboard -> {
+                focusRequester.requestFocus()
+
+                keyboardController?.show()
+            }
         }
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/SearchBar.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/SearchBar.kt
@@ -32,6 +32,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
@@ -42,6 +44,7 @@ import com.eblan.launcher.common.R as commonR
 @Composable
 internal fun ApplicationSearchBar(
     modifier: Modifier = Modifier,
+    focusRequester: FocusRequester,
     searchBarState: SearchBarState,
     textFieldState: TextFieldState,
     onUpdateShowEblanApplicationInfoOrderDialog: (Boolean) -> Unit,
@@ -55,6 +58,7 @@ internal fun ApplicationSearchBar(
             .padding(10.dp),
         inputField = {
             SearchBarDefaults.InputField(
+                modifier = Modifier.focusRequester(focusRequester),
                 textFieldState = textFieldState,
                 searchBarState = searchBarState,
                 leadingIcon = {
@@ -105,6 +109,7 @@ internal fun ApplicationSearchBar(
 @Composable
 internal fun ApplicationSearchBarWithoutMenu(
     modifier: Modifier = Modifier,
+    focusRequester: FocusRequester,
     searchBarState: SearchBarState,
     textFieldState: TextFieldState,
 ) {
@@ -117,6 +122,7 @@ internal fun ApplicationSearchBarWithoutMenu(
             .padding(10.dp),
         inputField = {
             SearchBarDefaults.InputField(
+                modifier = Modifier.focusRequester(focusRequester),
                 textFieldState = textFieldState,
                 searchBarState = searchBarState,
                 leadingIcon = {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
@@ -165,6 +166,8 @@ internal fun HorizontalApplicationScreen(
             getEblanApplicationInfosByLabelAndTag.eblanApplicationInfoWithIconPackInfos.keys.distinctBy { it.eblanUser.serialNumber }
         }
 
+    val focusRequester = remember { FocusRequester() }
+
     ApplicationScreenEffect(
         horizontalPagerState = horizontalPagerState,
         isPressHome = isPressHome,
@@ -173,6 +176,8 @@ internal fun HorizontalApplicationScreen(
         showPopupApplicationMenu = showPopupApplicationMenu,
         swipeY = swipeY,
         textFieldState = textFieldState,
+        showKeyboard = appDrawerSettings.showKeyboard,
+        focusRequester = focusRequester,
         onDismiss = onDismiss,
         onGetEblanApplicationInfosByLabel = onGetEblanApplicationInfosByLabel,
         onGetEblanApplicationInfosByTagId = onGetEblanApplicationInfosByTagId,
@@ -187,6 +192,7 @@ internal fun HorizontalApplicationScreen(
             .padding(paddingValues),
     ) {
         ApplicationSearchBarWithoutMenu(
+            focusRequester = focusRequester,
             searchBarState = searchBarState,
             textFieldState = textFieldState,
         )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.layer.drawLayer
@@ -208,6 +209,8 @@ internal fun ListApplicationScreen(
             getEblanApplicationInfosByLabelAndTag.eblanApplicationInfoWithIconPackInfos.keys.distinctBy { it.eblanUser.serialNumber }
         }
 
+    val focusRequester = remember { FocusRequester() }
+
     ApplicationScreenEffect(
         horizontalPagerState = horizontalPagerState,
         isPressHome = isPressHome,
@@ -216,6 +219,8 @@ internal fun ListApplicationScreen(
         showPopupApplicationMenu = showPopupApplicationMenu,
         swipeY = swipeY,
         textFieldState = textFieldState,
+        showKeyboard = appDrawerSettings.showKeyboard,
+        focusRequester = focusRequester,
         onDismiss = onDismiss,
         onGetEblanApplicationInfosByLabel = onGetEblanApplicationInfosByLabel,
         onGetEblanApplicationInfosByTagId = onGetEblanApplicationInfosByTagId,
@@ -234,6 +239,7 @@ internal fun ListApplicationScreen(
             ),
     ) {
         ApplicationSearchBarWithoutMenu(
+            focusRequester = focusRequester,
             searchBarState = searchBarState,
             textFieldState = textFieldState,
         )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
@@ -183,6 +184,8 @@ internal fun VerticalApplicationScreen(
             getEblanApplicationInfosByLabelAndTag.eblanApplicationInfoWithIconPackInfos.keys.distinctBy { it.eblanUser.serialNumber }
         }
 
+    val focusRequester = remember { FocusRequester() }
+
     ApplicationScreenEffect(
         horizontalPagerState = horizontalPagerState,
         isPressHome = isPressHome,
@@ -191,6 +194,8 @@ internal fun VerticalApplicationScreen(
         showPopupApplicationMenu = showPopupApplicationMenu,
         swipeY = swipeY,
         textFieldState = textFieldState,
+        showKeyboard = appDrawerSettings.showKeyboard,
+        focusRequester = focusRequester,
         onDismiss = onDismiss,
         onGetEblanApplicationInfosByLabel = onGetEblanApplicationInfosByLabel,
         onGetEblanApplicationInfosByTagId = onGetEblanApplicationInfosByTagId,
@@ -209,6 +214,7 @@ internal fun VerticalApplicationScreen(
             ),
     ) {
         ApplicationSearchBar(
+            focusRequester = focusRequester,
             searchBarState = searchBarState,
             textFieldState = textFieldState,
             onUpdateShowEblanApplicationInfoOrderDialog = {

--- a/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
+++ b/feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
@@ -213,6 +213,17 @@ private fun Success(
                     onUpdateAppDrawerSettings(appDrawerSettings.copy(excludeTaggedApps = it))
                 },
             )
+
+            HorizontalDivider(modifier = Modifier.fillMaxWidth())
+
+            SettingsSwitch(
+                checked = appDrawerSettings.showKeyboard,
+                title = stringResource(R.string.show_keyboard),
+                subtitle = stringResource(R.string.show_keyboard_when_app_drawer_opens),
+                onCheckedChange = {
+                    onUpdateAppDrawerSettings(appDrawerSettings.copy(showKeyboard = it))
+                },
+            )
         }
 
         GridItemSettings(

--- a/feature/settings/app-drawer/src/main/res/values/strings.xml
+++ b/feature/settings/app-drawer/src/main/res/values/strings.xml
@@ -27,4 +27,6 @@
     <string name="exclude_tagged_apps">Exclude Tagged Apps</string>
     <string name="hide_selected_apps_from_the_app_drawer">Hide selected apps from the app drawer</string>
     <string name="hide_apps_marked_with_selected_tags">Hide apps marked with selected tags</string>
+    <string name="show_keyboard">Show Keyboard</string>
+    <string name="show_keyboard_when_app_drawer_opens">Show keyboard when app drawer opens</string>
 </resources>


### PR DESCRIPTION
Closes #768 
Closes #662 

This commit introduces a new setting in the App Drawer settings that allows users to control whether the keyboard should be automatically shown when the app drawer opens.

The `showKeyboard` boolean is now included in `AppDrawerSettings` and is persisted through `UserDataSerializer` and `DataStoreMapper`. This setting defaults to `false`.

The `ApplicationScreenEffect` now takes `showKeyboard` and a `FocusRequester` as parameters. When `swipeY` is 0f and `showKeyboard` is true, the focus is requested and the keyboard is shown. The keyboard is also hidden and focus is cleared when the swipe gesture completes (`swipeY == screenHeight.toFloat()`).

Affected files:
- data/datastore-proto/src/main/proto/com/eblan/launcher/data/datastore/proto/appdrawer/app_drawer_settings.proto
- data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/UserDataSerializer.kt
- data/datastore/src/main/kotlin/com/eblan/launcher/data/datastore/mapper/DataStoreMapper.kt
- domain/model/src/main/kotlin/com/eblan/launcher/domain/model/AppDrawerSettings.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/SearchBar.kt
- feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
- feature/settings/app-drawer/src/main/kotlin/com/eblan/launcher/feature/settings/appdrawer/AppDrawerSettingsScreen.kt
- feature/settings/app-drawer/src/main/res/values/strings.xml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Show keyboard when app drawer opens” setting.
  * The app drawer can now automatically focus the search field and display the keyboard when opened.
  * Keyboard and search focus are cleared when the app drawer closes.
  * The setting is saved and restored with other app drawer preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->