### PR TITLE
Use Layout Instead Of SubcomposeLayout in Folder

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-08-18T21:15:24.234354297Z">
+        <DropdownSelection timestamp="2026-08-24T22:14:00.856250957Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_9a.avd" />

--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -4,6 +4,7 @@
       <w>Yagni</w>
       <w>eblan</w>
       <w>klwp</w>
+      <w>placeables</w>
       <w>yagni</w>
     </words>
   </dictionary>

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/FolderGrid.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/FolderGrid.kt
@@ -22,11 +22,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.ParentDataModifier
-import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.usecase.grid.FOLDER_PREVIEW_COLUMNS
 import com.eblan.launcher.domain.usecase.grid.FOLDER_PREVIEW_ROWS
@@ -37,9 +39,18 @@ internal fun PreviewFolderGridLayout(
     gridItems: List<GridItem>?,
     previewColumns: Int = FOLDER_PREVIEW_COLUMNS,
     previewRows: Int = FOLDER_PREVIEW_ROWS,
-    content: @Composable BoxScope.(GridItem) -> Unit,
+    content: @Composable (GridItem) -> Unit,
 ) {
-    SubcomposeLayout(modifier = modifier) { constraints ->
+    Layout(
+        modifier = modifier,
+        content = {
+            gridItems?.forEach { gridItem ->
+                key(gridItem.id) {
+                    content(gridItem)
+                }
+            }
+        },
+    ) { measurables, constraints ->
         val previewCellSize = minOf(
             constraints.maxWidth,
             constraints.maxHeight,
@@ -56,39 +67,30 @@ internal fun PreviewFolderGridLayout(
 
         val previewOffsetY = (constraints.maxHeight - previewGridHeight) / 2
 
+        val placeables = measurables.mapIndexed { index, measurable ->
+            val x = previewOffsetX +
+                (index % previewColumns) * previewCellSize
+
+            val y = previewOffsetY +
+                (index / previewColumns) * previewCellSize
+
+            measurable.measure(
+                Constraints.fixed(
+                    width = previewCellSize,
+                    height = previewCellSize,
+                ),
+            ) to IntOffset(x = x, y = y)
+        }
+
         layout(
             width = constraints.maxWidth,
             height = constraints.maxHeight,
         ) {
-            gridItems?.forEachIndexed { index, gridItem ->
-                subcompose(gridItem.id) {
-                    val x = previewOffsetX + (index % previewColumns) * previewCellSize
-
-                    val y = previewOffsetY + (index / previewColumns) * previewCellSize
-
-                    Box(
-                        modifier = Modifier.folderGridItem(
-                            x = x,
-                            y = y,
-                            width = previewCellSize,
-                            height = previewCellSize,
-                        ),
-                    ) {
-                        content(gridItem)
-                    }
-                }.forEach { measurable ->
-                    val parentData = measurable.parentData as FolderGridItemParentData
-
-                    measurable.measure(
-                        Constraints.fixed(
-                            width = parentData.width,
-                            height = parentData.height,
-                        ),
-                    ).placeRelative(
-                        x = parentData.x,
-                        y = parentData.y,
-                    )
-                }
+            placeables.forEach { (placeable, intOffset) ->
+                placeable.placeRelative(
+                    x = intOffset.x,
+                    y = intOffset.y,
+                )
             }
         }
     }
@@ -105,38 +107,45 @@ internal fun FolderGridLayout(
     animate: Boolean,
     content: @Composable BoxScope.(GridItem) -> Unit,
 ) {
-    SubcomposeLayout(modifier = modifier) { constraints ->
-        val cellWidth = width / columns
-        val cellHeight = height / rows
+    Layout(
+        modifier = modifier,
+        content = {
+            gridItems?.forEachIndexed { index, gridItem ->
+                key(gridItem.id) {
+                    FolderGridLayoutContent(
+                        index = index,
+                        columns = columns,
+                        cellWidth = width / columns,
+                        cellHeight = height / rows,
+                        gridItem = gridItem,
+                        animate = animate,
+                        content = content,
+                    )
+                }
+            }
+        },
+    ) { measurables, constraints ->
+        val placeables = measurables.map { measurable ->
+            val parentData =
+                measurable.parentData as FolderGridItemParentData
+
+            measurable.measure(
+                Constraints.fixed(
+                    width = parentData.width,
+                    height = parentData.height,
+                ),
+            ) to parentData
+        }
 
         layout(
             width = constraints.maxWidth,
             height = constraints.maxHeight,
         ) {
-            gridItems?.forEachIndexed { index, gridItem ->
-                subcompose(gridItem.id) {
-                    FolderGridLayoutContent(
-                        index = index,
-                        columns = columns,
-                        cellWidth = cellWidth,
-                        cellHeight = cellHeight,
-                        gridItem = gridItem,
-                        animate = animate,
-                        content = content,
-                    )
-                }.forEach { measurable ->
-                    val parentData = measurable.parentData as FolderGridItemParentData
-
-                    measurable.measure(
-                        Constraints.fixed(
-                            width = parentData.width,
-                            height = parentData.height,
-                        ),
-                    ).placeRelativeWithLayer(
-                        x = parentData.x,
-                        y = parentData.y,
-                    )
-                }
+            placeables.forEach { (placeable, parentData) ->
+                placeable.placeRelativeWithLayer(
+                    x = parentData.x,
+                    y = parentData.y,
+                )
             }
         }
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Modifier.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Modifier.kt
@@ -46,6 +46,7 @@ import kotlin.math.roundToInt
 internal fun Modifier.swipeGestures(
     swipeDown: EblanAction,
     swipeUp: EblanAction,
+    enabled: Boolean = true,
     onOpenAppDrawer: () -> Unit,
 ): Modifier {
     val context = LocalContext.current
@@ -56,8 +57,10 @@ internal fun Modifier.swipeGestures(
 
     val launcherApps = LocalLauncherApps.current
 
-    return if (swipeUp.eblanActionType != EblanActionType.None ||
-        swipeDown.eblanActionType != EblanActionType.None
+    return if ((
+            swipeUp.eblanActionType != EblanActionType.None ||
+                swipeDown.eblanActionType != EblanActionType.None
+            ) && enabled
     ) {
         val swipeY = remember { Animatable(0f) }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/GridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/GridItem.kt
@@ -80,7 +80,7 @@ internal fun GridItemContent(
         getGridItemTextColor(
             gridItemCustomTextColor = currentGridItemSettings.customTextColor,
             gridItemTextColor = currentGridItemSettings.textColor,
-            systemCustomTextColor = currentGridItemSettings.customTextColor,
+            systemCustomTextColor = gridItemSettings.customTextColor,
             systemTextColor = textColor,
         )
     } else {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/GridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/editpage/GridItem.kt
@@ -78,14 +78,14 @@ internal fun GridItemContent(
 
     val currentTextColor = if (gridItem.override) {
         getGridItemTextColor(
-            gridItemCustomTextColor = gridItem.gridItemSettings.customTextColor,
-            gridItemTextColor = gridItem.gridItemSettings.textColor,
-            systemCustomTextColor = gridItemSettings.customTextColor,
+            gridItemCustomTextColor = currentGridItemSettings.customTextColor,
+            gridItemTextColor = currentGridItemSettings.textColor,
+            systemCustomTextColor = currentGridItemSettings.customTextColor,
             systemTextColor = textColor,
         )
     } else {
         getTextColor(
-            customTextColor = gridItemSettings.customTextColor,
+            customTextColor = currentGridItemSettings.customTextColor,
             textColor = textColor,
         )
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
@@ -40,10 +40,10 @@ import kotlin.time.Duration.Companion.milliseconds
 internal suspend fun handlePageDirection(
     pageDirection: PageDirection?,
     currentPage: Int,
-    progress: Float,
+    isInProgress: Boolean,
     onAnimateScrollToPage: suspend (Int) -> Unit,
 ) {
-    if (pageDirection == null || progress < 1f) return
+    if (pageDirection == null || isInProgress) return
 
     delay(500L.milliseconds)
 
@@ -112,7 +112,7 @@ internal fun handleAnimateScrollToPage(
     layoutDirection: LayoutDirection,
     folderCellWidth: Int,
     isLast: Boolean,
-    progress: Float,
+    isInProgress: Boolean,
     onUpdateFolderPageDirection: (PageDirection?) -> Unit,
 ) {
     if (drag != Drag.Dragging ||
@@ -121,7 +121,7 @@ internal fun handleAnimateScrollToPage(
         lockMovement.value ||
         moveGridItemResult == null ||
         !isLast ||
-        progress < 1f
+        isInProgress
     ) {
         return
     }
@@ -159,7 +159,7 @@ internal fun handleDragFolderGridItem(
     folderCellWidth: Int,
     folderCellHeight: Int,
     isLastFolderGridItem: Boolean,
-    progress: Float,
+    isInProgress: Boolean,
     onMoveFolderGridItem: (
         folderPopup: FolderPopup,
         movingFolderGridItem: GridItem,
@@ -179,7 +179,7 @@ internal fun handleDragFolderGridItem(
         lockMovement.value ||
         moveGridItemResult == null ||
         !isLastFolderGridItem ||
-        progress < 1f
+        isInProgress
     ) {
         return
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -215,6 +215,7 @@ internal fun FolderScreen(
     val currentIsVisibleOverlay = rememberUpdatedState(isVisibleOverlay)
     val currentMoveGridItemResult = rememberUpdatedState(moveGridItemResult)
     val currentLockMovement = rememberUpdatedState(lockMovement)
+
     val isInProgress by remember {
         derivedStateOf { progress.value < 1f }
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -394,7 +394,7 @@ internal fun FolderScreen(
                 HorizontalPager(
                     modifier = Modifier.weight(1f),
                     state = folderGridHorizontalPagerState,
-                    userScrollEnabled = !isVisibleOverlay,
+                    userScrollEnabled = !isVisibleOverlay && !isInProgress,
                 ) { index ->
                     FolderGridLayout(
                         modifier = Modifier.fillMaxSize(),

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -215,6 +215,9 @@ internal fun FolderScreen(
     val currentIsVisibleOverlay = rememberUpdatedState(isVisibleOverlay)
     val currentMoveGridItemResult = rememberUpdatedState(moveGridItemResult)
     val currentLockMovement = rememberUpdatedState(lockMovement)
+    val isInProgress by remember {
+        derivedStateOf { progress.value < 1f }
+    }
 
     LaunchedEffect(key1 = Unit) {
         progress.animateTo(targetValue = 1f)
@@ -249,7 +252,7 @@ internal fun FolderScreen(
         folderPopup,
         moveGridItemResult,
         isLastFolderGridItem,
-        progress.value,
+        isInProgress,
     ) {
         handleDragFolderGridItem(
             density = density,
@@ -270,7 +273,7 @@ internal fun FolderScreen(
             folderCellWidth = folderCellWidth,
             folderCellHeight = folderCellHeight,
             isLastFolderGridItem = isLastFolderGridItem,
-            progress = progress.value,
+            isInProgress = isInProgress,
             onMoveFolderGridItem = onMoveFolderGridItem,
             onUpdateSharedElementKey = onUpdateSharedElementKey,
             onUpsertFolderPopupEntry = onUpsertFolderPopupEntry,
@@ -296,12 +299,12 @@ internal fun FolderScreen(
 
     LaunchedEffect(
         key1 = pageDirection,
-        key2 = progress.value,
+        key2 = isInProgress,
     ) {
         handlePageDirection(
             pageDirection = pageDirection,
             currentPage = folderGridHorizontalPagerState.currentPage,
-            progress = progress.value,
+            isInProgress = isInProgress,
             onAnimateScrollToPage = folderGridHorizontalPagerState::animateScrollToPage,
         )
     }
@@ -318,7 +321,7 @@ internal fun FolderScreen(
         moveGridItemResult,
         folderPopup,
         isLastFolderGridItem,
-        progress.value,
+        isInProgress,
     ) {
         handleAnimateScrollToPage(
             density = density,
@@ -335,7 +338,7 @@ internal fun FolderScreen(
             layoutDirection = layoutDirection,
             folderCellWidth = folderCellWidth,
             isLast = isLastFolderGridItem,
-            progress = progress.value,
+            isInProgress = isInProgress,
             onUpdateFolderPageDirection = {
                 pageDirection = it
             },
@@ -417,12 +420,13 @@ internal fun FolderScreen(
                                 previewFolderGridItems = previewFolderGridItems,
                                 minCellWidthPx = folderPopupLayoutInfo.minCellWidthPx,
                                 minCellHeightPx = folderPopupLayoutInfo.minCellHeightPx,
-                                onOpenAppDrawer = onOpenAppDrawer,
                                 paddingValues = paddingValues,
                                 sharedElementKey = SharedElementKey(
                                     id = it.id,
                                     parent = SharedElementKey.Parent.Folder,
                                 ),
+                                isInProgress = isInProgress,
+                                onOpenAppDrawer = onOpenAppDrawer,
                                 onUpdateImageBitmap = onUpdateImageBitmap,
                                 onUpdateIsDragging = onUpdateIsDragging,
                                 onUpdateOverlayBounds = onUpdateOverlayBounds,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -224,11 +224,19 @@ internal fun FolderScreen(
         progress.animateTo(targetValue = 1f)
     }
 
-    BackHandler(enabled = !folderPopup.folderPopupEntry.isCloseFolder && isLastFolderGridItem) {
+    BackHandler(
+        enabled = !folderPopup.folderPopupEntry.isCloseFolder &&
+            isLastFolderGridItem &&
+            !isInProgress,
+    ) {
         onUpsertFolderPopupEntry(folderPopup.folderPopupEntry.copy(isCloseFolder = true))
     }
 
-    HomeHandler(enabled = !folderPopup.folderPopupEntry.isCloseFolder && isLastFolderGridItem) {
+    HomeHandler(
+        enabled = !folderPopup.folderPopupEntry.isCloseFolder &&
+            isLastFolderGridItem &&
+            !isInProgress,
+    ) {
         onUpsertFolderPopupEntry(folderPopup.folderPopupEntry.copy(isCloseFolder = true))
     }
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -79,6 +79,8 @@ import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.GridItemSettings
 import com.eblan.launcher.domain.model.MoveGridItemResult
 import com.eblan.launcher.domain.model.PreviewFolder
+import com.eblan.launcher.domain.usecase.grid.FOLDER_PREVIEW_COLUMNS
+import com.eblan.launcher.domain.usecase.grid.FOLDER_PREVIEW_ROWS
 import com.eblan.launcher.feature.home.component.PreviewFolderGridLayout
 import com.eblan.launcher.feature.home.component.swipeGestures
 import com.eblan.launcher.feature.home.model.Drag
@@ -143,6 +145,12 @@ internal fun InteractiveFolderGridItem(
 
     val padding = lerp(1.dp, gridItemSettings.padding.dp, progress)
 
+    val iconSize = lerp(
+        gridItemSettings.iconSize.dp / maxOf(FOLDER_PREVIEW_COLUMNS, FOLDER_PREVIEW_ROWS),
+        gridItemSettings.iconSize.dp,
+        progress,
+    )
+
     val hasInteraction = isSelected && isVisibleOverlay
 
     val sourceBounds = getSourceBounds(
@@ -181,6 +189,7 @@ internal fun InteractiveFolderGridItem(
                 sharedElementKey = sharedElementKey,
                 statusBarNotifications = statusBarNotifications,
                 padding = padding,
+                iconSize = iconSize,
                 sourceBounds = sourceBounds,
                 isInProgress = isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
@@ -206,6 +215,7 @@ internal fun InteractiveFolderGridItem(
                 isVisibleOverlay = isVisibleOverlay,
                 sharedElementKey = sharedElementKey,
                 padding = padding,
+                iconSize = iconSize,
                 sourceBounds = sourceBounds,
                 isInProgress = isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
@@ -230,6 +240,7 @@ internal fun InteractiveFolderGridItem(
                 isVisibleOverlay = isVisibleOverlay,
                 sharedElementKey = sharedElementKey,
                 padding = padding,
+                iconSize = iconSize,
                 isInProgress = isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
                 onShowGridItemPopup = onShowGridItemPopup,
@@ -288,6 +299,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
     sharedElementKey: SharedElementKey,
     statusBarNotifications: Map<String, Int>,
     padding: Dp,
+    iconSize: Dp,
     sourceBounds: Rect,
     isInProgress: Boolean,
     onOpenAppDrawer: () -> Unit,
@@ -409,7 +421,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
     ) {
         Box(
             modifier = Modifier
-                .size(gridItemSettings.iconSize.dp)
+                .size(iconSize)
                 .alpha(alpha),
         ) {
             AsyncImage(
@@ -486,6 +498,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
     isVisibleOverlay: Boolean,
     sharedElementKey: SharedElementKey,
     padding: Dp,
+    iconSize: Dp,
     sourceBounds: Rect,
     isInProgress: Boolean,
     onOpenAppDrawer: () -> Unit,
@@ -610,7 +623,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
         verticalArrangement = verticalArrangement,
     ) {
         Box(
-            modifier = Modifier.size(gridItemSettings.iconSize.dp),
+            modifier = Modifier.size(iconSize),
         ) {
             AsyncImage(
                 model = Builder(context).data(customIcon).addLastModifiedToFileCacheKey(true)
@@ -687,6 +700,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
     isVisibleOverlay: Boolean,
     sharedElementKey: SharedElementKey,
     padding: Dp,
+    iconSize: Dp,
     isInProgress: Boolean,
     onOpenAppDrawer: () -> Unit,
     onShowGridItemPopup: (
@@ -807,7 +821,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
                 .size(Size.ORIGINAL).build(),
             contentDescription = null,
             modifier = Modifier
-                .size(gridItemSettings.iconSize.dp)
+                .size(iconSize)
                 .onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -110,6 +110,7 @@ internal fun InteractiveFolderGridItem(
     minCellHeightPx: Int,
     paddingValues: PaddingValues,
     sharedElementKey: SharedElementKey,
+    isInProgress: Boolean,
     onOpenAppDrawer: () -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateIsDragging: (Boolean) -> Unit,
@@ -181,6 +182,7 @@ internal fun InteractiveFolderGridItem(
                 statusBarNotifications = statusBarNotifications,
                 padding = padding,
                 sourceBounds = sourceBounds,
+                isInProgress = isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
                 onShowGridItemPopup = onShowGridItemPopup,
                 onUpdateImageBitmap = onUpdateImageBitmap,
@@ -205,6 +207,7 @@ internal fun InteractiveFolderGridItem(
                 sharedElementKey = sharedElementKey,
                 padding = padding,
                 sourceBounds = sourceBounds,
+                isInProgress = isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
                 onShowGridItemPopup = onShowGridItemPopup,
                 onUpdateImageBitmap = onUpdateImageBitmap,
@@ -227,6 +230,7 @@ internal fun InteractiveFolderGridItem(
                 isVisibleOverlay = isVisibleOverlay,
                 sharedElementKey = sharedElementKey,
                 padding = padding,
+                isInProgress = isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
                 onShowGridItemPopup = onShowGridItemPopup,
                 onUpdateImageBitmap = onUpdateImageBitmap,
@@ -252,6 +256,7 @@ internal fun InteractiveFolderGridItem(
                 showFolderGridItemPopup = showFolderGridItemPopup,
                 previewFolderGridItems = previewFolderGridItems,
                 hasShortcutHostPermission = hasShortcutHostPermission,
+                isInProgress = isInProgress,
                 onUpdateIsCloseFolderGridItemPopup = onUpdateIsCloseFolderGridItemPopup,
                 onOpenAppDrawer = onOpenAppDrawer,
                 onShowGridItemPopup = onShowGridItemPopup,
@@ -284,6 +289,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
     statusBarNotifications: Map<String, Int>,
     padding: Dp,
     sourceBounds: Rect,
+    isInProgress: Boolean,
     onOpenAppDrawer: () -> Unit,
     onShowGridItemPopup: (
         intOffset: IntOffset,
@@ -415,7 +421,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
                         intSize = layoutCoordinates.size
                     }
                     .run {
-                        if (!isScrollInProgress && !hasInteraction) {
+                        if (!isScrollInProgress && !hasInteraction && !isInProgress) {
                             with(sharedTransitionScope) {
                                 sharedElementWithCallerManagedVisibility(
                                     rememberSharedContentState(
@@ -478,6 +484,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
     sharedElementKey: SharedElementKey,
     padding: Dp,
     sourceBounds: Rect,
+    isInProgress: Boolean,
     onOpenAppDrawer: () -> Unit,
     onShowGridItemPopup: (
         intOffset: IntOffset,
@@ -610,7 +617,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
                         intSize = layoutCoordinates.size
                     }
                     .run {
-                        if (!isScrollInProgress && !hasInteraction) {
+                        if (!isScrollInProgress && !hasInteraction && !isInProgress) {
                             with(sharedTransitionScope) {
                                 sharedElementWithCallerManagedVisibility(
                                     rememberSharedContentState(
@@ -674,6 +681,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
     isVisibleOverlay: Boolean,
     sharedElementKey: SharedElementKey,
     padding: Dp,
+    isInProgress: Boolean,
     onOpenAppDrawer: () -> Unit,
     onShowGridItemPopup: (
         intOffset: IntOffset,
@@ -800,7 +808,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
                     intSize = layoutCoordinates.size
                 }
                 .run {
-                    if (!isScrollInProgress && !hasInteraction) {
+                    if (!isScrollInProgress && !hasInteraction && !isInProgress) {
                         with(sharedTransitionScope) {
                             sharedElementWithCallerManagedVisibility(
                                 rememberSharedContentState(
@@ -851,6 +859,7 @@ private fun InteractiveNestedFolderGridItem(
     showFolderGridItemPopup: Boolean,
     previewFolderGridItems: Map<String, PreviewFolder>,
     hasShortcutHostPermission: Boolean,
+    isInProgress: Boolean,
     onUpdateIsCloseFolderGridItemPopup: (Boolean) -> Unit,
     onOpenAppDrawer: () -> Unit,
     onShowGridItemPopup: (
@@ -982,7 +991,7 @@ private fun InteractiveNestedFolderGridItem(
                     intSize = layoutCoordinates.size
                 }
                 .run {
-                    if (!isScrollInProgress && !hasInteraction) {
+                    if (!isScrollInProgress && !hasInteraction && !isInProgress) {
                         with(sharedTransitionScope) {
                             sharedElementWithCallerManagedVisibility(
                                 rememberSharedContentState(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -267,6 +267,8 @@ internal fun InteractiveFolderGridItem(
                 showFolderGridItemPopup = showFolderGridItemPopup,
                 previewFolderGridItems = previewFolderGridItems,
                 hasShortcutHostPermission = hasShortcutHostPermission,
+                padding = padding,
+                iconSize = iconSize,
                 isInProgress = isInProgress,
                 onUpdateIsCloseFolderGridItemPopup = onUpdateIsCloseFolderGridItemPopup,
                 onOpenAppDrawer = onOpenAppDrawer,
@@ -883,6 +885,8 @@ private fun InteractiveNestedFolderGridItem(
     showFolderGridItemPopup: Boolean,
     previewFolderGridItems: Map<String, PreviewFolder>,
     hasShortcutHostPermission: Boolean,
+    padding: Dp,
+    iconSize: Dp,
     isInProgress: Boolean,
     onUpdateIsCloseFolderGridItemPopup: (Boolean) -> Unit,
     onOpenAppDrawer: () -> Unit,
@@ -1002,7 +1006,7 @@ private fun InteractiveNestedFolderGridItem(
                 onOpenAppDrawer = onOpenAppDrawer,
             )
             .fillMaxSize()
-            .padding(gridItemSettings.padding.dp)
+            .padding(padding)
             .background(
                 color = Color(gridItemSettings.customBackgroundColor),
                 shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
@@ -1012,7 +1016,7 @@ private fun InteractiveNestedFolderGridItem(
     ) {
         val commonModifier =
             Modifier
-                .size(gridItemSettings.iconSize.dp)
+                .size(iconSize)
                 .onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -758,7 +758,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay && !isInProgress) {
                 detectTapGestures(
-                    onDoubleTap = if (!isVisibleOverlay) {
+                    onDoubleTap = if (!isVisibleOverlay && !isInProgress) {
                         {
                             onDoubleTap(
                                 context = context,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -408,6 +408,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
             .swipeGestures(
                 swipeDown = gridItem.swipeDown,
                 swipeUp = gridItem.swipeUp,
+                enabled = !isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
             )
             .fillMaxSize()
@@ -611,6 +612,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
             .swipeGestures(
                 swipeDown = gridItem.swipeDown,
                 swipeUp = gridItem.swipeUp,
+                enabled = !isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
             )
             .fillMaxSize()
@@ -805,6 +807,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
             .swipeGestures(
                 swipeDown = gridItem.swipeDown,
                 swipeUp = gridItem.swipeUp,
+                enabled = !isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
             )
             .fillMaxSize()
@@ -995,6 +998,7 @@ private fun InteractiveNestedFolderGridItem(
             .swipeGestures(
                 swipeDown = gridItem.swipeDown,
                 swipeUp = gridItem.swipeUp,
+                enabled = !isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
             )
             .fillMaxSize()

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -342,9 +342,12 @@ private fun InteractiveFolderApplicationInfoGridItem(
 
     Column(
         modifier = modifier
-            .pointerInput(key1 = isVisibleOverlay) {
+            .pointerInput(
+                key1 = isVisibleOverlay,
+                key2 = isInProgress,
+            ) {
                 detectTapGestures(
-                    onDoubleTap = if (!isVisibleOverlay) {
+                    onDoubleTap = if (!isVisibleOverlay && !isInProgress) {
                         {
                             onDoubleTap(
                                 context = context,
@@ -356,7 +359,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
                     } else {
                         null
                     },
-                    onLongPress = if (!isVisibleOverlay) {
+                    onLongPress = if (!isVisibleOverlay && !isInProgress) {
                         {
                             scope.launch {
                                 onLongPressFolderGridItem(
@@ -377,7 +380,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
                     } else {
                         null
                     },
-                    onTap = if (!isVisibleOverlay) {
+                    onTap = if (!isVisibleOverlay && !isInProgress) {
                         {
                             androidLauncherAppsWrapper.startMainActivity(
                                 serialNumber = data.serialNumber,
@@ -533,9 +536,12 @@ private fun InteractiveFolderShortcutInfoGridItem(
 
     Column(
         modifier = modifier
-            .pointerInput(key1 = isVisibleOverlay) {
+            .pointerInput(
+                key1 = isVisibleOverlay,
+                key2 = isInProgress,
+            ) {
                 detectTapGestures(
-                    onDoubleTap = if (!isVisibleOverlay) {
+                    onDoubleTap = if (!isVisibleOverlay && !isInProgress) {
                         {
                             scope.launch {
                                 onDoubleTap(
@@ -549,7 +555,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
                     } else {
                         null
                     },
-                    onLongPress = if (!isVisibleOverlay) {
+                    onLongPress = if (!isVisibleOverlay && !isInProgress) {
                         {
                             scope.launch {
                                 onLongPressFolderGridItem(
@@ -570,7 +576,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
                     } else {
                         null
                     },
-                    onTap = if (!isVisibleOverlay) {
+                    onTap = if (!isVisibleOverlay && !isInProgress) {
                         {
                             if (hasShortcutHostPermission &&
                                 data.isEnabled &&
@@ -736,7 +742,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
 
     Column(
         modifier = modifier
-            .pointerInput(key1 = isVisibleOverlay) {
+            .pointerInput(key1 = isVisibleOverlay && !isInProgress) {
                 detectTapGestures(
                     onDoubleTap = if (!isVisibleOverlay) {
                         {
@@ -750,7 +756,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
                     } else {
                         null
                     },
-                    onLongPress = if (!isVisibleOverlay) {
+                    onLongPress = if (!isVisibleOverlay && !isInProgress) {
                         {
                             scope.launch {
                                 onLongPressFolderGridItem(
@@ -771,7 +777,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
                     } else {
                         null
                     },
-                    onTap = if (!isVisibleOverlay) {
+                    onTap = if (!isVisibleOverlay && !isInProgress) {
                         {
                             data.shortcutIntentUri?.let {
                                 context.startActivity(parseUri(it, 0))
@@ -827,7 +833,8 @@ private fun InteractiveFolderShortcutConfigGridItem(
                     }
 
                     drawLayer(graphicsLayer)
-                }.alpha(alpha),
+                }
+                .alpha(alpha),
         )
 
         if (gridItemSettings.showLabel) {
@@ -915,9 +922,12 @@ private fun InteractiveNestedFolderGridItem(
 
     Column(
         modifier = modifier
-            .pointerInput(key1 = isVisibleOverlay) {
+            .pointerInput(
+                key1 = isVisibleOverlay,
+                key2 = isInProgress,
+            ) {
                 detectTapGestures(
-                    onDoubleTap = if (!isVisibleOverlay) {
+                    onDoubleTap = if (!isVisibleOverlay && !isInProgress) {
                         {
                             onDoubleTap(
                                 context = context,
@@ -929,7 +939,7 @@ private fun InteractiveNestedFolderGridItem(
                     } else {
                         null
                     },
-                    onLongPress = if (!isVisibleOverlay) {
+                    onLongPress = if (!isVisibleOverlay && !isInProgress) {
                         {
                             scope.launch {
                                 onLongPressFolderGridItem(
@@ -950,7 +960,7 @@ private fun InteractiveNestedFolderGridItem(
                     } else {
                         null
                     },
-                    onTap = if (!isVisibleOverlay) {
+                    onTap = if (!isVisibleOverlay && !isInProgress) {
                         {
                             onUpsertFolderPopupEntry(
                                 FolderPopupEntry(
@@ -1010,7 +1020,8 @@ private fun InteractiveNestedFolderGridItem(
                     }
 
                     drawLayer(graphicsLayer)
-                }.alpha(alpha)
+                }
+                .alpha(alpha)
 
         if (data.icon != null) {
             AsyncImage(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -464,7 +464,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
             if (isNotificationAccessGranted && hasNotifications) {
                 Box(
                     modifier = Modifier
-                        .size((gridItemSettings.iconSize * 0.3).dp)
+                        .size(iconSize * 0.3f)
                         .align(Alignment.TopEnd)
                         .background(
                             color = MaterialTheme.colorScheme.primary,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -143,11 +143,11 @@ internal fun InteractiveFolderGridItem(
         gridItemSettings
     }
 
-    val padding = lerp(1.dp, gridItemSettings.padding.dp, progress)
+    val padding = lerp(1.dp, currentGridItemSettings.padding.dp, progress)
 
     val iconSize = lerp(
-        gridItemSettings.iconSize.dp / maxOf(FOLDER_PREVIEW_COLUMNS, FOLDER_PREVIEW_ROWS),
-        gridItemSettings.iconSize.dp,
+        currentGridItemSettings.iconSize.dp / maxOf(FOLDER_PREVIEW_COLUMNS, FOLDER_PREVIEW_ROWS),
+        currentGridItemSettings.iconSize.dp,
         progress,
     )
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -506,7 +506,7 @@ private fun InteractiveApplicationInfoGridItem(
             if (isNotificationAccessGranted && hasNotifications) {
                 Box(
                     modifier = Modifier
-                        .size((gridItemSettings.iconSize * 0.3).dp)
+                        .size(gridItemSettings.iconSize.dp * 0.3f)
                         .align(Alignment.TopEnd)
                         .background(
                             color = MaterialTheme.colorScheme.primary,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -150,14 +150,14 @@ internal fun InteractiveGridItem(
 
     val currentTextColor = if (gridItem.override) {
         getGridItemTextColor(
-            gridItemCustomTextColor = gridItem.gridItemSettings.customTextColor,
-            gridItemTextColor = gridItem.gridItemSettings.textColor,
-            systemCustomTextColor = gridItemSettings.customTextColor,
+            gridItemCustomTextColor = currentGridItemSettings.customTextColor,
+            gridItemTextColor = currentGridItemSettings.textColor,
+            systemCustomTextColor = currentGridItemSettings.customTextColor,
             systemTextColor = textColor,
         )
     } else {
         getTextColor(
-            customTextColor = gridItemSettings.customTextColor,
+            customTextColor = currentGridItemSettings.customTextColor,
             textColor = textColor,
         )
     }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -181,23 +181,13 @@ internal fun InteractiveGridItem(
         }
     }
 
-    fun getSourceBounds(): Rect {
-        val x = gridItem.startColumn * cellWidth
-        val y = gridItem.startRow * cellHeight
-
-        val width = gridItem.columnSpan * cellWidth
-        val height = gridItem.rowSpan * cellHeight
-
-        val left = x + leftPadding
-        val top = y + topOffset
-
-        return Rect(
-            left,
-            top,
-            left + width,
-            top + height,
-        )
-    }
+    val sourceBounds = getSourceBounds(
+        gridItem = gridItem,
+        cellWidth = cellWidth,
+        cellHeight = cellHeight,
+        leftPadding = leftPadding,
+        topOffset = topOffset,
+    )
 
     when (val data = gridItem.data) {
         is GridItemData.ApplicationInfo -> {
@@ -215,7 +205,7 @@ internal fun InteractiveGridItem(
                 textColor = currentTextColor,
                 hasInteraction = hasInteraction,
                 isVisibleWhiteBox = isVisibleWhiteBox,
-                sourceBounds = getSourceBounds(),
+                sourceBounds = sourceBounds,
                 onOpenAppDrawer = onOpenAppDrawer,
                 onShowGridItemPopup = onShowGridItemPopup,
                 onUpdateGridItemSource = onUpdateGridItemSource,
@@ -264,7 +254,7 @@ internal fun InteractiveGridItem(
                 textColor = currentTextColor,
                 hasInteraction = hasInteraction,
                 isVisibleWhiteBox = isVisibleWhiteBox,
-                sourceBounds = getSourceBounds(),
+                sourceBounds = sourceBounds,
                 onOpenAppDrawer = onOpenAppDrawer,
                 onShowGridItemPopup = onShowGridItemPopup,
                 onUpdateGridItemSource = onUpdateGridItemSource,
@@ -1472,4 +1462,28 @@ private fun PreviewFolderGridItem(
             else -> Unit
         }
     }
+}
+
+private fun getSourceBounds(
+    gridItem: GridItem,
+    cellWidth: Int,
+    cellHeight: Int,
+    leftPadding: Int,
+    topOffset: Int,
+): Rect {
+    val x = gridItem.startColumn * cellWidth
+    val y = gridItem.startRow * cellHeight
+
+    val width = gridItem.columnSpan * cellWidth
+    val height = gridItem.rowSpan * cellHeight
+
+    val left = x + leftPadding
+    val top = y + topOffset
+
+    return Rect(
+        left,
+        top,
+        left + width,
+        top + height,
+    )
 }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -152,7 +152,7 @@ internal fun InteractiveGridItem(
         getGridItemTextColor(
             gridItemCustomTextColor = currentGridItemSettings.customTextColor,
             gridItemTextColor = currentGridItemSettings.textColor,
-            systemCustomTextColor = currentGridItemSettings.customTextColor,
+            systemCustomTextColor = gridItemSettings.customTextColor,
             systemTextColor = textColor,
         )
     } else {


### PR DESCRIPTION
This commit introduces an `isInProgress` boolean flag to manage the UI state during ongoing animations or operations. This flag helps prevent user interactions or state changes while the UI is still transitioning.

Key changes:

- **`isInProgress` State:** A new `isInProgress` state variable is derived from the `progress` animation value in `FolderScreen.kt`. This variable will be `true` when the `progress` is less than `1f`.

- **`FolderDragGridItemHelper.kt` Updates:**
    - The `handlePageDirection` function now checks `isInProgress` to determine if it should proceed with page direction handling.
    - The `handleAnimateScrollToPage` function also checks `isInProgress` before initiating scroll animations.

- **`InteractiveFolderGridItem.kt` Updates:**
    - The `isInProgress` flag is now passed down to `InteractiveFolderGridItem` and its sub-components.
    - The click handling logic within `InteractiveFolderGridItem` now considers the `isInProgress` flag, preventing interactions when an operation is in progress.

- **`FolderScreen.kt` Updates:**
    - The `isInProgress` flag is now passed as a parameter to various composable functions, including `FolderGrid`, `FolderGridItem`, and `FolderGridItemContent`, enabling them to react to the ongoing operation state.
    - The `LaunchedEffect` for handling page direction and scroll animations now uses `isInProgress` as a key, ensuring these effects are re-triggered correctly when the UI state changes.

These changes enhance the user experience by providing a more responsive and predictable UI during animations and background operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder dragging, scrolling, and page transitions by preventing conflicting actions while movement is in progress.
  * Temporarily disables taps, long-presses, double-taps, and page swipes during folder animations.
  * Stabilized folder grid layout and item placement across interactive and preview views.
  * Prevented shared-element transitions during active folder operations.
  * Improved folder icon resizing during open and close animations.
  * Corrected text colors when individual grid items use custom settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->