### PR TITLE
build: Bump actions/checkout from 4 to 7

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -31,7 +31,7 @@ jobs:
           ls /dev/kvm
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Grant execute permission to Gradle wrapper
         run: chmod +x ./gradlew
@@ -96,7 +96,7 @@ jobs:
           ls /dev/kvm
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Grant execute permission to Gradle wrapper
         run: chmod +x ./gradlew

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -24,7 +24,7 @@ jobs:
           ls /dev/kvm
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Grant execute permission to Gradle wrapper
         run: chmod +x ./gradlew


### PR DESCRIPTION
This should also remove the "Node 20" warning on the checkout step.

See-Also: https://github.com/actions/checkout/releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build and release automation to use the latest checkout action version.
  - Improves the reliability and maintenance of automated builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->