### PR TITLE
feat: Add JMH benchmarking support to domain/grid module (jmh)

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     compileOnly(libs.ksp.gradlePlugin)
     compileOnly(libs.room.gradlePlugin)
 
+    implementation(libs.kotlin.allopen.gradlePlugin)
+    implementation(libs.kotlinx.benchmark.gradlePlugin)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }
 
@@ -90,6 +92,11 @@ gradlePlugin {
         register("jvmLibrary") {
             id = "com.eblan.launcher.jvmLibrary"
             implementationClass = "JvmLibraryConventionPlugin"
+        }
+
+        register("jvmBenchmarkLibrary") {
+            id = "com.eblan.launcher.jvmBenchmarkLibrary"
+            implementationClass = "JvmBenchmarkLibraryConventionPlugin"
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/JvmBenchmarkLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmBenchmarkLibraryConventionPlugin.kt
@@ -1,0 +1,65 @@
+/*
+ *
+ *   Copyright 2023 Einstein Blanco
+ *
+ *   Licensed under the GNU General Public License v3.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       https://www.gnu.org/licenses/gpl-3.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+import com.eblan.launcher.libs
+import kotlinx.benchmark.gradle.BenchmarksExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.invoke
+import org.jetbrains.kotlin.allopen.gradle.AllOpenExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+
+class JvmBenchmarkLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply(plugin = libs.plugins.kotlin.jvm.get().pluginId)
+            apply(plugin = libs.plugins.kotlinx.benchmark.get().pluginId)
+            apply(plugin = libs.plugins.kotlin.allopen.get().pluginId)
+
+            extensions.configure<SourceSetContainer> {
+                create("benchmarks")
+            }
+
+            extensions.configure<KotlinJvmProjectExtension> {
+                sourceSets {
+                    getByName("benchmarks") {
+                        dependsOn(getByName("main"))
+                    }
+                }
+            }
+
+            extensions.configure<BenchmarksExtension> {
+                targets {
+                    register("benchmarks")
+                }
+            }
+
+            extensions.configure<AllOpenExtension> {
+                annotation("org.openjdk.jmh.annotations.State")
+            }
+
+            dependencies {
+                add("benchmarksImplementation", libs.kotlinx.benchmark.runtime)
+            }
+        }
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -20,7 +20,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
+
     versionCatalogs {
         create("libs") {
             from(files("../gradle/libs.versions.toml"))

--- a/domain/grid/build.gradle.kts
+++ b/domain/grid/build.gradle.kts
@@ -18,6 +18,7 @@
 
 plugins {
     alias(libs.plugins.com.eblan.launcher.jvmLibrary)
+    alias(libs.plugins.com.eblan.launcher.jvmBenchmarkLibrary)
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ hilt = "2.59.2"
 javaxInject = "1"
 junit-jupiter = "5.14.1"
 kotlin = "2.3.20"
+kotlinxBenchmark = "0.4.18"
 kotlinxCoroutines = "1.10.2"
 kotlinxSerializationJson = "1.10.0"
 ksp = "2.3.4"
@@ -58,6 +59,7 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.r
 javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javaxInject" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinxBenchmark" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
@@ -71,7 +73,9 @@ room-testing = { group = "androidx.room", name = "room-testing", version.ref = "
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 android-tools-common = { group = "com.android.tools", name = "common", version.ref = "androidTools" }
-compose-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+compose-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
+kotlin-allopen-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-allopen", version.ref = "kotlin" }
+kotlinx-benchmark-gradlePlugin = { group = "org.jetbrains.kotlinx.benchmark", name = "org.jetbrains.kotlinx.benchmark.gradle.plugin", version.ref = "kotlinxBenchmark" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "room" }
@@ -83,6 +87,8 @@ compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinxBenchmark" }
+kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 room = { id = "androidx.room", version.ref = "room" }
@@ -91,6 +97,7 @@ room = { id = "androidx.room", version.ref = "room" }
 com-eblan-launcher-application = { id = "com.eblan.launcher.application" }
 com-eblan-launcher-feature = { id = "com.eblan.launcher.feature" }
 com-eblan-launcher-hilt = { id = "com.eblan.launcher.hilt" }
+com-eblan-launcher-jvmBenchmarkLibrary = { id = "com.eblan.launcher.jvmBenchmarkLibrary" }
 com-eblan-launcher-jvmLibrary = { id = "com.eblan.launcher.jvmLibrary" }
 com-eblan-launcher-library = { id = "com.eblan.launcher.library" }
 com-eblan-launcher-libraryCompose = { id = "com.eblan.launcher.libraryCompose" }


### PR DESCRIPTION
This commit introduces support for Java Microbenchmark Harness (JMH) benchmarking within the `domain/grid` module. It sets up the necessary gradle plugins, dependencies, and configurations to enable writing and running microbenchmarks.

Key changes include:

- **build-logic/convention/build.gradle.kts:**
  - Added `kotlinxBenchmark` and `kotlin.allopen` plugins to the `JvmLibraryConventionPlugin`.

- **build-logic/settings.gradle.kts:**
  - Added `gradlePluginPortal()` to the repositories.

- **build-logic/convention/src/main/kotlin/JvmBenchmarkLibraryConventionPlugin.kt:**
  - A new convention plugin for JVM benchmark libraries is introduced.
  - It applies the `kotlinx.benchmark`, `kotlin.jvm`, and `kotlin.allopen` plugins.
  - Configures a new `benchmarks` source set and its dependencies.
  - Sets up JMH targets and enables the `@State` annotation for the all-open plugin.

- **domain/grid/build.gradle.kts:**
  - Applied the new `com.eblan.launcher.jvmBenchmarkLibrary` convention plugin.

- **gradle/libs.versions.toml:**
  - Added versions and dependencies for `kotlinxBenchmark` and related plugins and runtime.

This setup allows for the creation of benchmark classes within the `domain/grid` module's `benchmarks` source set, which can then be executed using JMH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JVM benchmarking support for the grid domain.
  * Introduced benchmark configuration, runtime support, and dedicated benchmark source sets.
  * Enabled benchmark classes using JMH state annotations to run without additional setup.

* **Build Improvements**
  * Added project-wide configuration for Kotlin benchmarking and related Gradle plugins.
  * Updated plugin resolution to support benchmark tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->