### PR TITLE
test: Add Domain Tests For Grid Only

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check Spotless
         run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
 
+      - name: Run Unit Tests
+        run: ./gradlew test
+
       - name: Assemble Debug
         run: ./gradlew :app:assembleDebug
 

--- a/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
@@ -21,11 +21,13 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.kotlin
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
@@ -47,6 +49,12 @@ class JvmLibraryConventionPlugin : Plugin<Project> {
 
             dependencies {
                 add("implementation", kotlin("stdlib"))
+                add("testImplementation", libs.junit.jupiter)
+                add("testRuntimeOnly", libs.junit.platform.launcher)
+            }
+
+            tasks.withType<Test>().configureEach {
+                useJUnitPlatform()
             }
         }
     }

--- a/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/GridItemConstraintsTest.kt
+++ b/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/GridItemConstraintsTest.kt
@@ -345,9 +345,18 @@ class GridItemConstraintsTest {
                 rowSpan = 2,
             )
 
-            assertEquals(
-                rectanglesOverlap(moving, other),
-                rectanglesOverlap(other, moving),
+            assertTrue(
+                rectanglesOverlap(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+
+            assertTrue(
+                rectanglesOverlap(
+                    moving = other,
+                    other = moving,
+                ),
             )
         }
     }

--- a/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/GridItemConstraintsTest.kt
+++ b/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/GridItemConstraintsTest.kt
@@ -1,0 +1,1152 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.domain.grid
+
+import com.eblan.launcher.domain.model.Associate
+import com.eblan.launcher.domain.model.EblanAction
+import com.eblan.launcher.domain.model.EblanActionType
+import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.model.GridItemData
+import com.eblan.launcher.domain.model.GridItemSettings
+import com.eblan.launcher.domain.model.HorizontalAlignment
+import com.eblan.launcher.domain.model.ResolveDirection
+import com.eblan.launcher.domain.model.TextColor
+import com.eblan.launcher.domain.model.VerticalArrangement
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+
+class GridItemConstraintsTest {
+    @Nested
+    inner class IsGridItemSpanWithinBounds {
+        @Test
+        fun `returns true when grid item is within bounds`() {
+            val gridItem = gridItem(
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            assertTrue(
+                isGridItemSpanWithinBounds(
+                    gridItem = gridItem,
+                    columns = 5,
+                    rows = 4,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns true when grid item exactly reaches right boundary`() {
+            val gridItem = gridItem(
+                startColumn = 3,
+                startRow = 0,
+                columnSpan = 2,
+                rowSpan = 1,
+            )
+
+            assertTrue(
+                isGridItemSpanWithinBounds(
+                    gridItem = gridItem,
+                    columns = 5,
+                    rows = 4,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns true when grid item exactly reaches bottom boundary`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 2,
+                columnSpan = 1,
+                rowSpan = 2,
+            )
+
+            assertTrue(
+                isGridItemSpanWithinBounds(
+                    gridItem = gridItem,
+                    columns = 5,
+                    rows = 4,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when start column is negative`() {
+            val gridItem = gridItem(
+                startColumn = -1,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertFalse(
+                isGridItemSpanWithinBounds(
+                    gridItem = gridItem,
+                    columns = 5,
+                    rows = 4,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when start row is negative`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = -1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertFalse(
+                isGridItemSpanWithinBounds(
+                    gridItem = gridItem,
+                    columns = 5,
+                    rows = 4,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when column span exceeds right boundary`() {
+            val gridItem = gridItem(
+                startColumn = 4,
+                startRow = 0,
+                columnSpan = 2,
+                rowSpan = 1,
+            )
+
+            assertFalse(
+                isGridItemSpanWithinBounds(
+                    gridItem = gridItem,
+                    columns = 5,
+                    rows = 4,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when row span exceeds bottom boundary`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 3,
+                columnSpan = 1,
+                rowSpan = 2,
+            )
+
+            assertFalse(
+                isGridItemSpanWithinBounds(
+                    gridItem = gridItem,
+                    columns = 5,
+                    rows = 4,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when grid item starts at column boundary`() {
+            val gridItem = gridItem(
+                startColumn = 5,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertFalse(
+                isGridItemSpanWithinBounds(
+                    gridItem = gridItem,
+                    columns = 5,
+                    rows = 4,
+                ),
+            )
+        }
+    }
+
+    @Nested
+    inner class RectanglesOverlap {
+        @Test
+        fun `returns true when rectangles overlap`() {
+            val moving = gridItem(
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            val other = gridItem(
+                startColumn = 2,
+                startRow = 2,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            assertTrue(
+                rectanglesOverlap(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when rectangles are separated horizontally`() {
+            val moving = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 1,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertFalse(
+                rectanglesOverlap(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when rectangles are separated vertically`() {
+            val moving = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 0,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertFalse(
+                rectanglesOverlap(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when rectangles only touch at a corner`() {
+            val moving = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertFalse(
+                rectanglesOverlap(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns true when moving rectangle is completely inside other rectangle`() {
+            val moving = gridItem(
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 3,
+                rowSpan = 3,
+            )
+
+            assertTrue(
+                rectanglesOverlap(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns true when other rectangle is completely inside moving rectangle`() {
+            val moving = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 3,
+                rowSpan = 3,
+            )
+
+            val other = gridItem(
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertTrue(
+                rectanglesOverlap(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns same result regardless of rectangle order`() {
+            val moving = gridItem(
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            val other = gridItem(
+                startColumn = 2,
+                startRow = 2,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            assertEquals(
+                rectanglesOverlap(moving, other),
+                rectanglesOverlap(other, moving),
+            )
+        }
+    }
+
+    @Nested
+    inner class GetResolveDirectionByX {
+        @Test
+        fun `returns right when x is in first third of grid item`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 3,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Right,
+                getResolveDirectionByX(
+                    gridItem = gridItem,
+                    x = 20,
+                    columns = 5,
+                    gridWidth = 500,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns center when x is in middle third of grid item`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 3,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Center,
+                getResolveDirectionByX(
+                    gridItem = gridItem,
+                    x = 150,
+                    columns = 5,
+                    gridWidth = 500,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns left when x is in last third of grid item`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 3,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Left,
+                getResolveDirectionByX(
+                    gridItem = gridItem,
+                    x = 280,
+                    columns = 5,
+                    gridWidth = 500,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns center when x is exactly at first third boundary`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 3,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Center,
+                getResolveDirectionByX(
+                    gridItem = gridItem,
+                    x = 100,
+                    columns = 5,
+                    gridWidth = 500,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns left when x is exactly at second third boundary`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 3,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Left,
+                getResolveDirectionByX(
+                    gridItem = gridItem,
+                    x = 200,
+                    columns = 5,
+                    gridWidth = 500,
+                ),
+            )
+        }
+
+        @Test
+        fun `accounts for grid item starting column`() {
+            val gridItem = gridItem(
+                startColumn = 2,
+                startRow = 0,
+                columnSpan = 2,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Right,
+                getResolveDirectionByX(
+                    gridItem = gridItem,
+                    x = 210,
+                    columns = 5,
+                    gridWidth = 500,
+                ),
+            )
+        }
+    }
+
+    @Nested
+    inner class GetGridItemByCoordinates {
+        @Test
+        fun `returns grid item when coordinates are inside its span`() {
+            val gridItem = gridItem(
+                id = "target",
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            val result = getGridItemByCoordinates(
+                id = "moving",
+                gridItems = listOf(gridItem),
+                columns = 5,
+                rows = 4,
+                x = 150,
+                y = 150,
+                gridWidth = 500,
+                gridHeight = 400,
+            )
+
+            assertEquals(gridItem, result)
+        }
+
+        @Test
+        fun `returns null when coordinates are outside grid item span`() {
+            val gridItem = gridItem(
+                id = "target",
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            val result = getGridItemByCoordinates(
+                id = "moving",
+                gridItems = listOf(gridItem),
+                columns = 5,
+                rows = 4,
+                x = 50,
+                y = 50,
+                gridWidth = 500,
+                gridHeight = 400,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `returns null when coordinates are inside item with same id`() {
+            val gridItem = gridItem(
+                id = "target",
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            val result = getGridItemByCoordinates(
+                id = "target",
+                gridItems = listOf(gridItem),
+                columns = 5,
+                rows = 4,
+                x = 150,
+                y = 150,
+                gridWidth = 500,
+                gridHeight = 400,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `returns item when coordinates are inside second column of its span`() {
+            val gridItem = gridItem(
+                id = "target",
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 2,
+                rowSpan = 1,
+            )
+
+            val result = getGridItemByCoordinates(
+                id = "moving",
+                gridItems = listOf(gridItem),
+                columns = 5,
+                rows = 4,
+                x = 250,
+                y = 150,
+                gridWidth = 500,
+                gridHeight = 400,
+            )
+
+            assertEquals(gridItem, result)
+        }
+
+        @Test
+        fun `returns item when coordinates are inside second row of its span`() {
+            val gridItem = gridItem(
+                id = "target",
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 2,
+            )
+
+            val result = getGridItemByCoordinates(
+                id = "moving",
+                gridItems = listOf(gridItem),
+                columns = 5,
+                rows = 4,
+                x = 150,
+                y = 250,
+                gridWidth = 500,
+                gridHeight = 400,
+            )
+
+            assertEquals(gridItem, result)
+        }
+
+        @Test
+        fun `returns matching item when multiple grid items exist`() {
+            val firstItem = gridItem(
+                id = "first",
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val secondItem = gridItem(
+                id = "second",
+                startColumn = 2,
+                startRow = 1,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            val result = getGridItemByCoordinates(
+                id = "moving",
+                gridItems = listOf(firstItem, secondItem),
+                columns = 5,
+                rows = 4,
+                x = 250,
+                y = 150,
+                gridWidth = 500,
+                gridHeight = 400,
+            )
+
+            assertEquals(secondItem, result)
+        }
+    }
+
+    @Nested
+    inner class GetRelativeResolveDirection {
+        @Test
+        fun `returns right when moving item is left of other`() {
+            val moving = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 1,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Right,
+                getRelativeResolveDirection(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns left when moving item is right of other`() {
+            val moving = gridItem(
+                startColumn = 2,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 1,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Left,
+                getRelativeResolveDirection(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns left when moving item is below other`() {
+            val moving = gridItem(
+                startColumn = 0,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Left,
+                getRelativeResolveDirection(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns right when moving item is above other`() {
+            val moving = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 0,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Right,
+                getRelativeResolveDirection(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns null when items have the same starting position`() {
+            val moving = gridItem(
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 1,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertNull(
+                getRelativeResolveDirection(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+
+        @Test
+        fun `prioritizes horizontal direction when both column and row differ`() {
+            val moving = gridItem(
+                startColumn = 0,
+                startRow = 1,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val other = gridItem(
+                startColumn = 1,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            assertEquals(
+                ResolveDirection.Right,
+                getRelativeResolveDirection(
+                    moving = moving,
+                    other = other,
+                ),
+            )
+        }
+    }
+
+    @Nested
+    inner class FindAvailableRegionByPage {
+        @Test
+        fun `returns first available region`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val result = runBlocking {
+                findAvailableRegionByPage(
+                    gridItems = emptyList(),
+                    gridItem = gridItem,
+                    pageCount = 1,
+                    columns = 5,
+                    rows = 4,
+                )
+            }
+
+            assertEquals(
+                gridItem.copy(
+                    page = 0,
+                    startColumn = 0,
+                    startRow = 0,
+                ),
+                result,
+            )
+        }
+
+        @Test
+        fun `skips occupied region`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val occupiedItem = gridItem(
+                id = "occupied",
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val result = runBlocking {
+                findAvailableRegionByPage(
+                    gridItems = listOf(occupiedItem),
+                    gridItem = gridItem,
+                    pageCount = 1,
+                    columns = 5,
+                    rows = 4,
+                )
+            }
+
+            assertEquals(
+                gridItem.copy(
+                    page = 0,
+                    startColumn = 1,
+                    startRow = 0,
+                ),
+                result,
+            )
+        }
+
+        @Test
+        fun `searches columns from left to right before moving to next row`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val occupiedItems = listOf(
+                gridItem(
+                    id = "occupied-1",
+                    startColumn = 0,
+                    startRow = 0,
+                    columnSpan = 1,
+                    rowSpan = 1,
+                ),
+                gridItem(
+                    id = "occupied-2",
+                    startColumn = 1,
+                    startRow = 0,
+                    columnSpan = 1,
+                    rowSpan = 1,
+                ),
+            )
+
+            val result = runBlocking {
+                findAvailableRegionByPage(
+                    gridItems = occupiedItems,
+                    gridItem = gridItem,
+                    pageCount = 1,
+                    columns = 5,
+                    rows = 4,
+                )
+            }
+
+            assertEquals(
+                gridItem.copy(
+                    page = 0,
+                    startColumn = 2,
+                    startRow = 0,
+                ),
+                result,
+            )
+        }
+
+        @Test
+        fun `moves to next row when current row has no available region`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val occupiedItems = (0 until 5).map { column ->
+                gridItem(
+                    id = "occupied-$column",
+                    startColumn = column,
+                    startRow = 0,
+                    columnSpan = 1,
+                    rowSpan = 1,
+                )
+            }
+
+            val result = runBlocking {
+                findAvailableRegionByPage(
+                    gridItems = occupiedItems,
+                    gridItem = gridItem,
+                    pageCount = 1,
+                    columns = 5,
+                    rows = 4,
+                )
+            }
+
+            assertEquals(
+                gridItem.copy(
+                    page = 0,
+                    startColumn = 0,
+                    startRow = 1,
+                ),
+                result,
+            )
+        }
+
+        @Test
+        fun `moves to next page when current page has no available region`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val occupiedItems = buildList {
+                repeat(4) { row ->
+                    repeat(5) { column ->
+                        add(
+                            gridItem(
+                                id = "occupied-$row-$column",
+                                page = 0,
+                                startColumn = column,
+                                startRow = row,
+                                columnSpan = 1,
+                                rowSpan = 1,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            val result = runBlocking {
+                findAvailableRegionByPage(
+                    gridItems = occupiedItems,
+                    gridItem = gridItem,
+                    pageCount = 2,
+                    columns = 5,
+                    rows = 4,
+                )
+            }
+
+            assertEquals(
+                gridItem.copy(
+                    page = 1,
+                    startColumn = 0,
+                    startRow = 0,
+                ),
+                result,
+            )
+        }
+
+        @Test
+        fun `returns null when all pages are full`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val occupiedItems = buildList {
+                repeat(2) { page ->
+                    repeat(4) { row ->
+                        repeat(5) { column ->
+                            add(
+                                gridItem(
+                                    id = "occupied-$page-$row-$column",
+                                    page = page,
+                                    startColumn = column,
+                                    startRow = row,
+                                    columnSpan = 1,
+                                    rowSpan = 1,
+                                ),
+                            )
+                        }
+                    }
+                }
+            }
+
+            val result = runBlocking {
+                findAvailableRegionByPage(
+                    gridItems = occupiedItems,
+                    gridItem = gridItem,
+                    pageCount = 2,
+                    columns = 5,
+                    rows = 4,
+                )
+            }
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `finds region large enough for multi-cell grid item`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 2,
+                rowSpan = 2,
+            )
+
+            val occupiedItem = gridItem(
+                id = "occupied",
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val result = runBlocking {
+                findAvailableRegionByPage(
+                    gridItems = listOf(occupiedItem),
+                    gridItem = gridItem,
+                    pageCount = 1,
+                    columns = 5,
+                    rows = 4,
+                )
+            }
+
+            assertEquals(
+                gridItem.copy(
+                    page = 0,
+                    startColumn = 1,
+                    startRow = 0,
+                ),
+                result,
+            )
+        }
+
+        @Test
+        fun `ignores grid items on other pages`() {
+            val gridItem = gridItem(
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val occupiedItem = gridItem(
+                id = "occupied",
+                page = 1,
+                startColumn = 0,
+                startRow = 0,
+                columnSpan = 1,
+                rowSpan = 1,
+            )
+
+            val result = runBlocking {
+                findAvailableRegionByPage(
+                    gridItems = listOf(occupiedItem),
+                    gridItem = gridItem,
+                    pageCount = 2,
+                    columns = 5,
+                    rows = 4,
+                )
+            }
+
+            assertEquals(
+                gridItem.copy(
+                    page = 0,
+                    startColumn = 0,
+                    startRow = 0,
+                ),
+                result,
+            )
+        }
+    }
+
+    private fun gridItem(
+        id: String = "Test",
+        page: Int = 0,
+        startColumn: Int,
+        startRow: Int,
+        columnSpan: Int,
+        rowSpan: Int,
+    ) = GridItem(
+        id = id,
+        page = page,
+        startColumn = startColumn,
+        startRow = startRow,
+        columnSpan = columnSpan,
+        rowSpan = rowSpan,
+        data = GridItemData.Folder(
+            label = "Test",
+            icon = null,
+            index = 0,
+            folderId = null,
+        ),
+        associate = Associate.Grid,
+        override = false,
+        gridItemSettings = GridItemSettings(
+            iconSize = 0,
+            textColor = TextColor.System,
+            textSize = 0,
+            showLabel = true,
+            singleLineLabel = true,
+            horizontalAlignment = HorizontalAlignment.CenterHorizontally,
+            verticalArrangement = VerticalArrangement.Center,
+            customTextColor = 0,
+            customBackgroundColor = 0,
+            padding = 0,
+            cornerRadius = 0,
+        ),
+        doubleTap = EblanAction(
+            eblanActionType = EblanActionType.None,
+            serialNumber = 0,
+            componentName = "",
+        ),
+        swipeUp = EblanAction(
+            eblanActionType = EblanActionType.None,
+            serialNumber = 0,
+            componentName = "",
+        ),
+        swipeDown = EblanAction(
+            eblanActionType = EblanActionType.None,
+            serialNumber = 0,
+            componentName = "",
+        ),
+    )
+}

--- a/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/GridItemConstraintsTest.kt
+++ b/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/GridItemConstraintsTest.kt
@@ -17,16 +17,7 @@
  */
 package com.eblan.launcher.domain.grid
 
-import com.eblan.launcher.domain.model.Associate
-import com.eblan.launcher.domain.model.EblanAction
-import com.eblan.launcher.domain.model.EblanActionType
-import com.eblan.launcher.domain.model.GridItem
-import com.eblan.launcher.domain.model.GridItemData
-import com.eblan.launcher.domain.model.GridItemSettings
-import com.eblan.launcher.domain.model.HorizontalAlignment
 import com.eblan.launcher.domain.model.ResolveDirection
-import com.eblan.launcher.domain.model.TextColor
-import com.eblan.launcher.domain.model.VerticalArrangement
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -1106,56 +1097,4 @@ class GridItemConstraintsTest {
             )
         }
     }
-
-    private fun gridItem(
-        id: String = "Test",
-        page: Int = 0,
-        startColumn: Int,
-        startRow: Int,
-        columnSpan: Int,
-        rowSpan: Int,
-    ) = GridItem(
-        id = id,
-        page = page,
-        startColumn = startColumn,
-        startRow = startRow,
-        columnSpan = columnSpan,
-        rowSpan = rowSpan,
-        data = GridItemData.Folder(
-            label = "Test",
-            icon = null,
-            index = 0,
-            folderId = null,
-        ),
-        associate = Associate.Grid,
-        override = false,
-        gridItemSettings = GridItemSettings(
-            iconSize = 0,
-            textColor = TextColor.System,
-            textSize = 0,
-            showLabel = true,
-            singleLineLabel = true,
-            horizontalAlignment = HorizontalAlignment.CenterHorizontally,
-            verticalArrangement = VerticalArrangement.Center,
-            customTextColor = 0,
-            customBackgroundColor = 0,
-            padding = 0,
-            cornerRadius = 0,
-        ),
-        doubleTap = EblanAction(
-            eblanActionType = EblanActionType.None,
-            serialNumber = 0,
-            componentName = "",
-        ),
-        swipeUp = EblanAction(
-            eblanActionType = EblanActionType.None,
-            serialNumber = 0,
-            componentName = "",
-        ),
-        swipeDown = EblanAction(
-            eblanActionType = EblanActionType.None,
-            serialNumber = 0,
-            componentName = "",
-        ),
-    )
 }

--- a/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/MoveGridItemTest.kt
+++ b/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/MoveGridItemTest.kt
@@ -1,0 +1,294 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.domain.grid
+
+import com.eblan.launcher.domain.model.ResolveDirection
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MoveGridItemTest {
+    @Test
+    fun `returns true when there are no conflicts`() {
+        val moving = gridItem(
+            id = "moving",
+            startColumn = 0,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val other = gridItem(
+            id = "other",
+            startColumn = 2,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val gridItems = mutableListOf(moving, other)
+
+        val result = runBlocking {
+            resolveConflicts(
+                gridItems = gridItems,
+                resolveDirection = ResolveDirection.Right,
+                movingGridItem = moving,
+                columns = 5,
+                rows = 4,
+            )
+        }
+
+        assertTrue(result)
+        assertEquals(
+            listOf(moving, other),
+            gridItems,
+        )
+    }
+
+    @Test
+    fun `moves conflicting item to the right`() {
+        val moving = gridItem(
+            id = "moving",
+            startColumn = 0,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val conflicting = gridItem(
+            id = "conflicting",
+            startColumn = 0,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val gridItems = mutableListOf(moving, conflicting)
+
+        val result = runBlocking {
+            resolveConflicts(
+                gridItems = gridItems,
+                resolveDirection = ResolveDirection.Right,
+                movingGridItem = moving,
+                columns = 5,
+                rows = 4,
+            )
+        }
+
+        assertTrue(result)
+
+        assertEquals(
+            conflicting.copy(
+                startColumn = 1,
+                startRow = 0,
+            ),
+            gridItems[1],
+        )
+    }
+
+    @Test
+    fun `moves conflicting item to the left`() {
+        val moving = gridItem(
+            id = "moving",
+            startColumn = 2,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val conflicting = gridItem(
+            id = "conflicting",
+            startColumn = 2,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val gridItems = mutableListOf(moving, conflicting)
+
+        val result = runBlocking {
+            resolveConflicts(
+                gridItems = gridItems,
+                resolveDirection = ResolveDirection.Left,
+                movingGridItem = moving,
+                columns = 5,
+                rows = 4,
+            )
+        }
+
+        assertTrue(result)
+
+        assertEquals(
+            conflicting.copy(
+                startColumn = 1,
+                startRow = 0,
+            ),
+            gridItems[1],
+        )
+    }
+
+    @Test
+    fun `returns false when conflicting item cannot move right`() {
+        val moving = gridItem(
+            id = "moving",
+            startColumn = 4,
+            startRow = 3,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val conflicting = gridItem(
+            id = "conflicting",
+            startColumn = 4,
+            startRow = 3,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val gridItems = mutableListOf(moving, conflicting)
+
+        val result = runBlocking {
+            resolveConflicts(
+                gridItems = gridItems,
+                resolveDirection = ResolveDirection.Right,
+                movingGridItem = moving,
+                columns = 5,
+                rows = 4,
+            )
+        }
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `returns false when conflicting item cannot move left`() {
+        val moving = gridItem(
+            id = "moving",
+            startColumn = 0,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val conflicting = gridItem(
+            id = "conflicting",
+            startColumn = 0,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val gridItems = mutableListOf(moving, conflicting)
+
+        val result = runBlocking {
+            resolveConflicts(
+                gridItems = gridItems,
+                resolveDirection = ResolveDirection.Left,
+                movingGridItem = moving,
+                columns = 5,
+                rows = 4,
+            )
+        }
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `moves conflicting item to next row when moving right exceeds column bounds`() {
+        val moving = gridItem(
+            id = "moving",
+            startColumn = 4,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val conflicting = gridItem(
+            id = "conflicting",
+            startColumn = 4,
+            startRow = 0,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val gridItems = mutableListOf(moving, conflicting)
+
+        val result = runBlocking {
+            resolveConflicts(
+                gridItems = gridItems,
+                resolveDirection = ResolveDirection.Right,
+                movingGridItem = moving,
+                columns = 5,
+                rows = 4,
+            )
+        }
+
+        assertTrue(result)
+
+        assertEquals(
+            conflicting.copy(
+                startColumn = 0,
+                startRow = 1,
+            ),
+            gridItems[1],
+        )
+    }
+
+    @Test
+    fun `moves conflicting item to previous row when moving left exceeds column bounds`() {
+        val moving = gridItem(
+            id = "moving",
+            startColumn = 0,
+            startRow = 1,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val conflicting = gridItem(
+            id = "conflicting",
+            startColumn = 0,
+            startRow = 1,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val gridItems = mutableListOf(moving, conflicting)
+
+        val result = runBlocking {
+            resolveConflicts(
+                gridItems = gridItems,
+                resolveDirection = ResolveDirection.Left,
+                movingGridItem = moving,
+                columns = 5,
+                rows = 4,
+            )
+        }
+
+        assertTrue(result)
+
+        assertEquals(
+            conflicting.copy(
+                startColumn = 4,
+                startRow = 0,
+            ),
+            gridItems[1],
+        )
+    }
+}

--- a/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/ResizeGridItemTest.kt
+++ b/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/ResizeGridItemTest.kt
@@ -1,0 +1,203 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.domain.grid
+
+import com.eblan.launcher.domain.model.SideAnchor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ResizeGridItemTest {
+    @Test
+    fun `converts pixel dimensions to grid spans`() {
+        val gridItem = gridItem(
+            startColumn = 1,
+            startRow = 1,
+            columnSpan = 2,
+            rowSpan = 2,
+        )
+
+        val result = resizeWidgetGridItemWithPixels(
+            gridItem = gridItem,
+            width = 250,
+            height = 150,
+            rows = 4,
+            columns = 5,
+            gridWidth = 500,
+            gridHeight = 400,
+            anchor = SideAnchor.Top,
+        )
+
+        assertEquals(
+            gridItem.copy(
+                columnSpan = 3,
+                rowSpan = 2,
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `rounds pixel dimensions up to next grid cell`() {
+        val gridItem = gridItem(
+            startColumn = 1,
+            startRow = 1,
+            columnSpan = 1,
+            rowSpan = 1,
+        )
+
+        val result = resizeWidgetGridItemWithPixels(
+            gridItem = gridItem,
+            width = 101,
+            height = 101,
+            rows = 4,
+            columns = 5,
+            gridWidth = 500,
+            gridHeight = 400,
+            anchor = SideAnchor.Top,
+        )
+
+        assertEquals(2, result.columnSpan)
+        assertEquals(2, result.rowSpan)
+    }
+
+    @Test
+    fun `clamps zero pixel dimensions to one cell`() {
+        val gridItem = gridItem(
+            startColumn = 1,
+            startRow = 1,
+            columnSpan = 2,
+            rowSpan = 2,
+        )
+
+        val result = resizeWidgetGridItemWithPixels(
+            gridItem = gridItem,
+            width = 0,
+            height = 0,
+            rows = 4,
+            columns = 5,
+            gridWidth = 500,
+            gridHeight = 400,
+            anchor = SideAnchor.Top,
+        )
+
+        assertEquals(1, result.columnSpan)
+        assertEquals(1, result.rowSpan)
+    }
+
+    @Test
+    fun `keeps top anchor fixed while resizing`() {
+        val gridItem = gridItem(
+            startColumn = 2,
+            startRow = 1,
+            columnSpan = 2,
+            rowSpan = 2,
+        )
+
+        val result = resizeWidgetGridItemWithPixels(
+            gridItem = gridItem,
+            width = 300,
+            height = 300,
+            rows = 4,
+            columns = 5,
+            gridWidth = 500,
+            gridHeight = 400,
+            anchor = SideAnchor.Top,
+        )
+
+        assertEquals(2, result.startColumn)
+        assertEquals(1, result.startRow)
+    }
+
+    @Test
+    fun `keeps bottom anchor fixed while resizing`() {
+        val gridItem = gridItem(
+            startColumn = 2,
+            startRow = 1,
+            columnSpan = 2,
+            rowSpan = 2,
+        )
+
+        val result = resizeWidgetGridItemWithPixels(
+            gridItem = gridItem,
+            width = 100,
+            height = 100,
+            rows = 4,
+            columns = 5,
+            gridWidth = 500,
+            gridHeight = 400,
+            anchor = SideAnchor.Bottom,
+        )
+
+        assertEquals(2, result.startColumn)
+        assertEquals(2, result.startRow)
+        assertEquals(1, result.columnSpan)
+        assertEquals(1, result.rowSpan)
+    }
+
+    @Test
+    fun `keeps left anchor fixed while resizing`() {
+        val gridItem = gridItem(
+            startColumn = 2,
+            startRow = 1,
+            columnSpan = 2,
+            rowSpan = 2,
+        )
+
+        val result = resizeWidgetGridItemWithPixels(
+            gridItem = gridItem,
+            width = 100,
+            height = 100,
+            rows = 4,
+            columns = 5,
+            gridWidth = 500,
+            gridHeight = 400,
+            anchor = SideAnchor.Left,
+        )
+
+        assertEquals(2, result.startColumn)
+        assertEquals(1, result.startRow)
+        assertEquals(1, result.columnSpan)
+        assertEquals(1, result.rowSpan)
+    }
+
+    @Test
+    fun `keeps right anchor fixed while resizing`() {
+        val gridItem = gridItem(
+            startColumn = 2,
+            startRow = 1,
+            columnSpan = 2,
+            rowSpan = 2,
+        )
+
+        val result = resizeWidgetGridItemWithPixels(
+            gridItem = gridItem,
+            width = 100,
+            height = 100,
+            rows = 4,
+            columns = 5,
+            gridWidth = 500,
+            gridHeight = 400,
+            anchor = SideAnchor.Right,
+        )
+
+        assertEquals(3, result.startColumn)
+        assertEquals(1, result.startRow)
+        assertEquals(1, result.columnSpan)
+        assertEquals(1, result.rowSpan)
+    }
+}

--- a/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/TestGridItem.kt
+++ b/domain/grid/src/test/kotlin/com/eblan/launcher/domain/grid/TestGridItem.kt
@@ -1,0 +1,80 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.eblan.launcher.domain.grid
+
+import com.eblan.launcher.domain.model.Associate
+import com.eblan.launcher.domain.model.EblanAction
+import com.eblan.launcher.domain.model.EblanActionType
+import com.eblan.launcher.domain.model.GridItem
+import com.eblan.launcher.domain.model.GridItemData
+import com.eblan.launcher.domain.model.GridItemSettings
+import com.eblan.launcher.domain.model.HorizontalAlignment
+import com.eblan.launcher.domain.model.TextColor
+import com.eblan.launcher.domain.model.VerticalArrangement
+
+fun gridItem(
+    id: String = "Test",
+    page: Int = 0,
+    startColumn: Int,
+    startRow: Int,
+    columnSpan: Int,
+    rowSpan: Int,
+) = GridItem(
+    id = id,
+    page = page,
+    startColumn = startColumn,
+    startRow = startRow,
+    columnSpan = columnSpan,
+    rowSpan = rowSpan,
+    data = GridItemData.Folder(
+        label = "Test",
+        icon = null,
+        index = 0,
+        folderId = null,
+    ),
+    associate = Associate.Grid,
+    override = false,
+    gridItemSettings = GridItemSettings(
+        iconSize = 0,
+        textColor = TextColor.System,
+        textSize = 0,
+        showLabel = true,
+        singleLineLabel = true,
+        horizontalAlignment = HorizontalAlignment.CenterHorizontally,
+        verticalArrangement = VerticalArrangement.Center,
+        customTextColor = 0,
+        customBackgroundColor = 0,
+        padding = 0,
+        cornerRadius = 0,
+    ),
+    doubleTap = EblanAction(
+        eblanActionType = EblanActionType.None,
+        serialNumber = 0,
+        componentName = "",
+    ),
+    swipeUp = EblanAction(
+        eblanActionType = EblanActionType.None,
+        serialNumber = 0,
+        componentName = "",
+    ),
+    swipeDown = EblanAction(
+        eblanActionType = EblanActionType.None,
+        serialNumber = 0,
+        componentName = "",
+    ),
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ apacheCommonsText = "1.15.0"
 coil = "3.4.0"
 hilt = "2.59.2"
 javaxInject = "1"
+junit-jupiter = "5.14.1"
 kotlin = "2.3.20"
 kotlinxCoroutines = "1.10.2"
 kotlinxSerializationJson = "1.10.0"
@@ -55,6 +56,8 @@ hilt-android-gradle-plugin = { group = "com.google.dagger", name = "hilt-android
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javaxInject" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobuf" }


### PR DESCRIPTION
This commit introduces a comprehensive suite of unit tests for grid item constraints and related functionalities. It also updates the build scripts to include JUnit 5 and configure test tasks.

#958 

The new `GridItemConstraintsTest.kt` file covers various scenarios for:
- `isGridItemSpanWithinBounds`: Verifies if a grid item's span is within the defined grid boundaries.
- `rectanglesOverlap`: Checks for overlapping areas between grid items.
- `getResolveDirectionByX`: Determines the direction of resolution based on X-coordinate.
- `getGridItemByCoordinates`: Finds a grid item at specific coordinates.
- `getRelativeResolveDirection`: Calculates the relative direction between two grid items.
- `findAvailableRegionByPage`: Locates the next available region on a page, considering existing items and multi-cell items.

Additionally, the `gradle/libs.versions.toml` file has been updated to include the `junit-jupiter` dependency. The `build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt` has been modified to apply the `testImplementation` dependency for JUnit Jupiter and configure tasks to use the JUnit Platform.

Key changes:
- Added `GridItemConstraintsTest.kt` to test grid item constraint logic.
- Updated `libs.versions.toml` to include `junit-jupiter`.
- Configured `JvmLibraryConventionPlugin.kt` to use JUnit 5 for testing.
- Added tests for bounds checking, rectangle overlap, coordinate-based item retrieval, and available region finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for grid bounds, overlap handling, coordinate lookup, available-space detection, item movement, row wrapping, and resizing behavior.
  * Standardized test execution on the JUnit Platform.
  * Automated unit tests now run before creating debug builds, helping catch regressions earlier.

* **Chores**
  * Updated testing support with JUnit Jupiter and platform components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->