### PR TITLE
refactor: Simplify app info retrieval and filtering logic (i886)

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/application/GetEblanApplicationInfosByLabelAndTagUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/application/GetEblanApplicationInfosByLabelAndTagUseCase.kt
@@ -176,15 +176,21 @@ class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
         tagId: Long?,
         eblanApplicationInfos: List<EblanApplicationInfo>,
     ): MutableList<EblanApplicationInfoWithIconPackInfo> {
-        val currentEblanApplicationInfos = if (tagId != null) {
-            eblanApplicationInfoRepository.getEblanApplicationInfosByTagId(id = tagId)
-        } else if (excludeTaggedApps) {
-            eblanApplicationInfoRepository.getEblanApplicationInfosWithoutTag()
-        } else {
-            eblanApplicationInfos
-        }
+        val eblanApplicationInfosByTag = when {
+            tagId != null -> {
+                eblanApplicationInfoRepository.getEblanApplicationInfosByTagId(id = tagId)
+            }
 
-        val fastMatchesEblanApplicationInfos = currentEblanApplicationInfos.filter {
+            excludeTaggedApps -> {
+                eblanApplicationInfoRepository.getEblanApplicationInfosWithoutTag()
+            }
+
+            else -> {
+                eblanApplicationInfos
+            }
+        }.filterNot { it.isHidden }
+
+        val eblanApplicationInfosByLabel = eblanApplicationInfosByTag.filter {
             it.label.startsWith(
                 prefix = label,
                 ignoreCase = true,
@@ -195,13 +201,13 @@ class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
         }
 
         val filterEblanApplicationInfos = when {
-            !fuzzySearch && fastMatchesEblanApplicationInfos.isEmpty() -> {
+            !fuzzySearch && eblanApplicationInfosByLabel.isEmpty() -> {
                 emptyList()
             }
 
             else -> {
                 val fuzzyMatches = if (fuzzySearch) {
-                    (currentEblanApplicationInfos - fastMatchesEblanApplicationInfos.toSet())
+                    (eblanApplicationInfosByTag - eblanApplicationInfosByLabel.toSet())
                         .map {
                             it to jaroWinklerSimilarityWrapper.apply(
                                 left = transliteratorWrapper.normalize(text = label),
@@ -215,7 +221,7 @@ class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
                     emptyList()
                 }
 
-                fastMatchesEblanApplicationInfos.sortedBy { it.label.lowercase() } + fuzzyMatches
+                eblanApplicationInfosByLabel.sortedBy { it.label.lowercase() } + fuzzyMatches
             }
         }
 


### PR DESCRIPTION
Fixes #886

This commit simplifies the logic for retrieving and filtering application information based on tags and exclusion settings.

The `GetEblanApplicationInfosByLabelAndTagUseCase` now uses a `when` statement for initial filtering by tag or exclusion, and then applies label-based filtering. Hidden applications are also excluded.

The fuzzy search logic is applied to the remaining applications after initial filtering, improving clarity and reducing code duplication.

Affected files:
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/application/GetEblanApplicationInfosByLabelAndTagUseCase.kt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application search filtering by consistently excluding hidden applications.
  * Refined exact and fuzzy label matching to provide more accurate results.
  * Ensured fuzzy search results are ordered after exact matches.
  * When fuzzy search is disabled, results now correctly return only exact label matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->