### PR TITLE
Another Regression On Folder

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -25,61 +25,6 @@
         <option name="selectionMode" value="DROPDOWN" />
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="Migration3To4Test">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-05-23T01:42:17.432439357Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_9a.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
-      <SelectionState runConfigName="Migration4To5Test">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-05-23T01:42:17.432439357Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_9a.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
-      <SelectionState runConfigName="Migration6To7Test">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-05-23T01:42:17.432439357Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_9a.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
-      <SelectionState runConfigName="Migration7To8Test">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-05-23T01:42:17.432439357Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_9a.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
-      <SelectionState runConfigName="Migration14To15Test">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-05-23T01:42:17.432439357Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_9a.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetGridItemsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetGridItemsUseCase.kt
@@ -41,39 +41,36 @@ class GetGridItemsUseCase @Inject constructor(
 
         val gridItems = gridRepository.getGridItems()
 
-        val currentApplicationGridItems =
-            gridItems.applicationInfoGridItems.map {
-                it.asGridItem(
-                    fileManager = fileManager,
-                    iconKeyGenerator = iconKeyGenerator,
-                    iconPackInfoPackageName = userData.generalSettings.iconPackInfoPackageName,
-                )
-            }
-
-        val currentWidgetGridItems = gridItems.widgetGridItems.map {
-            it.asGridItem()
-        }
-
-        val currentShortcutInfoGridItems =
-            gridItems.shortcutInfoGridItems.map {
-                it.asGridItem()
-            }
-
-        val currentShortcutConfigGridItems =
-            gridItems.shortcutConfigGridItems.map {
-                it.asGridItem()
-            }
-
-        val currentFolderGridItems = gridItems.folderGridItems.map {
-            it.asEmptyFolderGridItem()
-        }
-
         buildList {
-            addAll(currentApplicationGridItems)
-            addAll(currentWidgetGridItems)
-            addAll(currentShortcutInfoGridItems)
-            addAll(currentShortcutConfigGridItems)
-            addAll(currentFolderGridItems)
+            addAll(
+                gridItems.applicationInfoGridItems.map {
+                    it.asGridItem(
+                        fileManager = fileManager,
+                        iconKeyGenerator = iconKeyGenerator,
+                        iconPackInfoPackageName = userData.generalSettings.iconPackInfoPackageName,
+                    )
+                },
+            )
+            addAll(
+                gridItems.widgetGridItems.map {
+                    it.asGridItem()
+                },
+            )
+            addAll(
+                gridItems.shortcutInfoGridItems.map {
+                    it.asGridItem()
+                },
+            )
+            addAll(
+                gridItems.shortcutConfigGridItems.map {
+                    it.asGridItem()
+                },
+            )
+            addAll(
+                gridItems.folderGridItems.map {
+                    it.asEmptyFolderGridItem()
+                },
+            )
         }
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -619,8 +619,8 @@ internal class HomeViewModel @Inject constructor(
             moveGridItemJob?.cancelAndJoin()
 
             _folderPopupEntries.update { folderPopupEntries ->
-                folderPopupEntries.map { folderGridItemId ->
-                    folderGridItemId.copy(isCloseFolder = true)
+                folderPopupEntries.map { folderPopupEntry ->
+                    folderPopupEntry.copy(isCloseFolder = true)
                 }
             }
 
@@ -692,8 +692,8 @@ internal class HomeViewModel @Inject constructor(
     }
 
     fun deleteFolderPopupEntry(folderPopupEntry: FolderPopupEntry) {
-        _folderPopupEntries.update {
-            it - folderPopupEntry
+        _folderPopupEntries.update { folderPopupEntries ->
+            folderPopupEntries.filterNot { it.id == folderPopupEntry.id }
         }
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/HomeViewModel.kt
@@ -618,8 +618,8 @@ internal class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             moveGridItemJob?.cancelAndJoin()
 
-            _folderPopupEntries.update { folderGridItemIds ->
-                folderGridItemIds.map { folderGridItemId ->
+            _folderPopupEntries.update { folderPopupEntries ->
+                folderPopupEntries.map { folderGridItemId ->
                     folderGridItemId.copy(isCloseFolder = true)
                 }
             }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
@@ -307,7 +307,7 @@ internal fun handleDragFolderGridItem(
             folderGridHeightPx,
             currentPage,
         )
-    } else {
+    } else if (!folderPopup.folderPopupEntry.isCloseFolder) {
         onUpsertFolderPopupEntry(folderPopup.folderPopupEntry.copy(isCloseFolder = true))
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
@@ -174,7 +174,7 @@ internal fun handleDragFolderGridItem(
     dragIntOffset: IntOffset,
     currentPage: Int,
     folderPopup: FolderPopup,
-    folderPopupIntOffset: State<IntOffset>,
+    folderPopupIntOffset: IntOffset,
     isDragging: State<Boolean>,
     isVisibleOverlay: State<Boolean>,
     isScrollInProgress: Boolean,
@@ -186,7 +186,6 @@ internal fun handleDragFolderGridItem(
     layoutDirection: LayoutDirection,
     folderCellWidth: Int,
     folderCellHeight: Int,
-    folderPopupEntry: State<FolderPopupEntry>,
     isLastFolderGridItem: Boolean,
     onMoveFolderGridItem: (
         folderPopup: FolderPopup,
@@ -274,11 +273,11 @@ internal fun handleDragFolderGridItem(
         ).coerceAtLeast(minimumValue = topPadding)
 
     val endIntOffset = IntOffset(
-        x = folderPopupIntOffset.value.x.coerceIn(
+        x = folderPopupIntOffset.x.coerceIn(
             minimumValue = leftPadding,
             maximumValue = maximumX,
         ),
-        y = folderPopupIntOffset.value.y.coerceIn(
+        y = folderPopupIntOffset.y.coerceIn(
             minimumValue = topPadding,
             maximumValue = maximumY,
         ),
@@ -309,6 +308,6 @@ internal fun handleDragFolderGridItem(
             currentPage,
         )
     } else {
-        onUpsertFolderPopupEntry(folderPopupEntry.value.copy(isCloseFolder = true))
+        onUpsertFolderPopupEntry(folderPopup.folderPopupEntry.copy(isCloseFolder = true))
     }
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -274,8 +274,6 @@ internal fun FolderScreen(
     val currentIsVisibleOverlay = rememberUpdatedState(isVisibleOverlay)
     val currentMoveGridItemResult = rememberUpdatedState(moveGridItemResult)
     val currentLockMovement = rememberUpdatedState(lockMovement)
-    val currentFolderPopupEntry = rememberUpdatedState(folderPopup.folderPopupEntry)
-    val currentFolderPopupIntOffset = rememberUpdatedState(folderPopupIntOffset)
 
     LaunchedEffect(key1 = Unit) {
         progress.animateTo(targetValue = 1f)
@@ -303,7 +301,7 @@ internal fun FolderScreen(
     LaunchedEffect(
         drag,
         dragIntOffset,
-        folderPopup.gridItem,
+        folderPopup,
         moveGridItemResult,
         isLastFolderGridItem,
     ) {
@@ -313,7 +311,7 @@ internal fun FolderScreen(
             dragIntOffset = dragIntOffset,
             currentPage = folderGridHorizontalPagerState.currentPage,
             folderPopup = folderPopup,
-            folderPopupIntOffset = currentFolderPopupIntOffset,
+            folderPopupIntOffset = folderPopupIntOffset,
             isDragging = currentIsDragging,
             isVisibleOverlay = currentIsVisibleOverlay,
             isScrollInProgress = folderGridHorizontalPagerState.isScrollInProgress,
@@ -325,7 +323,6 @@ internal fun FolderScreen(
             layoutDirection = layoutDirection,
             folderCellWidth = folderCellWidth,
             folderCellHeight = folderCellHeight,
-            folderPopupEntry = currentFolderPopupEntry,
             isLastFolderGridItem = isLastFolderGridItem,
             onMoveFolderGridItem = onMoveFolderGridItem,
             onUpdateSharedElementKey = onUpdateSharedElementKey,
@@ -368,7 +365,7 @@ internal fun FolderScreen(
         drag,
         dragIntOffset,
         moveGridItemResult,
-        folderPopup.gridItem,
+        folderPopup,
         isLastFolderGridItem,
     ) {
         handleAnimateScrollToPage(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -293,7 +293,6 @@ internal fun FolderScreen(
             moveGridItemResult = currentMoveGridItemResult,
             folderPopup = folderPopup,
             progress = progress,
-            folderGridItem = folderPopup.gridItem,
             onAnimateToScrollToPage = folderGridHorizontalPagerState::animateScrollToPage,
             onDeleteFolderPopupEntry = onDeleteFolderPopupEntry,
             onMoveFolderGridItemOutsideFolder = onMoveFolderGridItemOutsideFolder,
@@ -575,7 +574,6 @@ private suspend fun handleFolderPopup(
     moveGridItemResult: State<MoveGridItemResult?>,
     folderPopup: FolderPopup,
     progress: Animatable<Float, AnimationVector1D>,
-    folderGridItem: GridItem,
     onAnimateToScrollToPage: suspend (Int) -> Unit,
     onDeleteFolderPopupEntry: (FolderPopupEntry) -> Unit,
     onMoveFolderGridItemOutsideFolder: (GridItem) -> Unit,
@@ -603,9 +601,9 @@ private suspend fun handleFolderPopup(
             val newGridItem = when (val data = gridItem.data) {
                 is GridItemData.ApplicationInfo -> {
                     gridItem.copy(
-                        page = folderGridItem.page,
-                        startColumn = folderGridItem.startColumn,
-                        startRow = folderGridItem.startRow,
+                        page = folderPopup.gridItem.page,
+                        startColumn = folderPopup.gridItem.startColumn,
+                        startRow = folderPopup.gridItem.startRow,
                         data = data.copy(
                             index = -1,
                             folderId = null,
@@ -615,9 +613,9 @@ private suspend fun handleFolderPopup(
 
                 is GridItemData.Folder -> {
                     gridItem.copy(
-                        page = folderGridItem.page,
-                        startColumn = folderGridItem.startColumn,
-                        startRow = folderGridItem.startRow,
+                        page = folderPopup.gridItem.page,
+                        startColumn = folderPopup.gridItem.startColumn,
+                        startRow = folderPopup.gridItem.startRow,
                         data = data.copy(
                             index = -1,
                             folderId = null,
@@ -627,9 +625,9 @@ private suspend fun handleFolderPopup(
 
                 is GridItemData.ShortcutConfig -> {
                     gridItem.copy(
-                        page = folderGridItem.page,
-                        startColumn = folderGridItem.startColumn,
-                        startRow = folderGridItem.startRow,
+                        page = folderPopup.gridItem.page,
+                        startColumn = folderPopup.gridItem.startColumn,
+                        startRow = folderPopup.gridItem.startRow,
                         data = data.copy(
                             index = -1,
                             folderId = null,
@@ -639,9 +637,9 @@ private suspend fun handleFolderPopup(
 
                 is GridItemData.ShortcutInfo -> {
                     gridItem.copy(
-                        page = folderGridItem.page,
-                        startColumn = folderGridItem.startColumn,
-                        startRow = folderGridItem.startRow,
+                        page = folderPopup.gridItem.page,
+                        startColumn = folderPopup.gridItem.startColumn,
+                        startRow = folderPopup.gridItem.startRow,
                         data = data.copy(
                             index = -1,
                             folderId = null,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -940,11 +940,11 @@ internal fun PagerScreen(
             )
         }
 
-        folderPopups.forEach { popupFolderGridItem ->
+        folderPopups.forEach { folderPopup ->
             FolderScreen(
                 sharedTransitionScope = this@SharedTransitionLayout,
                 drag = pagerScreenState.drag,
-                folderPopup = popupFolderGridItem,
+                folderPopup = folderPopup,
                 gridItemSettings = homeSettings.gridItemSettings,
                 paddingValues = paddingValues,
                 safeDrawingHeight = safeDrawingHeight,


### PR DESCRIPTION
Fixes #894 

This commit removes stale entries for migration tests from the `.idea/deploymentTargetSelector.xml` file. These entries were no longer relevant and have been cleaned up to maintain a cleaner configuration.

Affected files:
- .idea/deploymentTargetSelector.xml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item handling when closing a folder, preserving page and grid position as items move out.
  * Improved folder popup positioning and closing interactions during item movement.
  * Ensured all matching popup entries are removed when deleting an item.

* **Chores**
  * Removed obsolete deployment target selections from migration test configurations.
  * Simplified grid-item processing without changing ordering or conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->