### PR TITLE
refactor: Remove unnecessary ensureActive calls

### DIFF
--- a/domain/framework/src/main/kotlin/com/eblan/launcher/domain/framework/LauncherAppsWrapper.kt
+++ b/domain/framework/src/main/kotlin/com/eblan/launcher/domain/framework/LauncherAppsWrapper.kt
@@ -60,7 +60,7 @@ interface LauncherAppsWrapper {
         packageName: String,
     ): List<ShortcutConfigActivityInfo>
 
-    fun getUser(serialNumber: Long): EblanUser
+    suspend fun getUser(serialNumber: Long): EblanUser
 
     fun pinShortcuts(
         packageName: String,

--- a/domain/framework/src/main/kotlin/com/eblan/launcher/domain/framework/PackageManagerWrapper.kt
+++ b/domain/framework/src/main/kotlin/com/eblan/launcher/domain/framework/PackageManagerWrapper.kt
@@ -34,7 +34,7 @@ interface PackageManagerWrapper {
 
     suspend fun getIconPackInfos(): List<PackageManagerIconPackInfo>
 
-    fun getLastUpdateTime(packageName: String): Long
+    suspend fun getLastUpdateTime(packageName: String): Long
 
     fun isSystem(flags: Int): Boolean
 }

--- a/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/GridItemConstraints.kt
+++ b/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/GridItemConstraints.kt
@@ -80,7 +80,7 @@ fun getResolveDirectionByX(
     }
 }
 
-suspend fun getGridItemByCoordinates(
+fun getGridItemByCoordinates(
     id: String,
     gridItems: List<GridItem>,
     columns: Int,
@@ -95,8 +95,6 @@ suspend fun getGridItemByCoordinates(
     val cellHeight = gridHeight / rows
 
     return gridItems.find { gridItem ->
-        currentCoroutineContext().ensureActive()
-
         val startColumn = x / cellWidth
 
         val startRow = y / cellHeight
@@ -132,8 +130,6 @@ suspend fun findAvailableRegionByPage(
         currentCoroutineContext().ensureActive()
 
         for (row in 0..(rows - gridItem.rowSpan)) {
-            currentCoroutineContext().ensureActive()
-
             for (column in 0..(columns - gridItem.columnSpan)) {
                 val candidateGridItem = gridItem.copy(
                     page = page,
@@ -141,12 +137,10 @@ suspend fun findAvailableRegionByPage(
                     startRow = row,
                 )
 
-                val isFree = gridItems.none { otherGridItem ->
-                    currentCoroutineContext().ensureActive()
-
-                    otherGridItem.page == page && rectanglesOverlap(
+                val isFree = gridItems.none {
+                    it.page == page && rectanglesOverlap(
                         moving = candidateGridItem,
-                        other = otherGridItem,
+                        other = it,
                     )
                 }
 

--- a/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/MoveGridItem.kt
+++ b/domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/MoveGridItem.kt
@@ -45,8 +45,6 @@ suspend fun resolveConflicts(
         val current = gridItems[currentIndex]
 
         for (i in gridItems.indices) {
-            currentCoroutineContext().ensureActive()
-
             val other = gridItems[i]
 
             if (other.id == current.id) continue

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/application/GetEblanApplicationInfosByLabelAndTagUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/application/GetEblanApplicationInfosByLabelAndTagUseCase.kt
@@ -101,7 +101,7 @@ class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
         }
     }.flowOn(ioDispatcher)
 
-    private fun getVerticalOrListEblanApplicationInfosByLabel(eblanApplicationInfos: MutableList<EblanApplicationInfoWithIconPackInfo>): GetEblanApplicationInfosByLabelAndTag {
+    private suspend fun getVerticalOrListEblanApplicationInfosByLabel(eblanApplicationInfos: MutableList<EblanApplicationInfoWithIconPackInfo>): GetEblanApplicationInfosByLabelAndTag {
         val groupedEblanApplicationInfos = eblanApplicationInfos.groupBy {
             EblanUserPageKey(
                 eblanUser = launcherAppsWrapper.getUser(serialNumber = it.eblanApplicationInfo.serialNumber),
@@ -120,7 +120,7 @@ class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
         )
     }
 
-    private fun getHorizontalEblanApplicationInfosByLabel(
+    private suspend fun getHorizontalEblanApplicationInfosByLabel(
         horizontalAppDrawerColumns: Int,
         horizontalAppDrawerRows: Int,
         eblanApplicationInfosByLabel: MutableList<EblanApplicationInfoWithIconPackInfo>,

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
@@ -32,8 +32,6 @@ import com.eblan.launcher.domain.model.ShortcutConfigGridItem
 import com.eblan.launcher.domain.model.ShortcutInfoGridItem
 import com.eblan.launcher.domain.model.WidgetGridItem
 import com.eblan.launcher.domain.repository.FolderGridItemRepository
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
 import java.io.File
 import kotlin.math.ceil
 import kotlin.math.min
@@ -362,12 +360,10 @@ internal fun deleteGridItemCustomIconFile(gridItem: GridItem) = when (val data =
     else -> Unit
 }
 
-private suspend fun List<GridItem>.getGridItemsByPage(
+private fun List<GridItem>.getGridItemsByPage(
     maxFolderColumns: Int,
     maxFolderRows: Int,
 ): Map<Int, List<GridItem>> = chunked(maxFolderColumns * maxFolderRows).mapIndexed { index, gridItems ->
-    currentCoroutineContext().ensureActive()
-
     index to gridItems
 }.toMap()
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt
@@ -32,6 +32,8 @@ import com.eblan.launcher.domain.model.ShortcutConfigGridItem
 import com.eblan.launcher.domain.model.ShortcutInfoGridItem
 import com.eblan.launcher.domain.model.WidgetGridItem
 import com.eblan.launcher.domain.repository.FolderGridItemRepository
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import java.io.File
 import kotlin.math.ceil
 import kotlin.math.min
@@ -360,10 +362,12 @@ internal fun deleteGridItemCustomIconFile(gridItem: GridItem) = when (val data =
     else -> Unit
 }
 
-private fun List<GridItem>.getGridItemsByPage(
+private suspend fun List<GridItem>.getGridItemsByPage(
     maxFolderColumns: Int,
     maxFolderRows: Int,
 ): Map<Int, List<GridItem>> = chunked(maxFolderColumns * maxFolderRows).mapIndexed { index, gridItems ->
+    currentCoroutineContext().ensureActive()
+
     index to gridItems
 }.toMap()
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveFolderGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveFolderGridItemUseCase.kt
@@ -25,7 +25,6 @@ import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.MoveGridItemResult
 import com.eblan.launcher.domain.repository.GridRepository
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -57,8 +56,6 @@ class MoveFolderGridItemUseCase @Inject constructor(
 
         val movingIndex =
             folderGridItems.indexOfFirst {
-                ensureActive()
-
                 it.id == movingGridItem.id
             }
 
@@ -73,8 +70,6 @@ class MoveFolderGridItemUseCase @Inject constructor(
         }
 
         val indexedGridItems = folderGridItems.mapIndexed { index, gridItem ->
-            ensureActive()
-
             when (val data = gridItem.data) {
                 is GridItemData.ApplicationInfo -> gridItem.copy(data = data.copy(index = index))
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveGridItemUseCase.kt
@@ -30,7 +30,6 @@ import com.eblan.launcher.domain.model.MoveGridItemResult
 import com.eblan.launcher.domain.model.ResolveDirection
 import com.eblan.launcher.domain.repository.GridRepository
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -50,16 +49,12 @@ class MoveGridItemUseCase @Inject constructor(
     ): MoveGridItemResult {
         return withContext(defaultDispatcher) {
             val gridItemsByPage = getGridItemsUseCase().filter {
-                ensureActive()
-
                 it.isTopLevel() && it.page == movingGridItem.page &&
                     it.associate == movingGridItem.associate
             }.toMutableList()
 
             val index =
                 gridItemsByPage.indexOfFirst {
-                    ensureActive()
-
                     it.id == movingGridItem.id
                 }
 
@@ -93,8 +88,6 @@ class MoveGridItemUseCase @Inject constructor(
             }
 
             val conflictingGridItemBySpan = gridItemsByPage.find {
-                ensureActive()
-
                 it.id != movingGridItem.id && rectanglesOverlap(
                     moving = movingGridItem,
                     other = it,

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/ResizeGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/ResizeGridItemUseCase.kt
@@ -25,7 +25,6 @@ import com.eblan.launcher.domain.grid.resolveConflicts
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.repository.GridRepository
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -41,15 +40,12 @@ class ResizeGridItemUseCase @Inject constructor(
     ): GridItem = withContext(defaultDispatcher) {
         val gridItems =
             getGridItemsUseCase().filter {
-                ensureActive()
-
                 it.isTopLevel() && it.page == resizingGridItem.page &&
                     it.associate == resizingGridItem.associate
             }.toMutableList()
 
         val index =
             gridItems.indexOfFirst {
-                ensureActive()
                 it.id == resizingGridItem.id
             }
 
@@ -58,8 +54,6 @@ class ResizeGridItemUseCase @Inject constructor(
         gridItems[index] = resizingGridItem
 
         val gridItemBySpan = gridItems.find {
-            ensureActive()
-
             it.id != resizingGridItem.id && rectanglesOverlap(
                 moving = resizingGridItem,
                 other = it,

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/AddPackageUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/AddPackageUseCase.kt
@@ -81,8 +81,6 @@ class AddPackageUseCase @Inject constructor(
                 serialNumber = serialNumber,
                 packageName = packageName,
             ).onEach {
-                currentCoroutineContext().ensureActive()
-
                 addEblanApplicationInfo(
                     homeSettings = userData.homeSettings,
                     serialNumber = it.serialNumber,
@@ -184,8 +182,6 @@ class AddPackageUseCase @Inject constructor(
                 it.serialNumber == serialNumber &&
                     it.packageName == packageName
             }.map {
-                currentCoroutineContext().ensureActive()
-
                 it.toEblanAppWidgetProviderInfo(
                     fileManager = fileManager,
                     packageManagerWrapper = packageManagerWrapper,
@@ -207,8 +203,6 @@ class AddPackageUseCase @Inject constructor(
                 serialNumber = serialNumber,
                 packageName = packageName,
             )?.map {
-                currentCoroutineContext().ensureActive()
-
                 it.toEblanShortcutInfo()
             }
 
@@ -227,8 +221,6 @@ class AddPackageUseCase @Inject constructor(
             serialNumber = serialNumber,
             packageName = packageName,
         ).map {
-            currentCoroutineContext().ensureActive()
-
             it.toEblanShortcutConfig(
                 fileManager = fileManager,
                 packageManagerWrapper = packageManagerWrapper,

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangePackageUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangePackageUseCase.kt
@@ -122,8 +122,6 @@ class ChangePackageUseCase @Inject constructor(
                         serialNumber = launcherAppsActivityInfo.serialNumber,
                         packageName = launcherAppsActivityInfo.packageName,
                     ).map {
-                        currentCoroutineContext().ensureActive()
-
                         it.toEblanShortcutConfig(
                             fileManager = fileManager,
                             packageManagerWrapper = packageManagerWrapper,
@@ -146,7 +144,7 @@ class ChangePackageUseCase @Inject constructor(
                 oldSyncEblanApplicationInfosByPackageName.map {
                     it.toDeleteEblanApplicationInfo()
                 }
-                    .filter { it !in newDeleteEblanApplicationInfos }
+                    .filterNot { it in newDeleteEblanApplicationInfos }
 
             eblanApplicationInfoRepository.upsertSyncEblanApplicationInfos(
                 syncEblanApplicationInfos = newSyncEblanApplicationInfosByPackageName,
@@ -195,8 +193,6 @@ class ChangePackageUseCase @Inject constructor(
 
         val newEblanAppWidgetProviderInfosByPackageName =
             appWidgetManagerAppWidgetProviderInfosByPackageName.map {
-                currentCoroutineContext().ensureActive()
-
                 it.toEblanAppWidgetProviderInfo(
                     fileManager = fileManager,
                     packageManagerWrapper = packageManagerWrapper,
@@ -213,8 +209,8 @@ class ChangePackageUseCase @Inject constructor(
             val oldDeleteEblanAppWidgetProviderInfos =
                 oldEblanAppWidgetProviderInfosByPackageName.map {
                     it.toDeleteEblanAppWidgetProviderInfo()
-                }.filter {
-                    it !in newDeleteEblanAppWidgetProviderInfos
+                }.filterNot {
+                    it in newDeleteEblanAppWidgetProviderInfos
                 }
 
             eblanAppWidgetProviderInfoRepository.upsertEblanAppWidgetProviderInfos(
@@ -274,8 +270,8 @@ class ChangePackageUseCase @Inject constructor(
             val oldDeleteEblanShortcutInfos =
                 oldEblanShortcutInfosByPackageName.map {
                     it.toDeleteEblanShortcutInfo()
-                }.filter {
-                    it !in newDeleteEblanShortcutInfos
+                }.filterNot {
+                    it in newDeleteEblanShortcutInfos
                 }
 
             eblanShortcutInfoRepository.upsertEblanShortcutInfos(
@@ -320,8 +316,8 @@ class ChangePackageUseCase @Inject constructor(
             val oldDeleteEblanShortcutConfigs =
                 oldEblanShortcutConfigsByPackageName.map {
                     it.toDeleteEblanShortcutConfig()
-                }.filter {
-                    it !in newDeleteEblanShortcutConfigs
+                }.filterNot {
+                    it in newDeleteEblanShortcutConfigs
                 }
 
             eblanShortcutConfigRepository.upsertEblanShortcutConfigs(
@@ -403,8 +399,6 @@ class ChangePackageUseCase @Inject constructor(
         if (oldFastEblanLauncherAppsActivityInfo.toSet() != fastLauncherAppsActivityInfos.toSet()) {
             iconPackInfoDirectory.listFiles()
                 ?.filter {
-                    currentCoroutineContext().ensureActive()
-
                     it.isFile && it.name !in installedComponentHashCodes
                 }
                 ?.forEach {

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangeShortcutsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangeShortcutsUseCase.kt
@@ -28,7 +28,6 @@ import com.eblan.launcher.domain.repository.EblanShortcutInfoRepository
 import com.eblan.launcher.domain.repository.ShortcutInfoGridItemRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -65,8 +64,6 @@ class ChangeShortcutsUseCase @Inject constructor(
             )
 
             val newEblanShortcutInfos = launcherAppsShortcutInfos.map {
-                ensureActive()
-
                 it.toEblanShortcutInfo()
             }
 
@@ -77,8 +74,8 @@ class ChangeShortcutsUseCase @Inject constructor(
 
                 val oldDeleteEblanShortcutInfos = oldEblanShortcutInfos.map {
                     it.toDeleteEblanShortcutInfo()
-                }.filter {
-                    it !in newDeleteEblanShortcutInfos
+                }.filterNot {
+                    it in newDeleteEblanShortcutInfos
                 }
 
                 eblanShortcutInfoRepository.upsertEblanShortcutInfos(

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/LauncherAppsUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/LauncherAppsUtil.kt
@@ -74,12 +74,8 @@ internal suspend fun deleteEblanApplicationInfoIcons(
 
         val hasNoIconReference =
             icon != null && eblanApplicationInfos.none {
-                currentCoroutineContext().ensureActive()
-
                 it.icon == icon
             } && eblanAppWidgetProviderInfos.none {
-                currentCoroutineContext().ensureActive()
-
                 it.applicationIcon == icon
             }
 
@@ -105,12 +101,8 @@ internal suspend fun deleteEblanAppWidgetProviderInfoIcons(
 
         val hasNoIconReference =
             applicationIcon != null && eblanAppWidgetProviderInfos.none {
-                currentCoroutineContext().ensureActive()
-
                 it.applicationIcon == applicationIcon
             } && eblanApplicationInfos.none {
-                currentCoroutineContext().ensureActive()
-
                 it.icon == applicationIcon
             }
 
@@ -143,8 +135,6 @@ internal suspend fun deleteEblanShortInfoIcons(
 
         val hasNoIconReference =
             icon != null && eblanShortcutInfos.none {
-                currentCoroutineContext().ensureActive()
-
                 it.icon == icon
             }
 
@@ -186,15 +176,11 @@ internal suspend fun updateApplicationInfoGridItems(
         applicationInfoGridItemRepository.getApplicationInfoGridItems()
 
     applicationInfoGridItems.filterNot {
-        currentCoroutineContext().ensureActive()
-
         it.override
     }.forEach { applicationInfoGridItem ->
         currentCoroutineContext().ensureActive()
 
         val eblanApplicationInfo = eblanApplicationInfos.find {
-            currentCoroutineContext().ensureActive()
-
             it.serialNumber == applicationInfoGridItem.serialNumber && it.componentName == applicationInfoGridItem.componentName
         }
 
@@ -241,8 +227,6 @@ internal suspend fun updateShortcutInfoGridItems(
             currentCoroutineContext().ensureActive()
 
             val eblanShortcutInfo = eblanShortcutInfos.find {
-                currentCoroutineContext().ensureActive()
-
                 it.serialNumber == shortcutInfoGridItem.serialNumber && it.shortcutId == shortcutInfoGridItem.shortcutId
             }
 
@@ -295,8 +279,6 @@ internal suspend fun updateShortcutConfigGridItems(
         currentCoroutineContext().ensureActive()
 
         val eblanShortcutConfig = eblanShortcutConfigs.find {
-            currentCoroutineContext().ensureActive()
-
             it.serialNumber == shortcutConfigGridItem.serialNumber && it.componentName == shortcutConfigGridItem.componentName
         }
 
@@ -355,8 +337,6 @@ internal suspend fun updateWidgetGridItems(
 
         val eblanAppWidgetProviderInfo =
             eblanAppWidgetProviderInfos.find {
-                currentCoroutineContext().ensureActive()
-
                 it.serialNumber == widgetGridItem.serialNumber && it.componentName == widgetGridItem.componentName
             }
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/RemovePackageUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/RemovePackageUseCase.kt
@@ -182,8 +182,6 @@ class RemovePackageUseCase @Inject constructor(
 
         val hasNoIconPackInfoReference = eblanApplicationInfoRepository.getEblanApplicationInfos()
             .none {
-                currentCoroutineContext().ensureActive()
-
                 it.componentName == componentName
             }
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
@@ -125,8 +125,6 @@ class SyncDataUseCase @Inject constructor(
     ) {
         val oldFastEblanLauncherAppsActivityInfo =
             eblanApplicationInfoRepository.getEblanApplicationInfos().map {
-                currentCoroutineContext().ensureActive()
-
                 it.toFastLauncherAppsActivityInfo()
             }
 
@@ -138,8 +136,6 @@ class SyncDataUseCase @Inject constructor(
 
         val oldSyncEblanApplicationInfos =
             eblanApplicationInfoRepository.getEblanApplicationInfos().map {
-                currentCoroutineContext().ensureActive()
-
                 it.toSyncEblanApplicationInfo()
             }
 
@@ -152,8 +148,6 @@ class SyncDataUseCase @Inject constructor(
                         serialNumber = launcherAppsActivityInfo.serialNumber,
                         packageName = launcherAppsActivityInfo.packageName,
                     ).map {
-                        currentCoroutineContext().ensureActive()
-
                         it.toEblanShortcutConfig(
                             fileManager = fileManager,
                             packageManagerWrapper = packageManagerWrapper,
@@ -177,20 +171,14 @@ class SyncDataUseCase @Inject constructor(
 
         val newDeleteEblanApplicationInfos =
             newSyncEblanApplicationInfos.map {
-                currentCoroutineContext().ensureActive()
-
                 it.toDeleteEblanApplicationInfo()
             }.toSet()
 
         val oldDeleteEblanApplicationInfos =
             oldSyncEblanApplicationInfos.map {
-                currentCoroutineContext().ensureActive()
-
                 it.toDeleteEblanApplicationInfo()
-            }.filter {
-                currentCoroutineContext().ensureActive()
-
-                it !in newDeleteEblanApplicationInfos
+            }.filterNot {
+                it in newDeleteEblanApplicationInfos
             }
 
         eblanApplicationInfoRepository.upsertSyncEblanApplicationInfos(
@@ -246,8 +234,6 @@ class SyncDataUseCase @Inject constructor(
 
                 packageManagerWrapper.isSystem(flags = it.flags)
             }.map {
-                currentCoroutineContext().ensureActive()
-
                 it.asAddNewEblanApplicationInfo()
             }
 
@@ -257,8 +243,6 @@ class SyncDataUseCase @Inject constructor(
 
                 packageManagerWrapper.isSystem(flags = it.flags)
             }.map {
-                currentCoroutineContext().ensureActive()
-
                 it.asAddNewEblanApplicationInfo()
             }
 
@@ -266,6 +250,8 @@ class SyncDataUseCase @Inject constructor(
             newAddNewEblanApplicationInfos - oldAddNewEblanApplicationInfos.toSet()
 
         addNewEblanApplicationInfos.forEach {
+            currentCoroutineContext().ensureActive()
+
             addNewApplicationToHomeScreen(
                 gridItems = gridItems,
                 componentName = it.componentName,
@@ -287,26 +273,24 @@ class SyncDataUseCase @Inject constructor(
 
         val oldFastAppWidgetManagerAppWidgetProviderInfos =
             eblanAppWidgetProviderInfoRepository.getEblanAppWidgetProviderInfos()
-                .map { eblanAppWidgetProviderInfo ->
-                    currentCoroutineContext().ensureActive()
-
+                .map {
                     FastAppWidgetManagerAppWidgetProviderInfo(
-                        componentName = eblanAppWidgetProviderInfo.componentName,
-                        serialNumber = eblanAppWidgetProviderInfo.serialNumber,
-                        configure = eblanAppWidgetProviderInfo.configure,
-                        packageName = eblanAppWidgetProviderInfo.packageName,
-                        targetCellWidth = eblanAppWidgetProviderInfo.targetCellWidth,
-                        targetCellHeight = eblanAppWidgetProviderInfo.targetCellHeight,
-                        minWidth = eblanAppWidgetProviderInfo.minWidth,
-                        minHeight = eblanAppWidgetProviderInfo.minHeight,
-                        resizeMode = eblanAppWidgetProviderInfo.resizeMode,
-                        minResizeWidth = eblanAppWidgetProviderInfo.minResizeWidth,
-                        minResizeHeight = eblanAppWidgetProviderInfo.minResizeHeight,
-                        maxResizeWidth = eblanAppWidgetProviderInfo.maxResizeWidth,
-                        maxResizeHeight = eblanAppWidgetProviderInfo.maxResizeHeight,
-                        lastUpdateTime = eblanAppWidgetProviderInfo.lastUpdateTime,
-                        label = eblanAppWidgetProviderInfo.label,
-                        description = eblanAppWidgetProviderInfo.description,
+                        componentName = it.componentName,
+                        serialNumber = it.serialNumber,
+                        configure = it.configure,
+                        packageName = it.packageName,
+                        targetCellWidth = it.targetCellWidth,
+                        targetCellHeight = it.targetCellHeight,
+                        minWidth = it.minWidth,
+                        minHeight = it.minHeight,
+                        resizeMode = it.resizeMode,
+                        minResizeWidth = it.minResizeWidth,
+                        minResizeHeight = it.minResizeHeight,
+                        maxResizeWidth = it.maxResizeWidth,
+                        maxResizeHeight = it.maxResizeHeight,
+                        lastUpdateTime = it.lastUpdateTime,
+                        label = it.label,
+                        description = it.description,
                     )
                 }
 
@@ -322,8 +306,6 @@ class SyncDataUseCase @Inject constructor(
 
         val newEblanAppWidgetProviderInfos =
             appWidgetManagerAppWidgetProviderInfos.map {
-                currentCoroutineContext().ensureActive()
-
                 it.toEblanAppWidgetProviderInfo(
                     fileManager = fileManager,
                     packageManagerWrapper = packageManagerWrapper,
@@ -333,20 +315,14 @@ class SyncDataUseCase @Inject constructor(
 
         val newDeleteEblanAppWidgetProviderInfos =
             newEblanAppWidgetProviderInfos.map {
-                currentCoroutineContext().ensureActive()
-
                 it.toDeleteEblanAppWidgetProviderInfo()
             }.toSet()
 
         val oldDeleteEblanAppWidgetProviderInfos =
             oldEblanAppWidgetProviderInfos.map {
-                currentCoroutineContext().ensureActive()
-
                 it.toDeleteEblanAppWidgetProviderInfo()
-            }.filter {
-                currentCoroutineContext().ensureActive()
-
-                it !in newDeleteEblanAppWidgetProviderInfos
+            }.filterNot {
+                it in newDeleteEblanAppWidgetProviderInfos
             }
 
         eblanAppWidgetProviderInfoRepository.upsertEblanAppWidgetProviderInfos(
@@ -377,8 +353,6 @@ class SyncDataUseCase @Inject constructor(
 
         val oldFastLauncherAppsShortcutInfos =
             eblanShortcutInfoRepository.getEblanShortcutInfos().map {
-                currentCoroutineContext().ensureActive()
-
                 FastLauncherAppsShortcutInfo(
                     packageName = it.packageName,
                     serialNumber = it.serialNumber,
@@ -396,25 +370,17 @@ class SyncDataUseCase @Inject constructor(
         val oldEblanShortcutInfos = eblanShortcutInfoRepository.getEblanShortcutInfos()
 
         val newEblanShortcutInfos = launcherAppsShortcutInfos.map {
-            currentCoroutineContext().ensureActive()
-
             it.toEblanShortcutInfo()
         }
 
         val newDeleteEblanShortcutInfos = newEblanShortcutInfos.map {
-            currentCoroutineContext().ensureActive()
-
             it.toDeleteEblanShortcutInfo()
         }.toSet()
 
         val oldDeleteEblanShortcutInfos = oldEblanShortcutInfos.map {
-            currentCoroutineContext().ensureActive()
-
             it.toDeleteEblanShortcutInfo()
-        }.filter {
-            currentCoroutineContext().ensureActive()
-
-            it !in newDeleteEblanShortcutInfos
+        }.filterNot {
+            it in newDeleteEblanShortcutInfos
         }
 
         eblanShortcutInfoRepository.upsertEblanShortcutInfos(
@@ -447,19 +413,13 @@ class SyncDataUseCase @Inject constructor(
         if (oldEblanShortcutConfigs.toSet() == newEblanShortcutConfigs) return
 
         val newDeleteEblanShortcutConfigs = newEblanShortcutConfigs.map {
-            currentCoroutineContext().ensureActive()
-
             it.toDeleteEblanShortcutConfig()
         }.toSet()
 
         val oldDeleteEblanShortcutConfigs = oldEblanShortcutConfigs.map {
-            currentCoroutineContext().ensureActive()
-
             it.toDeleteEblanShortcutConfig()
-        }.filter {
-            currentCoroutineContext().ensureActive()
-
-            it !in newDeleteEblanShortcutConfigs
+        }.filterNot {
+            it in newDeleteEblanShortcutConfigs
         }
 
         eblanShortcutConfigRepository.upsertEblanShortcutConfigs(

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/CachePageItemsUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/page/CachePageItemsUseCase.kt
@@ -65,7 +65,7 @@ class CachePageItemsUseCase @Inject constructor(
         (0 until pageCount).map {
             PageItem(
                 id = it,
-                gridItems = gridItemsByPage[it] ?: emptyList(),
+                gridItems = gridItemsByPage[it].orEmpty(),
             )
         }
     }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/util/IconPackInfoUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/util/IconPackInfoUtil.kt
@@ -65,8 +65,6 @@ internal suspend fun updateIconPackInfos(
 
     iconPackInfoDirectory.listFiles()
         ?.filter {
-            currentCoroutineContext().ensureActive()
-
             it.isFile && it.name !in installedComponentHashCodes
         }
         ?.forEach {
@@ -84,14 +82,12 @@ internal suspend fun cacheIconPackFile(
     componentName: String,
 ) {
     appFilter.find {
-        currentCoroutineContext().ensureActive()
-
         componentName == it.componentName.removePrefix("ComponentInfo{")
             .removeSuffix("}")
-    }?.let { iconPackInfoComponent ->
+    }?.let {
         iconPackManager.createIconPackInfoPath(
             packageName = iconPackInfoPackageName,
-            drawableName = iconPackInfoComponent.drawableName,
+            drawableName = it.drawableName,
             file = file,
         )
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -67,9 +67,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.repeatOnLifecycle
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.AppDrawerSettings
 import com.eblan.launcher.domain.model.AppDrawerType
@@ -95,8 +92,8 @@ import com.eblan.launcher.feature.home.screen.HomeHandler
 import com.eblan.launcher.feature.home.screen.application.horizontal.HorizontalApplicationScreen
 import com.eblan.launcher.feature.home.screen.application.list.ListApplicationScreen
 import com.eblan.launcher.feature.home.screen.application.vertical.VerticalApplicationScreen
-import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
+import com.eblan.launcher.ui.settings.rememberIsDefaultLauncher
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
@@ -480,18 +477,6 @@ internal fun ApplicationScreenEffect(
 
     HomeHandler(enabled = swipeY < screenHeight.toFloat()) {
         onDismiss()
-    }
-}
-
-@Composable
-internal fun rememberIsDefaultLauncher(): State<Boolean> {
-    val packageManager = LocalPackageManager.current
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    return produceState(initialValue = false, key1 = lifecycleOwner) {
-        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-            value = packageManager.isDefaultLauncher()
-        }
     }
 }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -80,6 +80,7 @@ import com.eblan.launcher.domain.model.EblanApplicationInfoTag
 import com.eblan.launcher.domain.model.EblanApplicationInfoWithIconPackInfo
 import com.eblan.launcher.domain.model.EblanShortcutInfo
 import com.eblan.launcher.domain.model.EblanShortcutInfoByGroup
+import com.eblan.launcher.domain.model.EblanUser
 import com.eblan.launcher.domain.model.EblanUserPageKey
 import com.eblan.launcher.domain.model.EblanUserType
 import com.eblan.launcher.domain.model.GetEblanApplicationInfosByLabelAndTag
@@ -281,6 +282,8 @@ internal fun QuiteModeScreen(
     onDragEnd: () -> Unit,
     onVerticalDrag: (Float) -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
+
     val userManager = LocalUserManager.current
 
     val isDefaultLauncher by rememberIsDefaultLauncher()
@@ -316,10 +319,12 @@ internal fun QuiteModeScreen(
 
             OutlinedButton(
                 onClick = {
-                    userManager.requestQuietModeEnabled(
-                        enableQuiteMode = false,
-                        userHandle = userHandle,
-                    )
+                    scope.launch {
+                        userManager.requestQuietModeEnabled(
+                            enableQuiteMode = false,
+                            userHandle = userHandle,
+                        )
+                    }
                 },
             ) {
                 Text(text = stringResource(R.string.unpause))
@@ -494,7 +499,7 @@ internal fun rememberIsDefaultLauncher(): State<Boolean> {
 internal fun rememberIsQuietModeEnabled(
     userHandle: UserHandle?,
     managedProfileResult: ManagedProfileResult?,
-    eblanUserPageKey: EblanUserPageKey,
+    eblanUser: EblanUser?,
 ): State<Boolean> {
     val userManager = LocalUserManager.current
 
@@ -508,7 +513,7 @@ internal fun rememberIsQuietModeEnabled(
         }
 
         if (managedProfileResult != null &&
-            managedProfileResult.serialNumber == eblanUserPageKey.eblanUser.serialNumber
+            managedProfileResult.serialNumber == eblanUser?.serialNumber
         ) {
             value = managedProfileResult.isQuiteModeEnabled
         }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -46,6 +46,9 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
@@ -64,6 +67,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.AppDrawerSettings
 import com.eblan.launcher.domain.model.AppDrawerType
@@ -88,8 +94,8 @@ import com.eblan.launcher.feature.home.screen.HomeHandler
 import com.eblan.launcher.feature.home.screen.application.horizontal.HorizontalApplicationScreen
 import com.eblan.launcher.feature.home.screen.application.list.ListApplicationScreen
 import com.eblan.launcher.feature.home.screen.application.vertical.VerticalApplicationScreen
-import com.eblan.launcher.framework.packagemanager.AndroidPackageManagerWrapper
-import com.eblan.launcher.framework.usermanager.AndroidUserManagerWrapper
+import com.eblan.launcher.ui.local.LocalPackageManager
+import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
@@ -271,13 +277,14 @@ internal fun ApplicationScreen(
 @Composable
 internal fun QuiteModeScreen(
     modifier: Modifier = Modifier,
-    packageManager: AndroidPackageManagerWrapper,
     userHandle: UserHandle?,
-    userManager: AndroidUserManagerWrapper,
     onDragEnd: () -> Unit,
-    onUpdateRequestQuietModeEnabled: (Boolean) -> Unit,
     onVerticalDrag: (Float) -> Unit,
 ) {
+    val userManager = LocalUserManager.current
+
+    val isDefaultLauncher by rememberIsDefaultLauncher()
+
     Column(
         modifier = modifier
             .pointerInput(key1 = Unit) {
@@ -304,7 +311,7 @@ internal fun QuiteModeScreen(
             textAlign = TextAlign.Center,
         )
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && packageManager.isDefaultLauncher() && userHandle != null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDefaultLauncher && userHandle != null) {
             Spacer(modifier = Modifier.height(10.dp))
 
             OutlinedButton(
@@ -313,8 +320,6 @@ internal fun QuiteModeScreen(
                         enableQuiteMode = false,
                         userHandle = userHandle,
                     )
-
-                    onUpdateRequestQuietModeEnabled(userManager.isQuietModeEnabled(userHandle = userHandle))
                 },
             ) {
                 Text(text = stringResource(R.string.unpause))
@@ -470,6 +475,43 @@ internal fun ApplicationScreenEffect(
 
     HomeHandler(enabled = swipeY < screenHeight.toFloat()) {
         onDismiss()
+    }
+}
+
+@Composable
+internal fun rememberIsDefaultLauncher(): State<Boolean> {
+    val packageManager = LocalPackageManager.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    return produceState(initialValue = false, key1 = lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            value = packageManager.isDefaultLauncher()
+        }
+    }
+}
+
+@Composable
+internal fun rememberIsQuietModeEnabled(
+    userHandle: UserHandle?,
+    managedProfileResult: ManagedProfileResult?,
+    eblanUserPageKey: EblanUserPageKey,
+): State<Boolean> {
+    val userManager = LocalUserManager.current
+
+    return produceState(
+        initialValue = false,
+        key1 = userHandle,
+        key2 = managedProfileResult,
+    ) {
+        if (userHandle != null) {
+            value = userManager.isQuietModeEnabled(userHandle = userHandle)
+        }
+
+        if (managedProfileResult != null &&
+            managedProfileResult.serialNumber == eblanUserPageKey.eblanUser.serialNumber
+        ) {
+            value = managedProfileResult.isQuiteModeEnabled
+        }
     }
 }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
@@ -81,6 +81,7 @@ import com.eblan.launcher.feature.home.screen.getVerticalArrangement
 import com.eblan.launcher.feature.home.util.getSystemTextColor
 import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalUserManager
+import com.eblan.launcher.ui.settings.rememberIsDefaultLauncher
 import kotlinx.coroutines.launch
 import kotlin.uuid.ExperimentalUuidApi
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -76,7 +75,6 @@ import com.eblan.launcher.domain.model.AppDrawerSettings
 import com.eblan.launcher.domain.model.EblanApplicationInfo
 import com.eblan.launcher.domain.model.EblanApplicationInfoWithIconPackInfo
 import com.eblan.launcher.domain.model.EblanUser
-import com.eblan.launcher.domain.model.ManagedProfileResult
 import com.eblan.launcher.feature.home.R
 import com.eblan.launcher.feature.home.screen.getHorizontalAlignment
 import com.eblan.launcher.feature.home.screen.getVerticalArrangement
@@ -89,12 +87,10 @@ import kotlin.uuid.ExperimentalUuidApi
 internal fun LazyGridScope.privateSpace(
     appDrawerSettings: AppDrawerSettings,
     isQuietModeEnabled: Boolean,
-    managedProfileResult: ManagedProfileResult?,
     paddingValues: PaddingValues,
     privateEblanApplicationInfoWithIconPackInfos: List<EblanApplicationInfoWithIconPackInfo>,
     privateEblanUser: EblanUser?,
     isVisibleOverlay: Boolean,
-    onUpdateIsQuietModeEnabled: (Boolean) -> Unit,
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
@@ -106,10 +102,8 @@ internal fun LazyGridScope.privateSpace(
 
     stickyHeader {
         PrivateSpaceStickyHeader(
+            serialNumber = privateEblanUser.serialNumber,
             isQuietModeEnabled = isQuietModeEnabled,
-            managedProfileResult = managedProfileResult,
-            privateEblanUser = privateEblanUser,
-            onUpdateIsQuietModeEnabled = onUpdateIsQuietModeEnabled,
         )
     }
 
@@ -131,37 +125,23 @@ internal fun LazyGridScope.privateSpace(
 @Composable
 internal fun PrivateSpaceStickyHeader(
     modifier: Modifier = Modifier,
+    serialNumber: Long,
     isQuietModeEnabled: Boolean,
-    managedProfileResult: ManagedProfileResult?,
-    privateEblanUser: EblanUser?,
-    onUpdateIsQuietModeEnabled: (Boolean) -> Unit,
 ) {
-    if (privateEblanUser == null) return
+    val scope = rememberCoroutineScope()
 
     val userManager = LocalUserManager.current
 
     val launcherApps = LocalLauncherApps.current
 
     val userHandle =
-        userManager.getUserForSerialNumber(serialNumber = privateEblanUser.serialNumber)
+        userManager.getUserForSerialNumber(serialNumber = serialNumber)
 
     val privateSpaceLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartIntentSenderForResult(),
     ) {}
 
     val isDefaultLauncher by rememberIsDefaultLauncher()
-
-    LaunchedEffect(key1 = userHandle) {
-        if (userHandle != null) {
-            onUpdateIsQuietModeEnabled(userManager.isQuietModeEnabled(userHandle = userHandle))
-        }
-    }
-
-    LaunchedEffect(key1 = managedProfileResult) {
-        if (managedProfileResult != null && managedProfileResult.serialNumber == privateEblanUser.serialNumber) {
-            onUpdateIsQuietModeEnabled(managedProfileResult.isQuiteModeEnabled)
-        }
-    }
 
     Row(
         modifier = modifier
@@ -193,12 +173,12 @@ internal fun PrivateSpaceStickyHeader(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDefaultLauncher && userHandle != null) {
                 IconButton(
                     onClick = {
-                        userManager.requestQuietModeEnabled(
-                            enableQuiteMode = !isQuietModeEnabled,
-                            userHandle = userHandle,
-                        )
-
-                        onUpdateIsQuietModeEnabled(userManager.isQuietModeEnabled(userHandle))
+                        scope.launch {
+                            userManager.requestQuietModeEnabled(
+                                enableQuiteMode = !isQuietModeEnabled,
+                                userHandle = userHandle,
+                            )
+                        }
                     },
                 ) {
                     Icon(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
@@ -82,7 +82,6 @@ import com.eblan.launcher.feature.home.screen.getHorizontalAlignment
 import com.eblan.launcher.feature.home.screen.getVerticalArrangement
 import com.eblan.launcher.feature.home.util.getSystemTextColor
 import com.eblan.launcher.ui.local.LocalLauncherApps
-import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.launch
 import kotlin.uuid.ExperimentalUuidApi
@@ -141,8 +140,6 @@ internal fun PrivateSpaceStickyHeader(
 
     val userManager = LocalUserManager.current
 
-    val packageManager = LocalPackageManager.current
-
     val launcherApps = LocalLauncherApps.current
 
     val userHandle =
@@ -151,6 +148,8 @@ internal fun PrivateSpaceStickyHeader(
     val privateSpaceLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartIntentSenderForResult(),
     ) {}
+
+    val isDefaultLauncher by rememberIsDefaultLauncher()
 
     LaunchedEffect(key1 = userHandle) {
         if (userHandle != null) {
@@ -191,7 +190,7 @@ internal fun PrivateSpaceStickyHeader(
                 }
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && packageManager.isDefaultLauncher() && userHandle != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDefaultLauncher && userHandle != null) {
                 IconButton(
                     onClick = {
                         userManager.requestQuietModeEnabled(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -81,10 +81,10 @@ import com.eblan.launcher.feature.home.screen.application.PrivateApplicationInfo
 import com.eblan.launcher.feature.home.screen.application.PrivateSpaceEblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.QuiteModeScreen
 import com.eblan.launcher.feature.home.screen.application.TagElevatedFilterChip
-import com.eblan.launcher.feature.home.screen.application.rememberIsDefaultLauncher
 import com.eblan.launcher.feature.home.screen.application.rememberIsQuietModeEnabled
 import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalUserManager
+import com.eblan.launcher.ui.settings.rememberIsDefaultLauncher
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.launch
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -83,9 +84,9 @@ import com.eblan.launcher.feature.home.screen.application.TagElevatedFilterChip
 import com.eblan.launcher.feature.home.screen.application.rememberIsDefaultLauncher
 import com.eblan.launcher.feature.home.screen.application.rememberIsQuietModeEnabled
 import com.eblan.launcher.ui.local.LocalLauncherApps
-import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class, FlowPreview::class)
 @Composable
@@ -382,9 +383,9 @@ private fun EblanApplicationInfosPage(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
 ) {
-    val userManager = LocalUserManager.current
+    val scope = rememberCoroutineScope()
 
-    val packageManager = LocalPackageManager.current
+    val userManager = LocalUserManager.current
 
     val eblanUserPageKey =
         getEblanApplicationInfosByLabelAndTag.eblanApplicationInfoWithIconPackInfos.keys.toList()
@@ -410,7 +411,7 @@ private fun EblanApplicationInfosPage(
     val isQuietModeEnabled by rememberIsQuietModeEnabled(
         userHandle = userHandle,
         managedProfileResult = managedProfileResult,
-        eblanUserPageKey = eblanUserPageKey,
+        eblanUser = eblanUserPageKey.eblanUser,
     )
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -457,10 +458,12 @@ private fun EblanApplicationInfosPage(
                             bottom = paddingValues.calculateBottomPadding() + 10.dp,
                         ),
                     onClick = {
-                        userManager.requestQuietModeEnabled(
-                            enableQuiteMode = true,
-                            userHandle = userHandle,
-                        )
+                        scope.launch {
+                            userManager.requestQuietModeEnabled(
+                                enableQuiteMode = true,
+                                userHandle = userHandle,
+                            )
+                        }
                     },
                 ) {
                     Icon(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,6 +80,8 @@ import com.eblan.launcher.feature.home.screen.application.PrivateApplicationInfo
 import com.eblan.launcher.feature.home.screen.application.PrivateSpaceEblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.QuiteModeScreen
 import com.eblan.launcher.feature.home.screen.application.TagElevatedFilterChip
+import com.eblan.launcher.feature.home.screen.application.rememberIsDefaultLauncher
+import com.eblan.launcher.feature.home.screen.application.rememberIsQuietModeEnabled
 import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
@@ -404,30 +405,19 @@ private fun EblanApplicationInfosPage(
     val userHandle =
         userManager.getUserForSerialNumber(serialNumber = eblanUserPageKey.eblanUser.serialNumber)
 
-    var isQuietModeEnabled by remember { mutableStateOf(false) }
+    val isDefaultLauncher by rememberIsDefaultLauncher()
 
-    LaunchedEffect(key1 = userHandle) {
-        if (userHandle != null) {
-            isQuietModeEnabled = userManager.isQuietModeEnabled(userHandle = userHandle)
-        }
-    }
-
-    LaunchedEffect(key1 = managedProfileResult) {
-        if (managedProfileResult != null && managedProfileResult.serialNumber == eblanUserPageKey.eblanUser.serialNumber) {
-            isQuietModeEnabled = managedProfileResult.isQuiteModeEnabled
-        }
-    }
+    val isQuietModeEnabled by rememberIsQuietModeEnabled(
+        userHandle = userHandle,
+        managedProfileResult = managedProfileResult,
+        eblanUserPageKey = eblanUserPageKey,
+    )
 
     Box(modifier = modifier.fillMaxSize()) {
         if (isQuietModeEnabled) {
             QuiteModeScreen(
-                packageManager = packageManager,
                 userHandle = userHandle,
-                userManager = userManager,
                 onDragEnd = onDragEnd,
-                onUpdateRequestQuietModeEnabled = {
-                    isQuietModeEnabled = it
-                },
                 onVerticalDrag = onVerticalDrag,
             )
         } else {
@@ -456,7 +446,7 @@ private fun EblanApplicationInfosPage(
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
             )
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && packageManager.isDefaultLauncher() &&
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDefaultLauncher &&
                 eblanUserPageKey.eblanUser.serialNumber > 0 && userHandle != null
             ) {
                 FloatingActionButton(
@@ -471,8 +461,6 @@ private fun EblanApplicationInfosPage(
                             enableQuiteMode = true,
                             userHandle = userHandle,
                         )
-
-                        isQuietModeEnabled = userManager.isQuietModeEnabled(userHandle)
                     },
                 ) {
                     Icon(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -118,9 +118,10 @@ import com.eblan.launcher.feature.home.screen.application.TagElevatedFilterChip
 import com.eblan.launcher.feature.home.screen.application.handleDragEblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.handleOnLongPressEblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.handleOnTapEblanApplicationInfoItem
+import com.eblan.launcher.feature.home.screen.application.rememberIsDefaultLauncher
+import com.eblan.launcher.feature.home.screen.application.rememberIsQuietModeEnabled
 import com.eblan.launcher.feature.home.util.getSystemTextColor
 import com.eblan.launcher.ui.local.LocalLauncherApps
-import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.launch
@@ -429,8 +430,6 @@ private fun EblanApplicationInfosPage(
 ) {
     val userManager = LocalUserManager.current
 
-    val packageManager = LocalPackageManager.current
-
     val eblanUserPageKey =
         getEblanApplicationInfosByLabelAndTag.eblanApplicationInfoWithIconPackInfos.keys.toList()
             .getOrElse(
@@ -450,30 +449,19 @@ private fun EblanApplicationInfosPage(
     val userHandle =
         userManager.getUserForSerialNumber(serialNumber = eblanUserPageKey.eblanUser.serialNumber)
 
-    var isQuietModeEnabled by remember { mutableStateOf(false) }
+    val isDefaultLauncher by rememberIsDefaultLauncher()
 
-    LaunchedEffect(key1 = userHandle) {
-        if (userHandle != null) {
-            isQuietModeEnabled = userManager.isQuietModeEnabled(userHandle = userHandle)
-        }
-    }
-
-    LaunchedEffect(key1 = managedProfileResult) {
-        if (managedProfileResult != null && managedProfileResult.serialNumber == eblanUserPageKey.eblanUser.serialNumber) {
-            isQuietModeEnabled = managedProfileResult.isQuiteModeEnabled
-        }
-    }
+    val isQuietModeEnabled by rememberIsQuietModeEnabled(
+        userHandle = userHandle,
+        managedProfileResult = managedProfileResult,
+        eblanUserPageKey = eblanUserPageKey,
+    )
 
     Box(modifier = modifier.fillMaxSize()) {
         if (isQuietModeEnabled) {
             QuiteModeScreen(
-                packageManager = packageManager,
                 userHandle = userHandle,
-                userManager = userManager,
                 onDragEnd = onDragEnd,
-                onUpdateRequestQuietModeEnabled = {
-                    isQuietModeEnabled = it
-                },
                 onVerticalDrag = onVerticalDrag,
             )
         } else {
@@ -504,7 +492,7 @@ private fun EblanApplicationInfosPage(
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
             )
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && packageManager.isDefaultLauncher() &&
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDefaultLauncher &&
                 eblanUserPageKey.eblanUser.serialNumber > 0 && userHandle != null
             ) {
                 FloatingActionButton(
@@ -519,8 +507,6 @@ private fun EblanApplicationInfosPage(
                             enableQuiteMode = true,
                             userHandle = userHandle,
                         )
-
-                        isQuietModeEnabled = userManager.isQuietModeEnabled(userHandle)
                     },
                 ) {
                     Icon(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -118,11 +118,11 @@ import com.eblan.launcher.feature.home.screen.application.TagElevatedFilterChip
 import com.eblan.launcher.feature.home.screen.application.handleDragEblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.handleOnLongPressEblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.handleOnTapEblanApplicationInfoItem
-import com.eblan.launcher.feature.home.screen.application.rememberIsDefaultLauncher
 import com.eblan.launcher.feature.home.screen.application.rememberIsQuietModeEnabled
 import com.eblan.launcher.feature.home.util.getSystemTextColor
 import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalUserManager
+import com.eblan.launcher.ui.settings.rememberIsDefaultLauncher
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.launch
 import kotlin.uuid.ExperimentalUuidApi

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -428,6 +428,8 @@ private fun EblanApplicationInfosPage(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
+
     val userManager = LocalUserManager.current
 
     val eblanUserPageKey =
@@ -454,7 +456,7 @@ private fun EblanApplicationInfosPage(
     val isQuietModeEnabled by rememberIsQuietModeEnabled(
         userHandle = userHandle,
         managedProfileResult = managedProfileResult,
-        eblanUserPageKey = eblanUserPageKey,
+        eblanUser = eblanUserPageKey.eblanUser,
     )
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -492,9 +494,7 @@ private fun EblanApplicationInfosPage(
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
             )
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDefaultLauncher &&
-                eblanUserPageKey.eblanUser.serialNumber > 0 && userHandle != null
-            ) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDefaultLauncher && eblanUserPageKey.eblanUser.serialNumber > 0 && userHandle != null) {
                 FloatingActionButton(
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
@@ -503,10 +503,12 @@ private fun EblanApplicationInfosPage(
                             bottom = paddingValues.calculateBottomPadding() + 10.dp,
                         ),
                     onClick = {
-                        userManager.requestQuietModeEnabled(
-                            enableQuiteMode = true,
-                            userHandle = userHandle,
-                        )
+                        scope.launch {
+                            userManager.requestQuietModeEnabled(
+                                enableQuiteMode = true,
+                                userHandle = userHandle,
+                            )
+                        }
                     },
                 ) {
                     Icon(
@@ -551,6 +553,8 @@ private fun EblanApplicationInfos(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
 ) {
+    val userManager = LocalUserManager.current
+
     val lazyListState = rememberLazyListState()
 
     val canScroll by remember(key1 = lazyListState) {
@@ -575,7 +579,13 @@ private fun EblanApplicationInfos(
         )
     }
 
-    var isQuietModeEnabled by remember { mutableStateOf(false) }
+    val privateIsQuiteModeEnabled by rememberIsQuietModeEnabled(
+        userHandle = getEblanApplicationInfosByLabelAndTag.privateEblanUser?.serialNumber?.let(
+            userManager::getUserForSerialNumber,
+        ),
+        managedProfileResult = managedProfileResult,
+        eblanUser = getEblanApplicationInfosByLabelAndTag.privateEblanUser,
+    )
 
     LaunchedEffect(key1 = lazyListState.isScrollInProgress) {
         if (lazyListState.isScrollInProgress && showPopupApplicationMenu) {
@@ -607,8 +617,7 @@ private fun EblanApplicationInfos(
                     items(
                         items = getEblanApplicationInfosByLabelAndTag.eblanApplicationInfoWithIconPackInfos[eblanUserPageKey].orEmpty(),
                         key = {
-                            it.eblanApplicationInfo.serialNumber to
-                                it.eblanApplicationInfo.componentName
+                            it.eblanApplicationInfo.serialNumber to it.eblanApplicationInfo.componentName
                         },
                     ) {
                         EblanApplicationInfoListItem(
@@ -635,15 +644,11 @@ private fun EblanApplicationInfos(
 
                     privateSpace(
                         appDrawerSettings = appDrawerSettings,
-                        isQuietModeEnabled = isQuietModeEnabled,
-                        managedProfileResult = managedProfileResult,
+                        isQuietModeEnabled = privateIsQuiteModeEnabled,
                         paddingValues = paddingValues,
                         privateEblanApplicationInfos = getEblanApplicationInfosByLabelAndTag.privateEblanApplicationInfoWithIconPackInfos,
                         privateEblanUser = getEblanApplicationInfosByLabelAndTag.privateEblanUser,
                         isVisibleOverlay = isVisibleOverlay,
-                        onUpdateIsQuietModeEnabled = {
-                            isQuietModeEnabled = it
-                        },
                         onUpdateOverlayBounds = onUpdateOverlayBounds,
                         onUpdatePopupMenu = onUpdatePrivatePopupMenu,
                         onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
@@ -654,8 +659,7 @@ private fun EblanApplicationInfos(
                     items(
                         getEblanApplicationInfosByLabelAndTag.eblanApplicationInfoWithIconPackInfos[eblanUserPageKey].orEmpty(),
                         key = {
-                            it.eblanApplicationInfo.serialNumber to
-                                it.eblanApplicationInfo.componentName
+                            it.eblanApplicationInfo.serialNumber to it.eblanApplicationInfo.componentName
                         },
                     ) {
                         EblanApplicationInfoListItem(
@@ -854,31 +858,21 @@ private fun EblanApplicationInfoListItem(
         AsyncImage(
             model = ImageRequest.Builder(context)
                 .data(eblanApplicationInfoWithIconPackInfo.eblanApplicationInfo.customIcon ?: icon)
-                .addLastModifiedToFileCacheKey(true)
-                .size(iconSizePx)
-                .crossfade(false)
-                .build(),
+                .addLastModifiedToFileCacheKey(true).size(iconSizePx).crossfade(false).build(),
             contentDescription = null,
-            modifier = Modifier
-                .size(appDrawerSettings.gridItemSettings.iconSize.dp)
-                .alpha(alpha)
+            modifier = Modifier.size(appDrawerSettings.gridItemSettings.iconSize.dp).alpha(alpha)
                 .drawWithContent {
                     graphicsLayer.record {
                         this@drawWithContent.drawContent()
                     }
 
                     drawLayer(graphicsLayer)
-                }
-                .onGloballyPositioned { layoutCoordinates ->
+                }.onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 
                     intSize = layoutCoordinates.size
-                }
-                .run {
-                    if (!isScrollInProgress &&
-                        !isLongPress &&
-                        !isVisibleOverlay
-                    ) {
+                }.run {
+                    if (!isScrollInProgress && !isLongPress && !isVisibleOverlay) {
                         with(sharedTransitionScope) {
                             sharedElementWithCallerManagedVisibility(
                                 rememberSharedContentState(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
@@ -64,7 +64,6 @@ import com.eblan.launcher.domain.model.AppDrawerSettings
 import com.eblan.launcher.domain.model.EblanApplicationInfo
 import com.eblan.launcher.domain.model.EblanApplicationInfoWithIconPackInfo
 import com.eblan.launcher.domain.model.EblanUser
-import com.eblan.launcher.domain.model.ManagedProfileResult
 import com.eblan.launcher.feature.home.screen.application.PrivateSpaceStickyHeader
 import com.eblan.launcher.feature.home.screen.application.handleOnLongPressPrivateSpaceEblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.handleOnTapEblanApplicationInfoItem
@@ -76,12 +75,10 @@ import kotlin.uuid.ExperimentalUuidApi
 internal fun LazyListScope.privateSpace(
     appDrawerSettings: AppDrawerSettings,
     isQuietModeEnabled: Boolean,
-    managedProfileResult: ManagedProfileResult?,
     paddingValues: PaddingValues,
     privateEblanApplicationInfos: List<EblanApplicationInfoWithIconPackInfo>,
     privateEblanUser: EblanUser?,
     isVisibleOverlay: Boolean,
-    onUpdateIsQuietModeEnabled: (Boolean) -> Unit,
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
@@ -93,10 +90,8 @@ internal fun LazyListScope.privateSpace(
 
     stickyHeader {
         PrivateSpaceStickyHeader(
+            serialNumber = privateEblanUser.serialNumber,
             isQuietModeEnabled = isQuietModeEnabled,
-            managedProfileResult = managedProfileResult,
-            privateEblanUser = privateEblanUser,
-            onUpdateIsQuietModeEnabled = onUpdateIsQuietModeEnabled,
         )
     }
 
@@ -153,7 +148,8 @@ private fun PrivateSpaceEblanApplicationInfoItem(
 
     val maxLines = if (appDrawerSettings.gridItemSettings.singleLineLabel) 1 else Int.MAX_VALUE
 
-    val icon = eblanApplicationInfoWithIconPackInfo.iconPackInfoFilePath ?: eblanApplicationInfoWithIconPackInfo.eblanApplicationInfo.icon
+    val icon = eblanApplicationInfoWithIconPackInfo.iconPackInfoFilePath
+        ?: eblanApplicationInfoWithIconPackInfo.eblanApplicationInfo.icon
 
     val leftPadding = with(density) {
         paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
@@ -222,10 +218,7 @@ private fun PrivateSpaceEblanApplicationInfoItem(
         AsyncImage(
             model = ImageRequest.Builder(context)
                 .data(eblanApplicationInfoWithIconPackInfo.eblanApplicationInfo.customIcon ?: icon)
-                .addLastModifiedToFileCacheKey(true)
-                .size(iconSizePx)
-                .crossfade(false)
-                .build(),
+                .addLastModifiedToFileCacheKey(true).size(iconSizePx).crossfade(false).build(),
             contentDescription = null,
             modifier = Modifier
                 .onGloballyPositioned { layoutCoordinates ->
@@ -241,7 +234,8 @@ private fun PrivateSpaceEblanApplicationInfoItem(
         Spacer(modifier = Modifier.width(10.dp))
 
         Text(
-            text = eblanApplicationInfoWithIconPackInfo.eblanApplicationInfo.customLabel ?: eblanApplicationInfoWithIconPackInfo.eblanApplicationInfo.label,
+            text = eblanApplicationInfoWithIconPackInfo.eblanApplicationInfo.customLabel
+                ?: eblanApplicationInfoWithIconPackInfo.eblanApplicationInfo.label,
             color = textColor,
             textAlign = TextAlign.Center,
             maxLines = maxLines,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -93,8 +93,9 @@ import com.eblan.launcher.feature.home.screen.application.PrivateApplicationInfo
 import com.eblan.launcher.feature.home.screen.application.QuiteModeScreen
 import com.eblan.launcher.feature.home.screen.application.TagElevatedFilterChip
 import com.eblan.launcher.feature.home.screen.application.privateSpace
+import com.eblan.launcher.feature.home.screen.application.rememberIsDefaultLauncher
+import com.eblan.launcher.feature.home.screen.application.rememberIsQuietModeEnabled
 import com.eblan.launcher.ui.local.LocalLauncherApps
-import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
 
@@ -436,8 +437,6 @@ private fun EblanApplicationInfosPage(
 ) {
     val userManager = LocalUserManager.current
 
-    val packageManager = LocalPackageManager.current
-
     val eblanUserPageKey =
         getEblanApplicationInfosByLabelAndTag.eblanApplicationInfoWithIconPackInfos.keys.toList()
             .getOrElse(
@@ -457,30 +456,19 @@ private fun EblanApplicationInfosPage(
     val userHandle =
         userManager.getUserForSerialNumber(serialNumber = eblanUserPageKey.eblanUser.serialNumber)
 
-    var isQuietModeEnabled by remember { mutableStateOf(false) }
+    val isDefaultLauncher by rememberIsDefaultLauncher()
 
-    LaunchedEffect(key1 = userHandle) {
-        if (userHandle != null) {
-            isQuietModeEnabled = userManager.isQuietModeEnabled(userHandle = userHandle)
-        }
-    }
-
-    LaunchedEffect(key1 = managedProfileResult) {
-        if (managedProfileResult != null && managedProfileResult.serialNumber == eblanUserPageKey.eblanUser.serialNumber) {
-            isQuietModeEnabled = managedProfileResult.isQuiteModeEnabled
-        }
-    }
+    val isQuietModeEnabled by rememberIsQuietModeEnabled(
+        userHandle = userHandle,
+        managedProfileResult = managedProfileResult,
+        eblanUserPageKey = eblanUserPageKey,
+    )
 
     Box(modifier = modifier.fillMaxSize()) {
         if (isQuietModeEnabled) {
             QuiteModeScreen(
-                packageManager = packageManager,
                 userHandle = userHandle,
-                userManager = userManager,
                 onDragEnd = onDragEnd,
-                onUpdateRequestQuietModeEnabled = {
-                    isQuietModeEnabled = it
-                },
                 onVerticalDrag = onVerticalDrag,
             )
         } else if (isRearrangeEblanApplicationInfo && eblanApplicationInfoOrder == EblanApplicationInfoOrder.Index) {
@@ -522,7 +510,7 @@ private fun EblanApplicationInfosPage(
                 onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
             )
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && packageManager.isDefaultLauncher() &&
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDefaultLauncher &&
                 eblanUserPageKey.eblanUser.serialNumber > 0 && userHandle != null
             ) {
                 FloatingActionButton(
@@ -537,8 +525,6 @@ private fun EblanApplicationInfosPage(
                             enableQuiteMode = true,
                             userHandle = userHandle,
                         )
-
-                        isQuietModeEnabled = userManager.isQuietModeEnabled(userHandle)
                     },
                 ) {
                     Icon(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -94,10 +94,10 @@ import com.eblan.launcher.feature.home.screen.application.PrivateApplicationInfo
 import com.eblan.launcher.feature.home.screen.application.QuiteModeScreen
 import com.eblan.launcher.feature.home.screen.application.TagElevatedFilterChip
 import com.eblan.launcher.feature.home.screen.application.privateSpace
-import com.eblan.launcher.feature.home.screen.application.rememberIsDefaultLauncher
 import com.eblan.launcher.feature.home.screen.application.rememberIsQuietModeEnabled
 import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalUserManager
+import com.eblan.launcher.ui.settings.rememberIsDefaultLauncher
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.launch
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -98,6 +99,7 @@ import com.eblan.launcher.feature.home.screen.application.rememberIsQuietModeEna
 import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalUserManager
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class, FlowPreview::class)
 @Composable
@@ -435,6 +437,8 @@ private fun EblanApplicationInfosPage(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
+
     val userManager = LocalUserManager.current
 
     val eblanUserPageKey =
@@ -461,7 +465,7 @@ private fun EblanApplicationInfosPage(
     val isQuietModeEnabled by rememberIsQuietModeEnabled(
         userHandle = userHandle,
         managedProfileResult = managedProfileResult,
-        eblanUserPageKey = eblanUserPageKey,
+        eblanUser = eblanUserPageKey.eblanUser,
     )
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -521,10 +525,12 @@ private fun EblanApplicationInfosPage(
                             bottom = paddingValues.calculateBottomPadding() + 10.dp,
                         ),
                     onClick = {
-                        userManager.requestQuietModeEnabled(
-                            enableQuiteMode = true,
-                            userHandle = userHandle,
-                        )
+                        scope.launch {
+                            userManager.requestQuietModeEnabled(
+                                enableQuiteMode = true,
+                                userHandle = userHandle,
+                            )
+                        }
                     },
                 ) {
                     Icon(
@@ -569,6 +575,8 @@ private fun EblanApplicationInfos(
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
 ) {
+    val userManager = LocalUserManager.current
+
     val lazyGridState = rememberLazyGridState()
 
     val canScroll by remember(key1 = lazyGridState) {
@@ -593,7 +601,13 @@ private fun EblanApplicationInfos(
         )
     }
 
-    var isQuietModeEnabled by remember { mutableStateOf(false) }
+    val privateIsQuiteModeEnabled by rememberIsQuietModeEnabled(
+        userHandle = getEblanApplicationInfosByLabelAndTag.privateEblanUser?.serialNumber?.let(
+            userManager::getUserForSerialNumber,
+        ),
+        managedProfileResult = managedProfileResult,
+        eblanUser = getEblanApplicationInfosByLabelAndTag.privateEblanUser,
+    )
 
     LaunchedEffect(key1 = lazyGridState.isScrollInProgress) {
         if (lazyGridState.isScrollInProgress && showPopupApplicationMenu) {
@@ -652,15 +666,11 @@ private fun EblanApplicationInfos(
 
                     privateSpace(
                         appDrawerSettings = appDrawerSettings,
-                        isQuietModeEnabled = isQuietModeEnabled,
-                        managedProfileResult = managedProfileResult,
+                        isQuietModeEnabled = privateIsQuiteModeEnabled,
                         paddingValues = paddingValues,
                         privateEblanApplicationInfoWithIconPackInfos = getEblanApplicationInfosByLabelAndTag.privateEblanApplicationInfoWithIconPackInfos,
                         privateEblanUser = getEblanApplicationInfosByLabelAndTag.privateEblanUser,
                         isVisibleOverlay = isVisibleOverlay,
-                        onUpdateIsQuietModeEnabled = {
-                            isQuietModeEnabled = it
-                        },
                         onUpdateOverlayBounds = onUpdateOverlayBounds,
                         onUpdatePopupMenu = onUpdatePrivatePopupMenu,
                         onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/LifecycleEffect.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/LifecycleEffect.kt
@@ -143,9 +143,9 @@ internal fun LifecycleEffect(
 
                     Lifecycle.Event.ON_STOP -> {
                         if (syncData && pinItemRequestWrapper.getPinItemRequest() == null) {
-                            if (shouldUnbindEblanNotificationListenerService) {
-                                context.unregisterReceiver(managedProfileBroadcastReceiver)
+                            context.unregisterReceiver(managedProfileBroadcastReceiver)
 
+                            if (shouldUnbindEblanNotificationListenerService) {
                                 context.unbindService(eblanNotificationListenerServiceConnection)
 
                                 shouldUnbindEblanNotificationListenerService = false

--- a/feature/settings/settings/src/main/kotlin/com/eblan/launcher/feature/settings/settings/SettingsScreen.kt
+++ b/feature/settings/settings/src/main/kotlin/com/eblan/launcher/feature/settings/settings/SettingsScreen.kt
@@ -40,6 +40,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -85,15 +90,7 @@ internal fun SettingsScreen(
     onGestures: () -> Unit,
     onHome: () -> Unit,
 ) {
-    val context = LocalContext.current
-
-    val packageManager = LocalPackageManager.current
-
     val items = buildSettingsItems(
-        isDefaultLauncher = packageManager.isDefaultLauncher(),
-        onDefaultLauncherClick = {
-            context.startActivity(Intent(ACTION_HOME_SETTINGS))
-        },
         onGeneralClick = onGeneral,
         onHomeClick = onHome,
         onAppDrawerClick = onAppDrawer,
@@ -221,67 +218,79 @@ private fun AlphaWarningCard(modifier: Modifier = Modifier) {
 
 @Composable
 private fun buildSettingsItems(
-    isDefaultLauncher: Boolean,
-    onDefaultLauncherClick: () -> Unit,
     onGeneralClick: () -> Unit,
     onHomeClick: () -> Unit,
     onAppDrawerClick: () -> Unit,
     onGesturesClick: () -> Unit,
     onExperimentalClick: () -> Unit,
-): List<SettingsItem> = buildList {
-    if (!isDefaultLauncher) {
+): List<SettingsItem> {
+    val context = LocalContext.current
+
+    val packageManager = LocalPackageManager.current
+
+    var isDefaultLauncher by remember { mutableStateOf(false) }
+
+    LaunchedEffect(key1 = Unit) {
+        isDefaultLauncher = packageManager.isDefaultLauncher()
+    }
+
+    return buildList {
+        if (!isDefaultLauncher) {
+            add(
+                SettingsItem.Row(
+                    imageVector = EblanLauncherIcons.Info,
+                    title = stringResource(R.string.default_launcher),
+                    subtitle = stringResource(R.string.choose_yagni_launcher),
+                    onClick = {
+                        context.startActivity(Intent(ACTION_HOME_SETTINGS))
+                    },
+                ),
+            )
+        }
+
         add(
             SettingsItem.Row(
-                imageVector = EblanLauncherIcons.Info,
-                title = stringResource(R.string.default_launcher),
-                subtitle = stringResource(R.string.choose_yagni_launcher),
-                onClick = onDefaultLauncherClick,
+                imageVector = EblanLauncherIcons.Settings,
+                title = stringResource(commonR.string.general),
+                subtitle = stringResource(R.string.themes_icon_packs),
+                onClick = onGeneralClick,
+            ),
+        )
+
+        add(
+            SettingsItem.Row(
+                imageVector = EblanLauncherIcons.Home,
+                title = stringResource(commonR.string.home),
+                subtitle = stringResource(R.string.grid_icon_dock_and_more),
+                onClick = onHomeClick,
+            ),
+        )
+
+        add(
+            SettingsItem.Row(
+                imageVector = EblanLauncherIcons.Apps,
+                title = stringResource(commonR.string.app_drawer),
+                subtitle = stringResource(R.string.columns_and_rows_count),
+                onClick = onAppDrawerClick,
+            ),
+        )
+
+        add(
+            SettingsItem.Row(
+                imageVector = EblanLauncherIcons.Gesture,
+                title = stringResource(commonR.string.gestures),
+                subtitle = stringResource(R.string.swipe_gesture_actions),
+                onClick = onGesturesClick,
+            ),
+        )
+
+        add(
+            SettingsItem.Row(
+                imageVector = EblanLauncherIcons.DeveloperMode,
+                title = stringResource(commonR.string.experimental),
+                subtitle = stringResource(R.string.advanced_options_for_power_users),
+                onClick = onExperimentalClick,
             ),
         )
     }
-
-    add(
-        SettingsItem.Row(
-            imageVector = EblanLauncherIcons.Settings,
-            title = stringResource(commonR.string.general),
-            subtitle = stringResource(R.string.themes_icon_packs),
-            onClick = onGeneralClick,
-        ),
-    )
-
-    add(
-        SettingsItem.Row(
-            imageVector = EblanLauncherIcons.Home,
-            title = stringResource(commonR.string.home),
-            subtitle = stringResource(R.string.grid_icon_dock_and_more),
-            onClick = onHomeClick,
-        ),
-    )
-
-    add(
-        SettingsItem.Row(
-            imageVector = EblanLauncherIcons.Apps,
-            title = stringResource(commonR.string.app_drawer),
-            subtitle = stringResource(R.string.columns_and_rows_count),
-            onClick = onAppDrawerClick,
-        ),
-    )
-
-    add(
-        SettingsItem.Row(
-            imageVector = EblanLauncherIcons.Gesture,
-            title = stringResource(commonR.string.gestures),
-            subtitle = stringResource(R.string.swipe_gesture_actions),
-            onClick = onGesturesClick,
-        ),
-    )
-
-    add(
-        SettingsItem.Row(
-            imageVector = EblanLauncherIcons.DeveloperMode,
-            title = stringResource(commonR.string.experimental),
-            subtitle = stringResource(R.string.advanced_options_for_power_users),
-            onClick = onExperimentalClick,
-        ),
-    )
 }

--- a/feature/settings/settings/src/main/kotlin/com/eblan/launcher/feature/settings/settings/SettingsScreen.kt
+++ b/feature/settings/settings/src/main/kotlin/com/eblan/launcher/feature/settings/settings/SettingsScreen.kt
@@ -40,11 +40,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -53,9 +49,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
-import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.model.SettingsItem
 import com.eblan.launcher.ui.settings.SettingsItemContent
+import com.eblan.launcher.ui.settings.rememberIsDefaultLauncher
 import com.eblan.launcher.common.R as commonR
 
 @Composable
@@ -226,13 +222,7 @@ private fun buildSettingsItems(
 ): List<SettingsItem> {
     val context = LocalContext.current
 
-    val packageManager = LocalPackageManager.current
-
-    var isDefaultLauncher by remember { mutableStateOf(false) }
-
-    LaunchedEffect(key1 = Unit) {
-        isDefaultLauncher = packageManager.isDefaultLauncher()
-    }
+    val isDefaultLauncher by rememberIsDefaultLauncher()
 
     return buildList {
         if (!isDefaultLauncher) {

--- a/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
+++ b/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
@@ -256,7 +256,7 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
 
                     launcherApps.getShortcuts(shortcutQuery, userHandle)?.map {
                         it.toLauncherAppsShortcutInfo()
-                    } ?: emptyList()
+                    }.orEmpty()
                 }
             } else {
                 launcherApps.getShortcuts(shortcutQuery, myUserHandle())?.map {
@@ -286,7 +286,7 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
 
                     launcherApps.getShortcuts(shortcutQuery, userHandle)?.map {
                         it.toFastLauncherAppsShortcutInfo()
-                    } ?: emptyList()
+                    }.orEmpty()
                 }
             } else {
                 launcherApps.getShortcuts(shortcutQuery, myUserHandle())?.map {

--- a/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
+++ b/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
@@ -166,24 +166,20 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
 
     override suspend fun getActivityList(): List<LauncherAppsActivityInfo> = withContext(defaultDispatcher) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            launcherApps.profiles.filterNot { userHandle ->
+            launcherApps.profiles.filterNot {
                 currentCoroutineContext().ensureActive()
 
-                isPrivateSpaceEntryPointHidden(userHandle = userHandle)
+                isPrivateSpaceEntryPointHidden(userHandle = it)
             }.flatMap { userHandle ->
                 currentCoroutineContext().ensureActive()
 
-                launcherApps.getActivityList(null, userHandle).map { launcherActivityInfo ->
-                    currentCoroutineContext().ensureActive()
-
-                    launcherActivityInfo.toLauncherAppsActivityInfo()
+                launcherApps.getActivityList(null, userHandle).map {
+                    it.toLauncherAppsActivityInfo()
                 }
             }
         } else {
-            launcherApps.getActivityList(null, myUserHandle()).map { launcherActivityInfo ->
-                currentCoroutineContext().ensureActive()
-
-                launcherActivityInfo.toLauncherAppsActivityInfo()
+            launcherApps.getActivityList(null, myUserHandle()).map {
+                it.toLauncherAppsActivityInfo()
             }
         }
     }
@@ -197,17 +193,13 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
             }.flatMap { userHandle ->
                 currentCoroutineContext().ensureActive()
 
-                launcherApps.getActivityList(null, userHandle).map { launcherActivityInfo ->
-                    currentCoroutineContext().ensureActive()
-
-                    launcherActivityInfo.toFastLauncherAppsActivityInfo()
+                launcherApps.getActivityList(null, userHandle).map {
+                    it.toFastLauncherAppsActivityInfo()
                 }
             }
         } else {
-            launcherApps.getActivityList(null, myUserHandle()).map { launcherActivityInfo ->
-                currentCoroutineContext().ensureActive()
-
-                launcherActivityInfo.toFastLauncherAppsActivityInfo()
+            launcherApps.getActivityList(null, myUserHandle()).map {
+                it.toFastLauncherAppsActivityInfo()
             }
         }
     }
@@ -218,10 +210,8 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
     ): List<LauncherAppsActivityInfo> = withContext(defaultDispatcher) {
         val userHandle = userManagerWrapper.getUserForSerialNumber(serialNumber = serialNumber)
 
-        launcherApps.getActivityList(packageName, userHandle).map { launcherActivityInfo ->
-            currentCoroutineContext().ensureActive()
-
-            launcherActivityInfo.toLauncherAppsActivityInfo()
+        launcherApps.getActivityList(packageName, userHandle).map {
+            it.toLauncherAppsActivityInfo()
         }
     }
 
@@ -231,10 +221,8 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
     ): List<FastLauncherAppsActivityInfo> = withContext(defaultDispatcher) {
         val userHandle = userManagerWrapper.getUserForSerialNumber(serialNumber = serialNumber)
 
-        launcherApps.getActivityList(packageName, userHandle).map { launcherActivityInfo ->
-            currentCoroutineContext().ensureActive()
-
-            launcherActivityInfo.toFastLauncherAppsActivityInfo()
+        launcherApps.getActivityList(packageName, userHandle).map {
+            it.toFastLauncherAppsActivityInfo()
         }
     }
 
@@ -266,17 +254,13 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
                 }.flatMap { userHandle ->
                     currentCoroutineContext().ensureActive()
 
-                    launcherApps.getShortcuts(shortcutQuery, userHandle)?.map { shortcutInfo ->
-                        currentCoroutineContext().ensureActive()
-
-                        shortcutInfo.toLauncherAppsShortcutInfo()
+                    launcherApps.getShortcuts(shortcutQuery, userHandle)?.map {
+                        it.toLauncherAppsShortcutInfo()
                     } ?: emptyList()
                 }
             } else {
-                launcherApps.getShortcuts(shortcutQuery, myUserHandle())?.map { shortcutInfo ->
-                    currentCoroutineContext().ensureActive()
-
-                    shortcutInfo.toLauncherAppsShortcutInfo()
+                launcherApps.getShortcuts(shortcutQuery, myUserHandle())?.map {
+                    it.toLauncherAppsShortcutInfo()
                 }
             }
         } else {
@@ -300,17 +284,13 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
                 }.flatMap { userHandle ->
                     currentCoroutineContext().ensureActive()
 
-                    launcherApps.getShortcuts(shortcutQuery, userHandle)?.map { shortcutInfo ->
-                        currentCoroutineContext().ensureActive()
-
-                        shortcutInfo.toFastLauncherAppsShortcutInfo()
+                    launcherApps.getShortcuts(shortcutQuery, userHandle)?.map {
+                        it.toFastLauncherAppsShortcutInfo()
                     } ?: emptyList()
                 }
             } else {
-                launcherApps.getShortcuts(shortcutQuery, myUserHandle())?.map { shortcutInfo ->
-                    currentCoroutineContext().ensureActive()
-
-                    shortcutInfo.toFastLauncherAppsShortcutInfo()
+                launcherApps.getShortcuts(shortcutQuery, myUserHandle())?.map {
+                    it.toFastLauncherAppsShortcutInfo()
                 }
             }
         } else {
@@ -333,10 +313,8 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
                 )
             }
 
-            launcherApps.getShortcuts(shortcutQuery, userHandle)?.map { shortcutInfo ->
-                currentCoroutineContext().ensureActive()
-
-                shortcutInfo.toLauncherAppsShortcutInfo()
+            launcherApps.getShortcuts(shortcutQuery, userHandle)?.map {
+                it.toLauncherAppsShortcutInfo()
             }
         } else {
             null
@@ -351,10 +329,8 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && userHandle != null) {
             launcherApps.getShortcutConfigActivityList(packageName, userHandle)
-                .map { launcherActivityInfo ->
-                    currentCoroutineContext().ensureActive()
-
-                    launcherActivityInfo.toLauncherAppsActivityInfo()
+                .map {
+                    it.toLauncherAppsActivityInfo()
                 }
         } else {
             emptyList()
@@ -465,8 +441,8 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
 
             val launcherActivityInfo = if (userHandle != null) {
                 launcherApps.getShortcutConfigActivityList(packageName, userHandle)
-                    .find { launcherActivityInfo ->
-                        launcherActivityInfo.componentName.flattenToString() == componentName
+                    .find {
+                        it.componentName.flattenToString() == componentName
                     }
             } else {
                 null

--- a/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
+++ b/framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
@@ -452,7 +452,7 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
         }
     }
 
-    override fun getUser(serialNumber: Long): EblanUser {
+    override suspend fun getUser(serialNumber: Long): EblanUser {
         val userHandle = userManagerWrapper.getUserForSerialNumber(serialNumber = serialNumber)
             ?: return EblanUser(
                 serialNumber = serialNumber,
@@ -532,6 +532,8 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
             ?.getBoolean(LauncherUserInfo.PRIVATE_SPACE_ENTRYPOINT_HIDDEN) == true
 
     private suspend fun LauncherActivityInfo.toLauncherAppsActivityInfo(): LauncherAppsActivityInfo {
+        currentCoroutineContext().ensureActive()
+
         val serialNumber = userManagerWrapper.getSerialNumberForUser(userHandle = user)
 
         val badgedIcon = try {
@@ -568,15 +570,21 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
         )
     }
 
-    private fun LauncherActivityInfo.toFastLauncherAppsActivityInfo(): FastLauncherAppsActivityInfo = FastLauncherAppsActivityInfo(
-        serialNumber = userManagerWrapper.getSerialNumberForUser(userHandle = user),
-        componentName = componentName.flattenToString(),
-        packageName = applicationInfo.packageName,
-        lastUpdateTime = packageManagerWrapper.getLastUpdateTime(packageName = applicationInfo.packageName),
-    )
+    private suspend fun LauncherActivityInfo.toFastLauncherAppsActivityInfo(): FastLauncherAppsActivityInfo {
+        currentCoroutineContext().ensureActive()
+
+        return FastLauncherAppsActivityInfo(
+            serialNumber = userManagerWrapper.getSerialNumberForUser(userHandle = user),
+            componentName = componentName.flattenToString(),
+            packageName = applicationInfo.packageName,
+            lastUpdateTime = packageManagerWrapper.getLastUpdateTime(packageName = applicationInfo.packageName),
+        )
+    }
 
     @RequiresApi(Build.VERSION_CODES.N_MR1)
     private suspend fun ShortcutInfo.toLauncherAppsShortcutInfo(): LauncherAppsShortcutInfo {
+        currentCoroutineContext().ensureActive()
+
         val serialNumber = userManagerWrapper.getSerialNumberForUser(userHandle = userHandle)
 
         val shortcutBadgedIconDrawable = try {
@@ -631,9 +639,13 @@ internal class DefaultLauncherAppsWrapper @Inject constructor(
     }
 
     @RequiresApi(Build.VERSION_CODES.N_MR1)
-    private fun ShortcutInfo.toFastLauncherAppsShortcutInfo(): FastLauncherAppsShortcutInfo = FastLauncherAppsShortcutInfo(
-        packageName = `package`,
-        serialNumber = userManagerWrapper.getSerialNumberForUser(userHandle = userHandle),
-        lastChangedTimestamp = packageManagerWrapper.getLastUpdateTime(packageName = `package`),
-    )
+    private suspend fun ShortcutInfo.toFastLauncherAppsShortcutInfo(): FastLauncherAppsShortcutInfo {
+        currentCoroutineContext().ensureActive()
+
+        return FastLauncherAppsShortcutInfo(
+            packageName = `package`,
+            serialNumber = userManagerWrapper.getSerialNumberForUser(userHandle = userHandle),
+            lastChangedTimestamp = packageManagerWrapper.getLastUpdateTime(packageName = `package`),
+        )
+    }
 }

--- a/framework/package-manager/src/main/kotlin/com/eblan/launcher/framework/packagemanager/AndroidPackageManagerWrapper.kt
+++ b/framework/package-manager/src/main/kotlin/com/eblan/launcher/framework/packagemanager/AndroidPackageManagerWrapper.kt
@@ -20,7 +20,7 @@ package com.eblan.launcher.framework.packagemanager
 import android.os.UserHandle
 
 interface AndroidPackageManagerWrapper {
-    fun isDefaultLauncher(): Boolean
+    suspend fun isDefaultLauncher(): Boolean
 
-    fun getUserBadgedLabel(label: CharSequence, userHandle: UserHandle): CharSequence
+    suspend fun getUserBadgedLabel(label: CharSequence, userHandle: UserHandle): CharSequence
 }

--- a/framework/package-manager/src/main/kotlin/com/eblan/launcher/framework/packagemanager/DefaultPackageManagerWrapper.kt
+++ b/framework/package-manager/src/main/kotlin/com/eblan/launcher/framework/packagemanager/DefaultPackageManagerWrapper.kt
@@ -37,7 +37,7 @@ import javax.inject.Inject
 internal class DefaultPackageManagerWrapper @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val imageSerializer: AndroidImageSerializer,
-    @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
+    @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : PackageManagerWrapper,
     AndroidPackageManagerWrapper {
     private val packageManager = context.packageManager
@@ -48,7 +48,7 @@ internal class DefaultPackageManagerWrapper @Inject constructor(
     override suspend fun getApplicationIcon(
         packageName: String,
         file: File,
-    ): String? = withContext(defaultDispatcher) {
+    ): String? = withContext(ioDispatcher) {
         try {
             imageSerializer.createDrawablePath(
                 drawable = packageManager.getApplicationIcon(
@@ -63,7 +63,7 @@ internal class DefaultPackageManagerWrapper @Inject constructor(
         }
     }
 
-    override suspend fun getApplicationLabel(packageName: String): String? = withContext(defaultDispatcher) {
+    override suspend fun getApplicationLabel(packageName: String): String? = withContext(ioDispatcher) {
         try {
             val applicationInfo =
                 packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
@@ -80,7 +80,7 @@ internal class DefaultPackageManagerWrapper @Inject constructor(
         return launchIntent?.component?.flattenToString()
     }
 
-    override fun isDefaultLauncher(): Boolean {
+    override suspend fun isDefaultLauncher(): Boolean = withContext(ioDispatcher) {
         val intent = Intent(Intent.ACTION_MAIN).apply {
             addCategory(Intent.CATEGORY_HOME)
         }
@@ -89,7 +89,7 @@ internal class DefaultPackageManagerWrapper @Inject constructor(
 
         val defaultLauncherPackage = resolveInfo?.activityInfo?.packageName
 
-        return defaultLauncherPackage == context.packageName
+        defaultLauncherPackage == context.packageName
     }
 
     override suspend fun getIconPackInfos(): List<PackageManagerIconPackInfo> {
@@ -102,7 +102,7 @@ internal class DefaultPackageManagerWrapper @Inject constructor(
 
         val resolveInfos = mutableSetOf<ResolveInfo>()
 
-        return withContext(defaultDispatcher) {
+        return withContext(ioDispatcher) {
             intents.forEach { intent ->
                 resolveInfos.addAll(
                     packageManager.queryIntentActivities(
@@ -128,13 +128,20 @@ internal class DefaultPackageManagerWrapper @Inject constructor(
         }
     }
 
-    override fun getLastUpdateTime(packageName: String): Long = try {
-        packageManager.getPackageInfo(packageName, 0).lastUpdateTime
-    } catch (_: PackageManager.NameNotFoundException) {
-        0L
+    override suspend fun getLastUpdateTime(packageName: String): Long = withContext(ioDispatcher) {
+        try {
+            packageManager.getPackageInfo(packageName, 0).lastUpdateTime
+        } catch (_: PackageManager.NameNotFoundException) {
+            0L
+        }
     }
 
     override fun isSystem(flags: Int): Boolean = (flags and (ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_UPDATED_SYSTEM_APP)) != 0
 
-    override fun getUserBadgedLabel(label: CharSequence, userHandle: UserHandle): CharSequence = packageManager.getUserBadgedLabel(label, userHandle)
+    override suspend fun getUserBadgedLabel(
+        label: CharSequence,
+        userHandle: UserHandle,
+    ): CharSequence = withContext(ioDispatcher) {
+        packageManager.getUserBadgedLabel(label, userHandle)
+    }
 }

--- a/framework/user-manager/src/main/kotlin/com/eblan/launcher/framework/usermanager/AndroidUserManagerWrapper.kt
+++ b/framework/user-manager/src/main/kotlin/com/eblan/launcher/framework/usermanager/AndroidUserManagerWrapper.kt
@@ -33,7 +33,7 @@ interface AndroidUserManagerWrapper {
     fun isQuietModeEnabled(userHandle: UserHandle): Boolean
 
     @RequiresApi(Build.VERSION_CODES.P)
-    fun requestQuietModeEnabled(
+    suspend fun requestQuietModeEnabled(
         enableQuiteMode: Boolean,
         userHandle: UserHandle,
     ): Boolean

--- a/framework/user-manager/src/main/kotlin/com/eblan/launcher/framework/usermanager/DefaultUserManagerWrapper.kt
+++ b/framework/user-manager/src/main/kotlin/com/eblan/launcher/framework/usermanager/DefaultUserManagerWrapper.kt
@@ -23,10 +23,17 @@ import android.os.Build
 import android.os.UserHandle
 import android.os.UserManager
 import androidx.annotation.RequiresApi
+import com.eblan.launcher.domain.common.Dispatcher
+import com.eblan.launcher.domain.common.EblanDispatchers
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-internal class DefaultUserManagerWrapper @Inject constructor(@param:ApplicationContext private val context: Context) : AndroidUserManagerWrapper {
+internal class DefaultUserManagerWrapper @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+) : AndroidUserManagerWrapper {
     private val userManager = context.getSystemService(USER_SERVICE) as UserManager
 
     override fun getSerialNumberForUser(userHandle: UserHandle): Long = userManager.getSerialNumberForUser(userHandle)
@@ -40,11 +47,13 @@ internal class DefaultUserManagerWrapper @Inject constructor(@param:ApplicationC
     override fun isQuietModeEnabled(userHandle: UserHandle): Boolean = userManager.isQuietModeEnabled(userHandle)
 
     @RequiresApi(Build.VERSION_CODES.P)
-    override fun requestQuietModeEnabled(
+    override suspend fun requestQuietModeEnabled(
         enableQuiteMode: Boolean,
         userHandle: UserHandle,
-    ): Boolean = userManager.requestQuietModeEnabled(
-        enableQuiteMode,
-        userHandle,
-    )
+    ): Boolean = withContext(ioDispatcher) {
+        userManager.requestQuietModeEnabled(
+            enableQuiteMode,
+            userHandle,
+        )
+    }
 }

--- a/framework/widget-manager/src/main/kotlin/com/eblan/launcher/framework/widgetmanager/DefaultAppWidgetManagerWrapper.kt
+++ b/framework/widget-manager/src/main/kotlin/com/eblan/launcher/framework/widgetmanager/DefaultAppWidgetManagerWrapper.kt
@@ -49,19 +49,21 @@ internal class DefaultAppWidgetManagerWrapper @Inject constructor(
     private val fileManager: FileManager,
     private val packageManagerWrapper: PackageManagerWrapper,
     private val iconKeyGenerator: IconKeyGenerator,
-    @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
+    @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : AppWidgetManagerWrapper,
     AndroidAppWidgetManagerWrapper {
     private val appWidgetManager = AppWidgetManager.getInstance(context)
 
-    override suspend fun getInstalledProviders(): List<AppWidgetManagerAppWidgetProviderInfo> = withContext(defaultDispatcher) {
+    override suspend fun getInstalledProviders(): List<AppWidgetManagerAppWidgetProviderInfo> = withContext(ioDispatcher) {
         appWidgetManager.installedProviders.map {
             it.toEblanAppWidgetProviderInfo()
         }
     }
 
-    override suspend fun getFastInstalledProviders(): List<FastAppWidgetManagerAppWidgetProviderInfo> = appWidgetManager.installedProviders.map {
-        it.toFastEblanAppWidgetProviderInfo()
+    override suspend fun getFastInstalledProviders(): List<FastAppWidgetManagerAppWidgetProviderInfo> = withContext(ioDispatcher) {
+        appWidgetManager.installedProviders.map {
+            it.toFastEblanAppWidgetProviderInfo()
+        }
     }
 
     override fun getAppWidgetInfo(appWidgetId: Int): AppWidgetProviderInfo? = appWidgetManager.getAppWidgetInfo(appWidgetId)

--- a/framework/widget-manager/src/main/kotlin/com/eblan/launcher/framework/widgetmanager/DefaultAppWidgetManagerWrapper.kt
+++ b/framework/widget-manager/src/main/kotlin/com/eblan/launcher/framework/widgetmanager/DefaultAppWidgetManagerWrapper.kt
@@ -36,6 +36,8 @@ import com.eblan.launcher.framework.imageserializer.AndroidImageSerializer
 import com.eblan.launcher.framework.usermanager.AndroidUserManagerWrapper
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
@@ -53,13 +55,13 @@ internal class DefaultAppWidgetManagerWrapper @Inject constructor(
     private val appWidgetManager = AppWidgetManager.getInstance(context)
 
     override suspend fun getInstalledProviders(): List<AppWidgetManagerAppWidgetProviderInfo> = withContext(defaultDispatcher) {
-        appWidgetManager.installedProviders.map { appWidgetProviderInfo ->
-            appWidgetProviderInfo.toEblanAppWidgetProviderInfo()
+        appWidgetManager.installedProviders.map {
+            it.toEblanAppWidgetProviderInfo()
         }
     }
 
-    override suspend fun getFastInstalledProviders(): List<FastAppWidgetManagerAppWidgetProviderInfo> = appWidgetManager.installedProviders.map { appWidgetProviderInfo ->
-        appWidgetProviderInfo.toFastEblanAppWidgetProviderInfo()
+    override suspend fun getFastInstalledProviders(): List<FastAppWidgetManagerAppWidgetProviderInfo> = appWidgetManager.installedProviders.map {
+        it.toFastEblanAppWidgetProviderInfo()
     }
 
     override fun getAppWidgetInfo(appWidgetId: Int): AppWidgetProviderInfo? = appWidgetManager.getAppWidgetInfo(appWidgetId)
@@ -82,6 +84,8 @@ internal class DefaultAppWidgetManagerWrapper @Inject constructor(
     }
 
     private suspend fun AppWidgetProviderInfo.toEblanAppWidgetProviderInfo(): AppWidgetManagerAppWidgetProviderInfo {
+        currentCoroutineContext().ensureActive()
+
         val serialNumber = userManagerWrapper.getSerialNumberForUser(userHandle = profile)
 
         val preview = loadPreviewImage(context, 0)?.let { drawable ->
@@ -140,7 +144,9 @@ internal class DefaultAppWidgetManagerWrapper @Inject constructor(
         }
     }
 
-    private fun AppWidgetProviderInfo.toFastEblanAppWidgetProviderInfo(): FastAppWidgetManagerAppWidgetProviderInfo {
+    private suspend fun AppWidgetProviderInfo.toFastEblanAppWidgetProviderInfo(): FastAppWidgetManagerAppWidgetProviderInfo {
+        currentCoroutineContext().ensureActive()
+
         val serialNumber = userManagerWrapper.getSerialNumberForUser(userHandle = profile)
 
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/settings/Settings.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/settings/Settings.kt
@@ -38,8 +38,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -50,11 +52,15 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import coil3.compose.AsyncImage
 import com.eblan.launcher.designsystem.component.VerticalSlideReveal
 import com.eblan.launcher.designsystem.icon.EblanLauncherIcons
 import com.eblan.launcher.domain.model.PackageManagerIconPackInfo
 import com.eblan.launcher.ui.R
+import com.eblan.launcher.ui.local.LocalPackageManager
 import com.eblan.launcher.ui.model.SettingsItem
 import com.eblan.launcher.common.R as commonR
 
@@ -226,6 +232,18 @@ fun SettingsCategoryText(
         text = text,
         style = MaterialTheme.typography.bodySmall,
     )
+}
+
+@Composable
+fun rememberIsDefaultLauncher(): State<Boolean> {
+    val packageManager = LocalPackageManager.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    return produceState(initialValue = false, key1 = lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            value = packageManager.isDefaultLauncher()
+        }
+    }
 }
 
 fun settingsItemShape(

--- a/ui/src/main/kotlin/com/eblan/launcher/ui/settings/Settings.kt
+++ b/ui/src/main/kotlin/com/eblan/launcher/ui/settings/Settings.kt
@@ -237,9 +237,14 @@ fun SettingsCategoryText(
 @Composable
 fun rememberIsDefaultLauncher(): State<Boolean> {
     val packageManager = LocalPackageManager.current
+
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    return produceState(initialValue = false, key1 = lifecycleOwner) {
+    return produceState(
+        initialValue = false,
+        key1 = lifecycleOwner,
+        key2 = packageManager,
+    ) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             value = packageManager.isDefaultLauncher()
         }


### PR DESCRIPTION
Fixes #921 

This commit removes redundant `currentCoroutineContext().ensureActive()` calls from various use cases and utility functions. These calls were added to ensure coroutine cancellation but were found to be unnecessary in these specific contexts, as the surrounding operations already provided adequate cancellation points or were inherently short-lived.

The removal of these calls simplifies the code and may offer minor performance improvements by reducing overhead.

Affected files:
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/util/IconPackInfoUtil.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveGridItemUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveFolderGridItemUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/ResizeGridItemUseCase.kt
- domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/GridItemConstraints.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/LauncherAppsUtil.kt
- domain/grid/src/main/kotlin/com/eblan/launcher/domain/grid/MoveGridItem.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/AddPackageUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangePackageUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/ChangeShortcutsUseCase.kt
- framework/launcher-apps/src/main/kotlin/com/eblan/launcher/framework/launcherapps/DefaultLauncherAppsWrapper.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/RemovePackageUseCase.kt
- domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GridUtil.kt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quiet-mode controls for work and private spaces now provide more consistent status updates.
  - Default-launcher status is reflected more reliably across home and settings screens.
  - Package, profile, shortcut, widget, and icon-pack operations now run more smoothly in the background.

- **Bug Fixes**
  - Reduced unnecessary processing during launcher synchronization and grid operations.
  - Preserved existing grid movement, resizing, and conflict-resolution behavior.
  - Improved lifecycle handling when stopping home-screen synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->