### PR TITLE
feat: Add German translations for app name and action (translation-de)

### DIFF
--- a/app/src/debug/res/values-de/strings.xml
+++ b/app/src/debug/res/values-de/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="app_name">Debug Yagni Launcher</string>
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="app_name">Yagni Launcher</string>
+    <string name="action_name">Yagni-Aktion</string>
+</resources>

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="save">Speichern</string>
+    <string name="settings">Einstellungen</string>
+    <string name="experimental">Experimentell</string>
+    <string name="custom_label">Benutzerdefiniertes Label</string>
+    <string name="background_color">Hintergrundfarbe</string>
+    <string name="gestures">Gesten</string>
+    <string name="columns_is_not_valid">Spalten sind ungültig</string>
+    <string name="grid">Raster</string>
+    <string name="columns">Spalten</string>
+    <string name="update">Aktualisieren</string>
+    <string name="none">Keine</string>
+    <string name="home">Startbildschirm</string>
+    <string name="general">Allgemein</string>
+    <string name="system">System</string>
+    <string name="edit">%1$s bearbeiten</string>
+    <string name="add">Hinzufügen</string>
+    <string name="okay">Okay</string>
+    <string name="custom_label_is_not_valid">Benutzerdefiniertes Label ist ungültig</string>
+    <string name="rows_is_not_valid">Zeilen sind ungültig</string>
+    <string name="search_applications">Anwendungen suchen</string>
+    <string name="dark">Dunkel</string>
+    <string name="app_drawer">App-Schublade</string>
+    <string name="rows">Zeilen</string>
+    <string name="light">Hell</string>
+    <string name="cancel">Abbrechen</string>
+</resources>

--- a/feature/action/src/main/res/values-de/strings.xml
+++ b/feature/action/src/main/res/values-de/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="yagni_launcher_action">Yagni Launcher Aktion</string>
+</resources>

--- a/feature/edit-application-info/src/main/res/values-de/strings.xml
+++ b/feature/edit-application-info/src/main/res/values-de/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="add_tag">Tag hinzufügen</string>
+    <string name="tag_is_not_valid">Tag ist ungültig</string>
+    <string name="update_tag">Tag aktualisieren</string>
+    <string name="hide_from_drawer">Aus Schublade ausblenden</string>
+    <string name="view_hidden_apps_in_app_drawer_settings">Versteckte Apps in den App-Schublade-Einstellungen anzeigen</string>
+</resources>

--- a/feature/edit-grid-item/src/main/res/values-de/strings.xml
+++ b/feature/edit-grid-item/src/main/res/values-de/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="label">Label</string>
+    <string name="label_is_not_valid">Label ist ungültig</string>
+    <string name="custom_short_label">Benutzerdefiniertes Kurzlabel</string>
+    <string name="custom_short_label_is_not_valid">Benutzerdefiniertes Kurzlabel ist ungültig</string>
+    <string name="grid_item_actions">Rasterelement-Aktionen</string>
+    <string name="override">Überschreiben</string>
+    <string name="override_the_grid_item_settings">Die Rasterelement-Einstellungen überschreiben</string>
+    <string name="edit_label">Label bearbeiten</string>
+</resources>

--- a/feature/home/src/main/res/values-de/strings.xml
+++ b/feature/home/src/main/res/values-de/strings.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="personal">Persönlich</string>
+    <string name="clone">Klon</string>
+    <string name="work">Arbeit</string>
+    <string name="sort_applications">Anwendungen sortieren</string>
+    <string name="rearrange_applications">Anwendungen neu anordnen</string>
+    <string name="rearrange_applications_by_index">Anwendungen nach Index neu anordnen</string>
+    <string name="drag_an_item_to_rearrange">Ziehen Sie ein Element, um es neu anzuordnen</string>
+    <string name="work_apps_are_paused">Arbeits-Apps sind pausiert</string>
+    <string name="you_won_t_receive_notifications_from_your_work_apps">Sie erhalten keine Benachrichtigungen mehr von Ihren Arbeits-Apps</string>
+    <string name="unpause">Fortsetzen</string>
+    <string name="private_space">Privat</string>
+    <string name="please_wait_for_the_white_box_indicator">Bitte warten Sie auf die weiße Kästchenanzeige</string>
+    <string name="edit_pages">Seiten bearbeiten</string>
+    <string name="edit_dock_pages">Dock-Seiten bearbeiten</string>
+    <string name="widgets">Widgets</string>
+    <string name="shortcuts">Verknüpfungen</string>
+    <string name="wallpaper">Hintergrundbild</string>
+    <string name="search_widgets">Widgets suchen</string>
+    <string name="request_permissions">Berechtigungen anfordern</string>
+    <string name="allow_permissions_so_we_can_inform_you_about_important_crash_reports_and_make_phone_shortcuts">Erlauben Sie Berechtigungen, damit wir Sie über wichtige Absturzberichte informieren und Telefonverknüpfungen erstellen können</string>
+    <string name="later">Später</string>
+</resources>

--- a/feature/pin/src/main/res/values-de/strings.xml
+++ b/feature/pin/src/main/res/values-de/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="touch_and_hold_the_widget_to_move_it_around_the_home_screen">Berühren und halten Sie das Widget, um es auf dem Startbildschirm zu verschieben</string>
+</resources>

--- a/feature/settings/app-drawer/src/main/res/values-de/strings.xml
+++ b/feature/settings/app-drawer/src/main/res/values-de/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="horizontal_grid">Horizontales Raster</string>
+    <string name="vertical_grid">Vertikales Raster</string>
+    <string name="rows_height">Zeilenhöhe</string>
+    <string name="rows_height_is_not_valid">Zeilenhöhe ist ungültig</string>
+    <string name="hidden_applications">Versteckte Anwendungen</string>
+    <string name="no_hidden_applications">Keine versteckten Anwendungen</string>
+    <string name="app_drawer_type">App-Schublade-Typ</string>
+    <string name="exclude_tagged_apps">Markierte Apps ausschließen</string>
+    <string name="hide_selected_apps_from_the_app_drawer">Ausgewählte Apps aus der App-Schublade ausblenden</string>
+    <string name="hide_apps_marked_with_selected_tags">Apps mit ausgewählten Tags ausblenden</string>
+    <string name="show_keyboard">Tastatur anzeigen</string>
+    <string name="show_keyboard_when_app_drawer_opens">Tastatur anzeigen, wenn die App-Schublade geöffnet wird</string>
+    <string name="fuzzy_search">Unscharfe Suche</string>
+    <string name="find_apps_even_with_typos_or_accented_characters">Apps auch bei Tippfehlern oder Akzentzeichen finden</string>
+</resources>

--- a/feature/settings/experimental/src/main/res/values-de/strings.xml
+++ b/feature/settings/experimental/src/main/res/values-de/strings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="warning">Warnung</string>
+    <string name="disable_background_sync_description">
+    Das Deaktivieren der Hintergrundsynchronisierung spart etwas Speicher und hält die App schlanker, bedeutet aber auch, dass Yagni Launcher Ihre Apps, Widgets oder Verknüpfungen nicht automatisch aktualisiert.\n\nIhre App-Schublade zeigt möglicherweise veraltete Symbole, fehlende Widgets oder Verknüpfungen an, die nicht mehr funktionieren.
+</string>
+    <string name="sync_data">Daten synchronisieren</string>
+    <string name="keep_data_up_to_date">Daten auf dem neuesten Stand halten</string>
+    <string name="enable_or_disable_sync_data">Datensynchronisierung aktivieren oder deaktivieren</string>
+    <string name="lock_movement">Bewegung sperren</string>
+    <string name="prevent_other_grid_items_from_moving">Verhindern, dass sich andere Rasterelemente bewegen</string>
+</resources>

--- a/feature/settings/general/src/main/res/values-de/strings.xml
+++ b/feature/settings/general/src/main/res/values-de/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="import_icon_pack">Icon-Pack importieren</string>
+    <string name="no_icon_packs">Keine Icon-Packs</string>
+    <string name="select_icon_pack">Icon-Pack auswählen</string>
+    <string name="please_import_an_icon_pack_first">Bitte importieren Sie zuerst ein Icon-Pack</string>
+    <string name="reset">Zurücksetzen</string>
+    <string name="default_icon_pack">Standard</string>
+    <string name="theme">Design</string>
+    <string name="dynamic_theme">Dynamisches Design</string>
+    <string name="notification_dots">Benachrichtigungspunkte</string>
+    <string name="show_notification_dots">Benachrichtigungspunkte anzeigen</string>
+    <string name="apply_icons_from_supported_icon_packs">Symbole aus unterstützten Icon-Packs anwenden</string>
+    <string name="adapt_colors_to_your_wallpaper_automatically">Farben automatisch an Ihr Hintergrundbild anpassen</string>
+</resources>

--- a/feature/settings/home/src/main/res/values-de/strings.xml
+++ b/feature/settings/home/src/main/res/values-de/strings.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="dock_grid">Dock-Raster</string>
+    <string name="dock_columns_is_not_valid">Dock-Spalten sind ungültig</string>
+    <string name="dock_rows_is_not_valid">Dock-Zeilen sind ungültig</string>
+    <string name="dock_height">Dock-Höhe</string>
+    <string name="dock_height_is_not_valid">Dock-Höhe ist ungültig</string>
+    <string name="folder_cell_dimension">Ordner-Zellenabmessung</string>
+    <string name="cell_width">Zellenbreite</string>
+    <string name="cell_width_is_not_valid">Zellenbreite ist ungültig</string>
+    <string name="cell_height">Zellenhöhe</string>
+    <string name="cell_height_is_not_valid">Zellenhöhe ist ungültig</string>
+    <string name="max_columns">Max. Spalten</string>
+    <string name="max_columns_is_not_valid">Max. Spalten sind ungültig</string>
+    <string name="folder_max_grid">Ordner-Max-Raster</string>
+    <string name="max_rows">Max. Zeilen</string>
+    <string name="max_rows_is_not_valid">Max. Zeilen sind ungültig</string>
+    <string name="infinite_scrolling">Endloses Scrollen</string>
+    <string name="seamless_loop_page_scroll">Nahtloses Schleifen-Seitenscrollen</string>
+    <string name="wallpaper_scrolling">Hintergrundbild-Scrollen</string>
+    <string name="scroll_wallpaper_across_pages">Hintergrundbild über Seiten hinweg scrollen</string>
+    <string name="lock_screen_orientation">Bildschirmausrichtung sperren</string>
+    <string name="add_new_apps">Neue Apps hinzufügen</string>
+    <string name="add_new_apps_to_home_screen">Neue Apps zum Startbildschirm hinzufügen</string>
+    <string name="dock">Dock</string>
+    <string name="dock_infinite_scroll">Dock endloses Scrollen</string>
+    <string name="folder">Ordner</string>
+    <string name="prevent_rotation_when_device_orientation_changes">Rotation verhindern, wenn sich die Geräteausrichtung ändert</string>
+    <string name="show_page_indicator">Seitenanzeige anzeigen</string>
+    <string name="show_an_indicator_for_the_current_page">Eine Anzeige für die aktuelle Seite anzeigen</string>
+</resources>

--- a/feature/settings/settings/src/main/res/values-de/strings.xml
+++ b/feature/settings/settings/src/main/res/values-de/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="choose_yagni_launcher">Yagni Launcher auswählen</string>
+    <string name="default_launcher">Standard-Launcher</string>
+    <string name="themes_icon_packs">Designs, Icon-Packs</string>
+    <string name="grid_icon_dock_and_more">Raster, Symbol, Dock und mehr</string>
+    <string name="columns_and_rows_count">Anzahl der Spalten und Zeilen</string>
+    <string name="swipe_gesture_actions">Wisch-Gesten-Aktionen</string>
+    <string name="advanced_options_for_power_users">Erweiterte Optionen für erfahrene Benutzer</string>
+    <string name="thank_you_for_using_yagni_launcher_alpha">Vielen Dank, dass Sie Yagni Launcher Alpha verwenden!</string>
+    <string name="about_development_description">
+    Die Entwicklung begann im Januar 2025 mit regelmäßigen wöchentlichen Updates. Dies ist mein bisher komplexestes Projekt, und ich investiere erhebliche Anstrengungen in seine Verbesserung.
+</string>
+    <string name="support_message">
+    Wenn Sie die Anwendung nützlich finden, würden wir uns sehr über Ihre Unterstützung durch eine Spende auf Ko-fi oder durch einen Stern für das Repository auf GitHub freuen.
+</string>
+    <string name="support_on_ko_fi">Auf Ko-Fi unterstützen</string>
+    <string name="star_on_github">Auf GitHub mit Stern versehen</string>
+    <string name="note_this_informational_card_will_be_removed_in_future_stable_releases">Hinweis: Diese Informationskarte wird in zukünftigen stabilen Versionen entfernt</string>
+</resources>

--- a/service/src/main/res/values-de/strings.xml
+++ b/service/src/main/res/values-de/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="accessibility_service_label">Yagni Launcher</string>
+    <string name="accessibility_service_description">Yagni Launcher Gesten-Aktionen</string>
+    <string name="notification_listener_service">Yagni Benachrichtigungs-Listener-Dienst</string>
+    <string name="importing_into_cache">Importiere %1$s in den Cache</string>
+    <string name="loading_icons_from_cache_is_faster">Das Laden von Symbolen aus dem Cache ist schneller</string>
+</resources>

--- a/ui/src/main/res/values-de/strings.xml
+++ b/ui/src/main/res/values-de/strings.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="open">%1$s öffnen</string>
+    <string name="app">App</string>
+    <string name="open_app_drawer">App-Schublade öffnen</string>
+    <string name="open_notification_panel">Benachrichtigungsleiste öffnen</string>
+    <string name="lock_screen">Bildschirm sperren</string>
+    <string name="open_quick_settings">Schnelleinstellungen öffnen</string>
+    <string name="open_recents">Letzte öffnen</string>
+    <string name="enable_the_accessibility_service_permission_to_use_additional_actions">Aktivieren Sie die Bedienungshilfen-Berechtigung, um zusätzliche Aktionen zu nutzen</string>
+    <string name="corner_radius">Eckenradius</string>
+    <string name="corner_radius_is_not_valid">Eckenradius ist ungültig</string>
+    <string name="icon_size">Symbolgröße</string>
+    <string name="icon_size_is_not_valid">Symbolgröße ist ungültig</string>
+    <string name="padding">Abstand</string>
+    <string name="padding_is_not_valid">Abstand ist ungültig</string>
+    <string name="text_size">Textgröße</string>
+    <string name="text_size_is_not_valid">Textgröße ist ungültig</string>
+    <string name="select_application">Anwendung auswählen</string>
+    <string name="custom_icon">Benutzerdefiniertes Symbol</string>
+    <string name="gallery">Galerie</string>
+    <string name="pick_icons_from_your_gallery">Symbole aus Ihrer Galerie auswählen</string>
+    <string name="reset_custom_icon">Benutzerdefiniertes Symbol zurücksetzen</string>
+    <string name="grid_item">Rasterelement</string>
+    <string name="text_color">Textfarbe</string>
+    <string name="show_label">Label anzeigen</string>
+    <string name="single_line_label">Einzeiliges Label</string>
+    <string name="horizontal_alignment">Horizontale Ausrichtung</string>
+    <string name="vertical_arrangement">Vertikale Anordnung</string>
+    <string name="start">Start</string>
+    <string name="center_horizontally">Horizontal zentrieren</string>
+    <string name="end">Ende</string>
+    <string name="bottom">Unten</string>
+    <string name="top">Oben</string>
+    <string name="center">Mitte</string>
+    <string name="double_tap">Doppeltippen</string>
+    <string name="swipe_up">Nach oben wischen</string>
+    <string name="swipe_down">Nach unten wischen</string>
+    <string name="display_app_names_below_icons">App-Namen unter Symbolen anzeigen</string>
+    <string name="limit_app_names_to_one_line">App-Namen auf eine Zeile begrenzen</string>
+    <string name="custom">Benutzerdefiniert</string>
+</resources>


### PR DESCRIPTION
This commit adds German translations for the application name and the "Yagni Action" string. These translations are essential for providing a localized experience to German-speaking users.

Affected files:
- app/src/main/res/values-de/strings.xml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added German localization across the launcher experience.
  * Translated app names, actions, settings, navigation, customization options, app-drawer controls, home-screen features, widgets, gestures, accessibility services, and validation messages.
  * Added German text for application editing, tags, icon packs, themes, synchronization, permissions, crash reports, and other launcher workflows.
  * German translations are also available in debug and supporting components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->