### PR TITLE
Folder Regression

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/UpdateGridItemsAfterMoveUseCase.kt
@@ -126,7 +126,10 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
         }
 
         gridRepository.updateGridItem(
-            gridItem = movingGridItem.copy(data = newData),
+            gridItem = movingGridItem.copy(
+                associate = conflictingGridItem.associate,
+                data = newData,
+            ),
         )
     }
 
@@ -203,7 +206,10 @@ class UpdateGridItemsAfterMoveUseCase @Inject constructor(
                     ),
                 ),
                 conflictingGridItem.copy(data = conflictingData),
-                movingGridItem.copy(data = movingData),
+                movingGridItem.copy(
+                    associate = conflictingGridItem.associate,
+                    data = movingData,
+                ),
             ),
         )
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/GridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/GridItem.kt
@@ -119,6 +119,7 @@ internal fun GridItemContent(
                 gridItemSettings = currentGridItemSettings,
                 textColor = currentTextColor,
                 previewFolderGridItems = previewFolderGridItems,
+                hasShortcutHostPermission = hasShortcutHostPermission,
             )
 
         is GridItemData.ShortcutConfig ->
@@ -251,12 +252,15 @@ private fun ShortcutInfoGridItem(
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
     ) {
-        Box(modifier = Modifier.size(gridItemSettings.iconSize.dp)) {
+        Box(
+            modifier = Modifier
+                .size(gridItemSettings.iconSize.dp)
+                .alpha(alpha),
+        ) {
             AsyncImage(
                 model = customIcon,
                 modifier = Modifier
-                    .matchParentSize()
-                    .alpha(alpha),
+                    .matchParentSize(),
                 contentDescription = null,
             )
 
@@ -264,8 +268,7 @@ private fun ShortcutInfoGridItem(
                 model = data.eblanApplicationInfoIcon,
                 modifier = Modifier
                     .size((gridItemSettings.iconSize * 0.25).dp)
-                    .align(Alignment.BottomEnd)
-                    .alpha(alpha),
+                    .align(Alignment.BottomEnd),
                 contentDescription = null,
             )
         }
@@ -293,6 +296,7 @@ private fun FolderGridItem(
     gridItemSettings: GridItemSettings,
     textColor: Color,
     previewFolderGridItems: Map<String, PreviewFolder>,
+    hasShortcutHostPermission: Boolean,
 ) {
     val horizontalAlignment =
         getHorizontalAlignment(horizontalAlignment = gridItemSettings.horizontalAlignment)
@@ -335,6 +339,7 @@ private fun FolderGridItem(
                         PreviewFolderGridItemContent(
                             gridItem = it,
                             textColor = textColor,
+                            hasShortcutHostPermission = hasShortcutHostPermission,
                         )
                     },
                 )
@@ -446,12 +451,26 @@ private fun PreviewFolderGridItemContent(
     modifier: Modifier = Modifier,
     gridItem: GridItem,
     textColor: Color,
+    hasShortcutHostPermission: Boolean,
 ) {
     val context = LocalContext.current
 
     key(gridItem.id) {
+        val alpha = when (val data = gridItem.data) {
+            is GridItemData.ApplicationInfo,
+            is GridItemData.Folder,
+            is GridItemData.ShortcutConfig,
+            is GridItemData.Widget,
+            -> 1f
+
+            is GridItemData.ShortcutInfo -> {
+                if (hasShortcutHostPermission && data.isEnabled) 1f else 0.3f
+            }
+        }
+
         val commonModifier = modifier
             .padding(1.dp)
+            .alpha(alpha)
 
         when (val data = gridItem.data) {
             is GridItemData.ApplicationInfo -> {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
@@ -17,8 +17,6 @@
  */
 package com.eblan.launcher.feature.home.screen.folder
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.State
 import androidx.compose.ui.graphics.ImageBitmap
@@ -42,10 +40,10 @@ import kotlin.time.Duration.Companion.milliseconds
 internal suspend fun handlePageDirection(
     pageDirection: PageDirection?,
     currentPage: Int,
-    progress: Animatable<Float, AnimationVector1D>,
+    progress: Float,
     onAnimateScrollToPage: suspend (Int) -> Unit,
 ) {
-    if (pageDirection == null || progress.value < 1f) return
+    if (pageDirection == null || progress < 1f) return
 
     delay(500L.milliseconds)
 
@@ -114,7 +112,7 @@ internal fun handleAnimateScrollToPage(
     layoutDirection: LayoutDirection,
     folderCellWidth: Int,
     isLast: Boolean,
-    progress: Animatable<Float, AnimationVector1D>,
+    progress: Float,
     onUpdateFolderPageDirection: (PageDirection?) -> Unit,
 ) {
     if (drag != Drag.Dragging ||
@@ -123,7 +121,7 @@ internal fun handleAnimateScrollToPage(
         lockMovement.value ||
         moveGridItemResult == null ||
         !isLast ||
-        progress.value < 1f
+        progress < 1f
     ) {
         return
     }
@@ -161,7 +159,7 @@ internal fun handleDragFolderGridItem(
     folderCellWidth: Int,
     folderCellHeight: Int,
     isLastFolderGridItem: Boolean,
-    progress: Animatable<Float, AnimationVector1D>,
+    progress: Float,
     onMoveFolderGridItem: (
         folderPopup: FolderPopup,
         movingFolderGridItem: GridItem,
@@ -181,7 +179,7 @@ internal fun handleDragFolderGridItem(
         lockMovement.value ||
         moveGridItemResult == null ||
         !isLastFolderGridItem ||
-        progress.value < 1f
+        progress < 1f
     ) {
         return
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
@@ -17,6 +17,8 @@
  */
 package com.eblan.launcher.feature.home.screen.folder
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.State
 import androidx.compose.ui.graphics.ImageBitmap
@@ -40,9 +42,10 @@ import kotlin.time.Duration.Companion.milliseconds
 internal suspend fun handlePageDirection(
     pageDirection: PageDirection?,
     currentPage: Int,
+    progress: Animatable<Float, AnimationVector1D>,
     onAnimateScrollToPage: suspend (Int) -> Unit,
 ) {
-    if (pageDirection == null) return
+    if (pageDirection == null || progress.value < 1f) return
 
     delay(500L.milliseconds)
 
@@ -111,6 +114,7 @@ internal fun handleAnimateScrollToPage(
     layoutDirection: LayoutDirection,
     folderCellWidth: Int,
     isLast: Boolean,
+    progress: Animatable<Float, AnimationVector1D>,
     onUpdateFolderPageDirection: (PageDirection?) -> Unit,
 ) {
     if (drag != Drag.Dragging ||
@@ -118,7 +122,8 @@ internal fun handleAnimateScrollToPage(
         !isDragging.value ||
         lockMovement.value ||
         moveGridItemResult == null ||
-        !isLast
+        !isLast ||
+        progress.value < 1f
     ) {
         return
     }
@@ -156,6 +161,7 @@ internal fun handleDragFolderGridItem(
     folderCellWidth: Int,
     folderCellHeight: Int,
     isLastFolderGridItem: Boolean,
+    progress: Animatable<Float, AnimationVector1D>,
     onMoveFolderGridItem: (
         folderPopup: FolderPopup,
         movingFolderGridItem: GridItem,
@@ -174,7 +180,8 @@ internal fun handleDragFolderGridItem(
         !isDragging.value ||
         lockMovement.value ||
         moveGridItemResult == null ||
-        !isLastFolderGridItem
+        !isLastFolderGridItem ||
+        progress.value < 1f
     ) {
         return
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
@@ -186,7 +186,7 @@ internal fun handleDragFolderGridItem(
         return
     }
 
-    val (intOffset, intSize) = calculateFolderGridDragPosition(
+    val folderGridDragPosition = calculateFolderGridDragPosition(
         density = density,
         dragIntOffset = dragIntOffset,
         folderPopup = folderPopup,
@@ -199,8 +199,8 @@ internal fun handleDragFolderGridItem(
         folderCellHeight = folderCellHeight,
     )
 
-    if (intOffset.x in 0 until intSize.width &&
-        intOffset.y in 0 until intSize.height
+    if (folderGridDragPosition.x in 0 until folderGridDragPosition.width &&
+        folderGridDragPosition.y in 0 until folderGridDragPosition.height
     ) {
         val movingGridItem = moveGridItemResult.movingGridItem
 
@@ -214,16 +214,23 @@ internal fun handleDragFolderGridItem(
         onMoveFolderGridItem(
             folderPopup,
             movingGridItem,
-            intOffset.x,
-            intOffset.y,
-            intSize.width,
-            intSize.height,
+            folderGridDragPosition.x,
+            folderGridDragPosition.y,
+            folderGridDragPosition.width,
+            folderGridDragPosition.height,
             currentPage,
         )
     } else if (!folderPopup.folderPopupEntry.isCloseFolder) {
         onUpsertFolderPopupEntry(folderPopup.folderPopupEntry.copy(isCloseFolder = true))
     }
 }
+
+private data class FolderGridDragPosition(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+)
 
 private fun calculateFolderPageDirection(
     density: Density,
@@ -288,7 +295,7 @@ private fun calculateFolderGridDragPosition(
     layoutDirection: LayoutDirection,
     folderCellWidth: Int,
     folderCellHeight: Int,
-): Pair<IntOffset, IntSize> {
+): FolderGridDragPosition {
     val leftPadding = with(density) {
         paddingValues.calculateLeftPadding(layoutDirection).roundToPx()
     }
@@ -371,6 +378,10 @@ private fun calculateFolderGridDragPosition(
         LayoutDirection.Ltr -> dragX
     }
 
-    return IntOffset(x = layoutDirectionX, y = dragY) to
-        IntSize(width = folderGridWidthPx, height = folderGridHeightPx)
+    return FolderGridDragPosition(
+        x = layoutDirectionX,
+        y = dragY,
+        width = folderGridWidthPx,
+        height = endHeight,
+    )
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -248,6 +248,7 @@ internal fun FolderScreen(
         folderPopup,
         moveGridItemResult,
         isLastFolderGridItem,
+        progress.value,
     ) {
         handleDragFolderGridItem(
             density = density,
@@ -268,7 +269,7 @@ internal fun FolderScreen(
             folderCellWidth = folderCellWidth,
             folderCellHeight = folderCellHeight,
             isLastFolderGridItem = isLastFolderGridItem,
-            progress = progress,
+            progress = progress.value,
             onMoveFolderGridItem = onMoveFolderGridItem,
             onUpdateSharedElementKey = onUpdateSharedElementKey,
             onUpsertFolderPopupEntry = onUpsertFolderPopupEntry,
@@ -292,11 +293,14 @@ internal fun FolderScreen(
         )
     }
 
-    LaunchedEffect(key1 = pageDirection) {
+    LaunchedEffect(
+        key1 = pageDirection,
+        key2 = progress.value,
+    ) {
         handlePageDirection(
             pageDirection = pageDirection,
             currentPage = folderGridHorizontalPagerState.currentPage,
-            progress = progress,
+            progress = progress.value,
             onAnimateScrollToPage = folderGridHorizontalPagerState::animateScrollToPage,
         )
     }
@@ -313,6 +317,7 @@ internal fun FolderScreen(
         moveGridItemResult,
         folderPopup,
         isLastFolderGridItem,
+        progress.value,
     ) {
         handleAnimateScrollToPage(
             density = density,
@@ -329,7 +334,7 @@ internal fun FolderScreen(
             layoutDirection = layoutDirection,
             folderCellWidth = folderCellWidth,
             isLast = isLastFolderGridItem,
-            progress = progress,
+            progress = progress.value,
             onUpdateFolderPageDirection = {
                 pageDirection = it
             },

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
+import com.eblan.launcher.domain.model.Associate
 import com.eblan.launcher.domain.model.FolderPopup
 import com.eblan.launcher.domain.model.FolderPopupEntry
 import com.eblan.launcher.domain.model.GridItem
@@ -570,13 +571,6 @@ private suspend fun handleFolderPopup(
         isVisibleOverlay.value &&
         gridItem != null
     ) {
-        onUpdateSharedElementKey(
-            SharedElementKey(
-                id = gridItem.id,
-                parent = SharedElementKey.Parent.Grid,
-            ),
-        )
-
         val newGridItem = when (val data = gridItem.data) {
             is GridItemData.ApplicationInfo -> {
                 gridItem.copy(
@@ -628,6 +622,16 @@ private suspend fun handleFolderPopup(
 
             is GridItemData.Widget -> error("Unsupported Folder Grid Item")
         }
+
+        onUpdateSharedElementKey(
+            SharedElementKey(
+                id = gridItem.id,
+                parent = when (folderPopup.gridItem.associate) {
+                    Associate.Grid -> SharedElementKey.Parent.Grid
+                    Associate.Dock -> SharedElementKey.Parent.Dock
+                },
+            ),
+        )
 
         onMoveFolderGridItemOutsideFolder(newGridItem)
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -268,6 +268,7 @@ internal fun FolderScreen(
             folderCellWidth = folderCellWidth,
             folderCellHeight = folderCellHeight,
             isLastFolderGridItem = isLastFolderGridItem,
+            progress = progress,
             onMoveFolderGridItem = onMoveFolderGridItem,
             onUpdateSharedElementKey = onUpdateSharedElementKey,
             onUpsertFolderPopupEntry = onUpsertFolderPopupEntry,
@@ -295,6 +296,7 @@ internal fun FolderScreen(
         handlePageDirection(
             pageDirection = pageDirection,
             currentPage = folderGridHorizontalPagerState.currentPage,
+            progress = progress,
             onAnimateScrollToPage = folderGridHorizontalPagerState::animateScrollToPage,
         )
     }
@@ -327,6 +329,7 @@ internal fun FolderScreen(
             layoutDirection = layoutDirection,
             folderCellWidth = folderCellWidth,
             isLast = isLastFolderGridItem,
+            progress = progress,
             onUpdateFolderPageDirection = {
                 pageDirection = it
             },
@@ -549,78 +552,82 @@ private suspend fun handleFolderPopup(
     onMoveFolderGridItemOutsideFolder: (GridItem) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
-    if (folderPopup.folderPopupEntry.isCloseFolder) {
-        onAnimateToScrollToPage(0)
+    if (!folderPopup.folderPopupEntry.isCloseFolder) return
 
-        progress.animateTo(targetValue = 0f)
+    onAnimateToScrollToPage(0)
 
-        val gridItem = moveGridItemResult.value?.movingGridItem
+    progress.animateTo(targetValue = 0f)
 
-        if (drag.value == Drag.Dragging && isDragging.value && isVisibleOverlay.value && gridItem != null) {
-            onUpdateSharedElementKey(
-                SharedElementKey(
-                    id = gridItem.id,
-                    parent = SharedElementKey.Parent.Grid,
-                ),
-            )
+    val gridItem = moveGridItemResult.value?.movingGridItem
 
-            val newGridItem = when (val data = gridItem.data) {
-                is GridItemData.ApplicationInfo -> {
-                    gridItem.copy(
-                        page = folderPopup.gridItem.page,
-                        startColumn = folderPopup.gridItem.startColumn,
-                        startRow = folderPopup.gridItem.startRow,
-                        data = data.copy(
-                            index = -1,
-                            folderId = null,
-                        ),
-                    )
-                }
+    if (drag.value == Drag.Dragging &&
+        isDragging.value &&
+        isVisibleOverlay.value &&
+        gridItem != null
+    ) {
+        onUpdateSharedElementKey(
+            SharedElementKey(
+                id = gridItem.id,
+                parent = SharedElementKey.Parent.Grid,
+            ),
+        )
 
-                is GridItemData.Folder -> {
-                    gridItem.copy(
-                        page = folderPopup.gridItem.page,
-                        startColumn = folderPopup.gridItem.startColumn,
-                        startRow = folderPopup.gridItem.startRow,
-                        data = data.copy(
-                            index = -1,
-                            folderId = null,
-                        ),
-                    )
-                }
-
-                is GridItemData.ShortcutConfig -> {
-                    gridItem.copy(
-                        page = folderPopup.gridItem.page,
-                        startColumn = folderPopup.gridItem.startColumn,
-                        startRow = folderPopup.gridItem.startRow,
-                        data = data.copy(
-                            index = -1,
-                            folderId = null,
-                        ),
-                    )
-                }
-
-                is GridItemData.ShortcutInfo -> {
-                    gridItem.copy(
-                        page = folderPopup.gridItem.page,
-                        startColumn = folderPopup.gridItem.startColumn,
-                        startRow = folderPopup.gridItem.startRow,
-                        data = data.copy(
-                            index = -1,
-                            folderId = null,
-                        ),
-                    )
-                }
-
-                is GridItemData.Widget -> error("Unsupported Folder Grid Item")
+        val newGridItem = when (val data = gridItem.data) {
+            is GridItemData.ApplicationInfo -> {
+                gridItem.copy(
+                    page = folderPopup.gridItem.page,
+                    startColumn = folderPopup.gridItem.startColumn,
+                    startRow = folderPopup.gridItem.startRow,
+                    data = data.copy(
+                        index = -1,
+                        folderId = null,
+                    ),
+                )
             }
 
-            onMoveFolderGridItemOutsideFolder(newGridItem)
+            is GridItemData.Folder -> {
+                gridItem.copy(
+                    page = folderPopup.gridItem.page,
+                    startColumn = folderPopup.gridItem.startColumn,
+                    startRow = folderPopup.gridItem.startRow,
+                    data = data.copy(
+                        index = -1,
+                        folderId = null,
+                    ),
+                )
+            }
+
+            is GridItemData.ShortcutConfig -> {
+                gridItem.copy(
+                    page = folderPopup.gridItem.page,
+                    startColumn = folderPopup.gridItem.startColumn,
+                    startRow = folderPopup.gridItem.startRow,
+                    data = data.copy(
+                        index = -1,
+                        folderId = null,
+                    ),
+                )
+            }
+
+            is GridItemData.ShortcutInfo -> {
+                gridItem.copy(
+                    page = folderPopup.gridItem.page,
+                    startColumn = folderPopup.gridItem.startColumn,
+                    startRow = folderPopup.gridItem.startRow,
+                    data = data.copy(
+                        index = -1,
+                        folderId = null,
+                    ),
+                )
+            }
+
+            is GridItemData.Widget -> error("Unsupported Folder Grid Item")
         }
 
-        onDeleteFolderPopupEntry(folderPopup.folderPopupEntry)
+        onMoveFolderGridItemOutsideFolder(newGridItem)
     }
+
+    onDeleteFolderPopupEntry(folderPopup.folderPopupEntry)
 }
 
 private fun getFolderPopupLayoutInfo(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -597,7 +597,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
         verticalArrangement = verticalArrangement,
     ) {
         Box(
-            modifier = Modifier.size(gridItemSettings.iconSize.dp),
+            modifier = Modifier.size(gridItemSettings.iconSize.dp).alpha(alpha),
         ) {
             AsyncImage(
                 model = Builder(context).data(customIcon).addLastModifiedToFileCacheKey(true)
@@ -642,6 +642,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
                     .build(),
                 modifier = Modifier
                     .size((gridItemSettings.iconSize * 0.25).dp)
+                    .alpha(alpha)
                     .align(Alignment.BottomEnd),
                 contentDescription = null,
             )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -597,7 +597,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
         verticalArrangement = verticalArrangement,
     ) {
         Box(
-            modifier = Modifier.size(gridItemSettings.iconSize.dp).alpha(alpha),
+            modifier = Modifier.size(gridItemSettings.iconSize.dp),
         ) {
             AsyncImage(
                 model = Builder(context).data(customIcon).addLastModifiedToFileCacheKey(true)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -251,6 +251,7 @@ internal fun InteractiveFolderGridItem(
                 sharedElementKey = sharedElementKey,
                 showFolderGridItemPopup = showFolderGridItemPopup,
                 previewFolderGridItems = previewFolderGridItems,
+                hasShortcutHostPermission = hasShortcutHostPermission,
                 onUpdateIsCloseFolderGridItemPopup = onUpdateIsCloseFolderGridItemPopup,
                 onOpenAppDrawer = onOpenAppDrawer,
                 onShowGridItemPopup = onShowGridItemPopup,
@@ -406,30 +407,34 @@ private fun InteractiveFolderApplicationInfoGridItem(
                 model = Builder(context).data(data.customIcon ?: icon)
                     .addLastModifiedToFileCacheKey(true).size(Size.ORIGINAL).build(),
                 contentDescription = null,
-                modifier = Modifier.matchParentSize().drawWithContent {
-                    graphicsLayer.record {
-                        this@drawWithContent.drawContent()
+                modifier = Modifier
+                    .matchParentSize()
+                    .onGloballyPositioned { layoutCoordinates ->
+                        intOffset = layoutCoordinates.positionInRoot().round()
+
+                        intSize = layoutCoordinates.size
                     }
-
-                    drawLayer(graphicsLayer)
-                }.onGloballyPositioned { layoutCoordinates ->
-                    intOffset = layoutCoordinates.positionInRoot().round()
-
-                    intSize = layoutCoordinates.size
-                }.run {
-                    if (!isScrollInProgress && !hasInteraction) {
-                        with(sharedTransitionScope) {
-                            sharedElementWithCallerManagedVisibility(
-                                rememberSharedContentState(
-                                    key = sharedElementKey,
-                                ),
-                                visible = true,
-                            )
+                    .run {
+                        if (!isScrollInProgress && !hasInteraction) {
+                            with(sharedTransitionScope) {
+                                sharedElementWithCallerManagedVisibility(
+                                    rememberSharedContentState(
+                                        key = sharedElementKey,
+                                    ),
+                                    visible = true,
+                                )
+                            }
+                        } else {
+                            this
                         }
-                    } else {
-                        this
                     }
-                },
+                    .drawWithContent {
+                        graphicsLayer.record {
+                            this@drawWithContent.drawContent()
+                        }
+
+                        drawLayer(graphicsLayer)
+                    },
             )
 
             if (isNotificationAccessGranted && hasNotifications) {
@@ -592,37 +597,43 @@ private fun InteractiveFolderShortcutInfoGridItem(
         verticalArrangement = verticalArrangement,
     ) {
         Box(
-            modifier = Modifier
-                .size(gridItemSettings.iconSize.dp)
-                .alpha(alpha),
+            modifier = Modifier.size(gridItemSettings.iconSize.dp),
         ) {
             AsyncImage(
                 model = Builder(context).data(customIcon).addLastModifiedToFileCacheKey(true)
                     .size(Size.ORIGINAL).build(),
-                modifier = Modifier.matchParentSize().drawWithContent {
-                    graphicsLayer.record {
-                        this@drawWithContent.drawContent()
+                modifier = Modifier
+                    .matchParentSize()
+                    .onGloballyPositioned { layoutCoordinates ->
+                        intOffset = layoutCoordinates.positionInRoot().round()
+
+                        intSize = layoutCoordinates.size
                     }
-
-                    drawLayer(graphicsLayer)
-                }.onGloballyPositioned { layoutCoordinates ->
-                    intOffset = layoutCoordinates.positionInRoot().round()
-
-                    intSize = layoutCoordinates.size
-                }.run {
-                    if (!isScrollInProgress && !hasInteraction) {
-                        with(sharedTransitionScope) {
-                            sharedElementWithCallerManagedVisibility(
-                                rememberSharedContentState(
-                                    key = sharedElementKey,
-                                ),
-                                visible = true,
-                            )
+                    .run {
+                        if (!isScrollInProgress && !hasInteraction) {
+                            with(sharedTransitionScope) {
+                                sharedElementWithCallerManagedVisibility(
+                                    rememberSharedContentState(
+                                        key = sharedElementKey,
+                                    ),
+                                    visible = true,
+                                )
+                            }
+                        } else {
+                            this
                         }
-                    } else {
-                        this
                     }
-                },
+                    .drawWithContent {
+                        graphicsLayer.apply {
+                            this.alpha = alpha
+                        }
+
+                        graphicsLayer.record {
+                            this@drawWithContent.drawContent()
+                        }
+
+                        drawLayer(graphicsLayer)
+                    },
                 contentDescription = null,
             )
 
@@ -780,30 +791,34 @@ private fun InteractiveFolderShortcutConfigGridItem(
             model = Builder(context).data(icon).addLastModifiedToFileCacheKey(true)
                 .size(Size.ORIGINAL).build(),
             contentDescription = null,
-            modifier = Modifier.size(gridItemSettings.iconSize.dp).alpha(alpha).drawWithContent {
-                graphicsLayer.record {
-                    this@drawWithContent.drawContent()
+            modifier = Modifier
+                .size(gridItemSettings.iconSize.dp)
+                .onGloballyPositioned { layoutCoordinates ->
+                    intOffset = layoutCoordinates.positionInRoot().round()
+
+                    intSize = layoutCoordinates.size
                 }
-
-                drawLayer(graphicsLayer)
-            }.onGloballyPositioned { layoutCoordinates ->
-                intOffset = layoutCoordinates.positionInRoot().round()
-
-                intSize = layoutCoordinates.size
-            }.run {
-                if (!isScrollInProgress && !hasInteraction) {
-                    with(sharedTransitionScope) {
-                        sharedElementWithCallerManagedVisibility(
-                            rememberSharedContentState(
-                                key = sharedElementKey,
-                            ),
-                            visible = true,
-                        )
+                .run {
+                    if (!isScrollInProgress && !hasInteraction) {
+                        with(sharedTransitionScope) {
+                            sharedElementWithCallerManagedVisibility(
+                                rememberSharedContentState(
+                                    key = sharedElementKey,
+                                ),
+                                visible = true,
+                            )
+                        }
+                    } else {
+                        this
                     }
-                } else {
-                    this
                 }
-            },
+                .drawWithContent {
+                    graphicsLayer.record {
+                        this@drawWithContent.drawContent()
+                    }
+
+                    drawLayer(graphicsLayer)
+                }.alpha(alpha),
         )
 
         if (gridItemSettings.showLabel) {
@@ -834,6 +849,7 @@ private fun InteractiveNestedFolderGridItem(
     sharedElementKey: SharedElementKey,
     showFolderGridItemPopup: Boolean,
     previewFolderGridItems: Map<String, PreviewFolder>,
+    hasShortcutHostPermission: Boolean,
     onUpdateIsCloseFolderGridItemPopup: (Boolean) -> Unit,
     onOpenAppDrawer: () -> Unit,
     onShowGridItemPopup: (
@@ -957,30 +973,34 @@ private fun InteractiveNestedFolderGridItem(
         verticalArrangement = verticalArrangement,
     ) {
         val commonModifier =
-            Modifier.size(gridItemSettings.iconSize.dp).alpha(alpha).drawWithContent {
-                graphicsLayer.record {
-                    this@drawWithContent.drawContent()
+            Modifier
+                .size(gridItemSettings.iconSize.dp)
+                .onGloballyPositioned { layoutCoordinates ->
+                    intOffset = layoutCoordinates.positionInRoot().round()
+
+                    intSize = layoutCoordinates.size
                 }
-
-                drawLayer(graphicsLayer)
-            }.onGloballyPositioned { layoutCoordinates ->
-                intOffset = layoutCoordinates.positionInRoot().round()
-
-                intSize = layoutCoordinates.size
-            }.run {
-                if (!isScrollInProgress && !hasInteraction) {
-                    with(sharedTransitionScope) {
-                        sharedElementWithCallerManagedVisibility(
-                            rememberSharedContentState(
-                                key = sharedElementKey,
-                            ),
-                            visible = true,
-                        )
+                .run {
+                    if (!isScrollInProgress && !hasInteraction) {
+                        with(sharedTransitionScope) {
+                            sharedElementWithCallerManagedVisibility(
+                                rememberSharedContentState(
+                                    key = sharedElementKey,
+                                ),
+                                visible = true,
+                            )
+                        }
+                    } else {
+                        this
                     }
-                } else {
-                    this
                 }
-            }
+                .drawWithContent {
+                    graphicsLayer.record {
+                        this@drawWithContent.drawContent()
+                    }
+
+                    drawLayer(graphicsLayer)
+                }.alpha(alpha)
 
         if (data.icon != null) {
             AsyncImage(
@@ -1002,6 +1022,7 @@ private fun InteractiveNestedFolderGridItem(
                         PreviewNestedFolderGridItem(
                             alpha = alpha,
                             gridItem = it,
+                            hasShortcutHostPermission = hasShortcutHostPermission,
                         )
                     },
                 )
@@ -1026,10 +1047,23 @@ private fun PreviewNestedFolderGridItem(
     modifier: Modifier = Modifier,
     alpha: Float,
     gridItem: GridItem,
+    hasShortcutHostPermission: Boolean,
 ) {
     val context = LocalContext.current
 
     key(gridItem.id) {
+        val alpha = when (val data = gridItem.data) {
+            is GridItemData.ApplicationInfo,
+            is GridItemData.Folder,
+            is GridItemData.ShortcutConfig,
+            is GridItemData.Widget,
+            -> alpha
+
+            is GridItemData.ShortcutInfo -> {
+                if (hasShortcutHostPermission && data.isEnabled) 1f else 0.3f
+            }
+        }
+
         val commonModifier = modifier
             .padding(1.dp)
             .alpha(alpha)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -515,7 +515,9 @@ private fun InteractiveFolderShortcutInfoGridItem(
 
     val hasInteraction = isSelected && isVisibleOverlay
 
-    val alpha = if (hasInteraction) 0f else 1f
+    val defaultAlpha = if (hasShortcutHostPermission && data.isEnabled) 1f else 0.3f
+
+    val alpha = if (hasInteraction) 0f else defaultAlpha
 
     Column(
         modifier = modifier

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -288,6 +288,7 @@ internal fun InteractiveGridItem(
                 hasInteraction = hasInteraction,
                 isVisibleWhiteBox = isVisibleWhiteBox,
                 previewFolderGridItems = previewFolderGridItems,
+                hasShortcutHostPermission = hasShortcutHostPermission,
                 onOpenAppDrawer = onOpenAppDrawer,
                 onShowGridItemPopup = onShowGridItemPopup,
                 onUpsertFolderPopupEntry = onUpsertFolderPopupEntry,
@@ -507,13 +508,6 @@ private fun InteractiveApplicationInfoGridItem(
                 contentDescription = null,
                 modifier = Modifier
                     .matchParentSize()
-                    .drawWithContent {
-                        graphicsLayer.record {
-                            this@drawWithContent.drawContent()
-                        }
-
-                        drawLayer(graphicsLayer)
-                    }
                     .onGloballyPositioned { layoutCoordinates ->
                         intOffset = layoutCoordinates.positionInRoot().round()
 
@@ -532,6 +526,13 @@ private fun InteractiveApplicationInfoGridItem(
                         } else {
                             this
                         }
+                    }
+                    .drawWithContent {
+                        graphicsLayer.record {
+                            this@drawWithContent.drawContent()
+                        }
+
+                        drawLayer(graphicsLayer)
                     },
             )
 
@@ -612,14 +613,6 @@ private fun InteractiveWidgetGridItem(
     ) {
         val commonModifier = Modifier
             .matchParentSize()
-            .alpha(alpha)
-            .drawWithContent {
-                graphicsLayer.record {
-                    this@drawWithContent.drawContent()
-                }
-
-                drawLayer(graphicsLayer)
-            }
             .onGloballyPositioned { layoutCoordinates ->
                 intOffset = layoutCoordinates.positionInRoot().round()
 
@@ -639,6 +632,14 @@ private fun InteractiveWidgetGridItem(
                     this
                 }
             }
+            .drawWithContent {
+                graphicsLayer.record {
+                    this@drawWithContent.drawContent()
+                }
+
+                drawLayer(graphicsLayer)
+            }
+            .alpha(alpha)
 
         if (appWidgetInfo != null) {
             AndroidView(
@@ -848,9 +849,7 @@ private fun InteractiveShortcutInfoGridItem(
         verticalArrangement = verticalArrangement,
     ) {
         Box(
-            modifier = Modifier
-                .size(gridItemSettings.iconSize.dp)
-                .alpha(alpha),
+            modifier = Modifier.size(gridItemSettings.iconSize.dp),
         ) {
             AsyncImage(
                 model = Builder(context).data(customIcon)
@@ -859,13 +858,6 @@ private fun InteractiveShortcutInfoGridItem(
                     .build(),
                 modifier = Modifier
                     .matchParentSize()
-                    .drawWithContent {
-                        graphicsLayer.record {
-                            this@drawWithContent.drawContent()
-                        }
-
-                        drawLayer(graphicsLayer)
-                    }
                     .onGloballyPositioned { layoutCoordinates ->
                         intOffset = layoutCoordinates.positionInRoot().round()
 
@@ -884,6 +876,17 @@ private fun InteractiveShortcutInfoGridItem(
                         } else {
                             this
                         }
+                    }
+                    .drawWithContent {
+                        graphicsLayer.apply {
+                            this.alpha = alpha
+                        }
+
+                        graphicsLayer.record {
+                            this@drawWithContent.drawContent()
+                        }
+
+                        drawLayer(graphicsLayer)
                     },
                 contentDescription = null,
             )
@@ -894,6 +897,7 @@ private fun InteractiveShortcutInfoGridItem(
                     .build(),
                 modifier = Modifier
                     .size((gridItemSettings.iconSize * 0.25).dp)
+                    .alpha(alpha)
                     .align(Alignment.BottomEnd),
                 contentDescription = null,
             )
@@ -933,6 +937,7 @@ private fun InteractiveFolderGridItem(
     hasInteraction: Boolean,
     isVisibleWhiteBox: Boolean,
     previewFolderGridItems: Map<String, PreviewFolder>,
+    hasShortcutHostPermission: Boolean,
     onOpenAppDrawer: () -> Unit,
     onShowGridItemPopup: (
         intOffset: IntOffset,
@@ -981,7 +986,8 @@ private fun InteractiveFolderGridItem(
     val currentIsVisibleOverlay = rememberUpdatedState(isVisibleOverlay)
     val currentGridItem = rememberUpdatedState(gridItem)
     val currentLockMovement = rememberUpdatedState(lockMovement)
-    val currentFolderGridItems = rememberUpdatedState(previewFolderGridItems[gridItem.id]?.folderGridItems)
+    val currentFolderGridItems =
+        rememberUpdatedState(previewFolderGridItems[gridItem.id]?.folderGridItems)
 
     LaunchedEffect(key1 = moveGridItemResult) {
         handleConflictingGridItem(
@@ -1075,14 +1081,6 @@ private fun InteractiveFolderGridItem(
     ) {
         val commonModifier = Modifier
             .size(gridItemSettings.iconSize.dp)
-            .alpha(alpha)
-            .drawWithContent {
-                graphicsLayer.record {
-                    this@drawWithContent.drawContent()
-                }
-
-                drawLayer(graphicsLayer)
-            }
             .onGloballyPositioned { layoutCoordinates ->
                 intOffset = layoutCoordinates.positionInRoot().round()
 
@@ -1102,6 +1100,13 @@ private fun InteractiveFolderGridItem(
                     this
                 }
             }
+            .drawWithContent {
+                graphicsLayer.record {
+                    this@drawWithContent.drawContent()
+                }
+
+                drawLayer(graphicsLayer)
+            }.alpha(alpha)
 
         if (data.icon != null) {
             AsyncImage(
@@ -1131,6 +1136,7 @@ private fun InteractiveFolderGridItem(
                             drag = drag,
                             folderGridItems = previewFolderGridItems[gridItem.id]?.folderGridItems,
                             isVisibleFolder = isVisibleFolder,
+                            hasShortcutHostPermission = hasShortcutHostPermission,
                             onResetGrid = onResetGrid,
                         )
                     },
@@ -1294,14 +1300,6 @@ private fun InteractiveShortcutConfigGridItem(
             contentDescription = null,
             modifier = Modifier
                 .size(gridItemSettings.iconSize.dp)
-                .alpha(alpha)
-                .drawWithContent {
-                    graphicsLayer.record {
-                        this@drawWithContent.drawContent()
-                    }
-
-                    drawLayer(graphicsLayer)
-                }
                 .onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 
@@ -1320,7 +1318,14 @@ private fun InteractiveShortcutConfigGridItem(
                     } else {
                         this
                     }
-                },
+                }
+                .drawWithContent {
+                    graphicsLayer.record {
+                        this@drawWithContent.drawContent()
+                    }
+
+                    drawLayer(graphicsLayer)
+                }.alpha(alpha),
         )
 
         if (gridItemSettings.showLabel) {
@@ -1350,6 +1355,7 @@ private fun PreviewFolderGridItem(
     drag: Drag,
     folderGridItems: List<GridItem>?,
     isVisibleFolder: Boolean,
+    hasShortcutHostPermission: Boolean,
     onResetGrid: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -1360,11 +1366,26 @@ private fun PreviewFolderGridItem(
 
         val hasInteraction = isSelected && isVisibleOverlay
 
-        val alpha = if (hasInteraction) 0f else 1f
+        val alpha = when (val data = gridItem.data) {
+            is GridItemData.ApplicationInfo,
+            is GridItemData.Folder,
+            is GridItemData.ShortcutConfig,
+            is GridItemData.Widget,
+            -> if (hasInteraction) 0f else 1f
+
+            is GridItemData.ShortcutInfo -> {
+                if (hasInteraction) {
+                    0f
+                } else if (hasShortcutHostPermission && data.isEnabled) {
+                    1f
+                } else {
+                    0.3f
+                }
+            }
+        }
 
         val commonModifier = modifier
             .padding(1.dp)
-            .alpha(alpha)
             .run {
                 if (!isScrollInProgress && !hasInteraction) {
                     with(sharedTransitionScope) {
@@ -1382,6 +1403,7 @@ private fun PreviewFolderGridItem(
                     this
                 }
             }
+            .alpha(alpha)
 
         LaunchedEffect(
             drag,


### PR DESCRIPTION
Fixes ShortcutInfo Default Transparency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Shortcut icons, labels, and preview items now appear dimmed when shortcuts are unavailable or disabled.
  * Available shortcuts remain fully visible.
  * Icon appearance is more consistent across folders, widgets, applications, and shortcut configurations.

* **Bug Fixes**
  * Improved folder drag and page transitions for smoother, more consistent movement.
  * Restored folder items correctly when closing folders.
  * Unavailable shortcut interaction overlays remain hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->