### PR TITLE
build: Bump actions/upload-artifact from 4 to 7

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload Debug APK
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Debug APK output
           path: '**/build/outputs/apk/**/*.apk'
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload test reports
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports-${{ matrix.api-level }}
           path: '**/build/reports/androidTests'

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -87,7 +87,7 @@ jobs:
         run: ./gradlew :app:assembleRelease
 
       - name: Upload mapping file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mapping-${{ github.ref_name }}
           path: app/build/outputs/mapping/release/mapping.txt


### PR DESCRIPTION
You asked for more contributions…

Let's try again?

Release Notes: https://github.com/actions/upload-artifact/releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release artifact handling to use the latest supported upload action.
  * Build, test, and release workflows otherwise remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->