### PR TITLE
refactor: Remove GetGridItemsUseCase dependency from use cases

### DIFF
--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/application/GetEblanApplicationInfosByLabelAndTagUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/application/GetEblanApplicationInfosByLabelAndTagUseCase.kt
@@ -31,13 +31,13 @@ import com.eblan.launcher.domain.model.EblanUserType
 import com.eblan.launcher.domain.model.GetEblanApplicationInfosByLabelAndTag
 import com.eblan.launcher.domain.repository.EblanApplicationInfoRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
+import com.eblan.launcher.domain.usecase.util.getIconPackInfoFilePaths
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
-import java.io.File
 import java.text.Normalizer
 import javax.inject.Inject
 
@@ -107,14 +107,18 @@ class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
             it.eblanUser.eblanUserType == EblanUserType.Private
         }
 
+        val iconPackInfoFilePaths = getIconPackInfoFilePaths(
+            iconPackInfoPackageName = iconPackInfoPackageName,
+            componentNames = eblanApplicationInfos.map { it.componentName },
+            fileManager = fileManager,
+            iconKeyGenerator = iconKeyGenerator,
+        )
+
         return GetEblanApplicationInfosByLabelAndTag(
             eblanApplicationInfoWithIconPackInfos = groupedEblanApplicationInfos.filterKeys { it != privateEblanUserPageKey },
             privateEblanUser = privateEblanUserPageKey?.eblanUser,
             privateEblanApplicationInfoWithIconPackInfos = groupedEblanApplicationInfos[privateEblanUserPageKey].orEmpty(),
-            iconPackInfoFilePaths = getIconPackInfoFilePaths(
-                iconPackInfoPackageName = iconPackInfoPackageName,
-                eblanApplicationInfos = eblanApplicationInfos,
-            ),
+            iconPackInfoFilePaths = iconPackInfoFilePaths,
         )
     }
 
@@ -137,14 +141,18 @@ class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
                     }
             }.toMap()
 
+        val iconPackInfoFilePaths = getIconPackInfoFilePaths(
+            iconPackInfoPackageName = iconPackInfoPackageName,
+            componentNames = eblanApplicationInfos.map { it.componentName },
+            fileManager = fileManager,
+            iconKeyGenerator = iconKeyGenerator,
+        )
+
         return GetEblanApplicationInfosByLabelAndTag(
             eblanApplicationInfoWithIconPackInfos = groupedEblanApplicationInfos,
             privateEblanUser = null,
             privateEblanApplicationInfoWithIconPackInfos = emptyList(),
-            iconPackInfoFilePaths = getIconPackInfoFilePaths(
-                iconPackInfoPackageName = iconPackInfoPackageName,
-                eblanApplicationInfos = eblanApplicationInfos,
-            ),
+            iconPackInfoFilePaths = iconPackInfoFilePaths,
         )
     }
 
@@ -223,37 +231,6 @@ class GetEblanApplicationInfosByLabelAndTagUseCase @Inject constructor(
         Normalizer.normalize(text, Normalizer.Form.NFD)
             .replace("\\p{M}+".toRegex(), "")
             .lowercase()
-    }
-
-    private suspend fun getIconPackInfoFilePaths(
-        iconPackInfoPackageName: String,
-        eblanApplicationInfos: List<EblanApplicationInfo>,
-    ): Map<String, String?> {
-        if (iconPackInfoPackageName.isEmpty()) {
-            return emptyMap()
-        }
-
-        val iconPacksDirectory = fileManager.getFilesDirectory(
-            FileManager.ICON_PACKS_DIR,
-        )
-
-        val iconPackDirectory = File(
-            iconPacksDirectory,
-            iconPackInfoPackageName,
-        )
-
-        return eblanApplicationInfos.associate {
-            val iconPackInfoFile = File(
-                iconPackDirectory,
-                iconKeyGenerator.getHashedName(
-                    name = it.componentName,
-                ),
-            )
-
-            it.componentName to iconPackInfoFile
-                .takeIf(File::exists)
-                ?.absolutePath
-        }.toMap()
     }
 }
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetGridItemByIdUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/GetGridItemByIdUseCase.kt
@@ -21,43 +21,16 @@ import com.eblan.launcher.domain.common.Dispatcher
 import com.eblan.launcher.domain.common.EblanDispatchers
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.repository.GridRepository
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class GetGridItemsUseCase @Inject constructor(
+class GetGridItemByIdUseCase @Inject constructor(
     private val gridRepository: GridRepository,
-    @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+    @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) {
-    suspend operator fun invoke(): List<GridItem> = withContext(ioDispatcher) {
-        val gridItems = gridRepository.getGridItems()
-
-        buildList {
-            addAll(
-                gridItems.applicationInfoGridItems.map {
-                    it.asGridItem()
-                },
-            )
-            addAll(
-                gridItems.widgetGridItems.map {
-                    it.asGridItem()
-                },
-            )
-            addAll(
-                gridItems.shortcutInfoGridItems.map {
-                    it.asGridItem()
-                },
-            )
-            addAll(
-                gridItems.shortcutConfigGridItems.map {
-                    it.asGridItem()
-                },
-            )
-            addAll(
-                gridItems.folderGridItems.map {
-                    it.asGridItem()
-                },
-            )
-        }
+    suspend operator fun invoke(id: String): GridItem? = withContext(defaultDispatcher) {
+        gridRepository.getGridItems().toGridItems().firstOrNull { it.id == id }
     }
 }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/MoveGridItemUseCase.kt
@@ -29,13 +29,13 @@ import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.model.MoveGridItemResult
 import com.eblan.launcher.domain.model.ResolveDirection
 import com.eblan.launcher.domain.repository.GridRepository
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class MoveGridItemUseCase @Inject constructor(
     private val gridRepository: GridRepository,
-    private val getGridItemsUseCase: GetGridItemsUseCase,
     @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(
@@ -48,7 +48,7 @@ class MoveGridItemUseCase @Inject constructor(
         gridHeight: Int,
     ): MoveGridItemResult {
         return withContext(defaultDispatcher) {
-            val gridItemsByPage = getGridItemsUseCase().filter {
+            val gridItemsByPage = gridRepository.getGridItems().toGridItems().filter {
                 it.isTopLevel() && it.page == movingGridItem.page &&
                     it.associate == movingGridItem.associate
             }.toMutableList()

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/ResizeGridItemUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/grid/ResizeGridItemUseCase.kt
@@ -24,13 +24,13 @@ import com.eblan.launcher.domain.grid.rectanglesOverlap
 import com.eblan.launcher.domain.grid.resolveConflicts
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.repository.GridRepository
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ResizeGridItemUseCase @Inject constructor(
     private val gridRepository: GridRepository,
-    private val getGridItemsUseCase: GetGridItemsUseCase,
     @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(
@@ -39,7 +39,7 @@ class ResizeGridItemUseCase @Inject constructor(
         rows: Int,
     ): GridItem = withContext(defaultDispatcher) {
         val gridItems =
-            getGridItemsUseCase().filter {
+            gridRepository.getGridItems().toGridItems().filter {
                 it.isTopLevel() && it.page == resizingGridItem.page &&
                     it.associate == resizingGridItem.associate
             }.toMutableList()

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/home/GetHomeDataUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/home/GetHomeDataUseCase.kt
@@ -24,20 +24,17 @@ import com.eblan.launcher.domain.framework.FileManager
 import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.framework.PackageManagerWrapper
 import com.eblan.launcher.domain.grid.isGridItemSpanWithinBounds
-import com.eblan.launcher.domain.model.ApplicationInfoGridItem
 import com.eblan.launcher.domain.model.Associate
-import com.eblan.launcher.domain.model.GridItem
-import com.eblan.launcher.domain.model.GridItems
 import com.eblan.launcher.domain.model.HomeData
 import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
-import com.eblan.launcher.domain.usecase.grid.asGridItem
 import com.eblan.launcher.domain.usecase.grid.isTopLevel
+import com.eblan.launcher.domain.usecase.util.getIconPackInfoFilePaths
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
-import java.io.File
 import javax.inject.Inject
 
 class GetHomeDataUseCase @Inject constructor(
@@ -53,7 +50,7 @@ class GetHomeDataUseCase @Inject constructor(
         userDataRepository.userDataFlow,
         gridRepository.gridItemsFlow,
     ) { userData, gridItems ->
-        val currentGridItems = gridItems.toGridItems()
+        val currentGridItems = gridItems.toGridItems().filter { it.isTopLevel() }
 
         val gridItemsByPage = currentGridItems.filter {
             isGridItemSpanWithinBounds(
@@ -71,6 +68,13 @@ class GetHomeDataUseCase @Inject constructor(
             ) && it.associate == Associate.Dock
         }.groupBy { it.page }
 
+        val iconPackInfoFilePaths = getIconPackInfoFilePaths(
+            iconPackInfoPackageName = userData.generalSettings.iconPackInfoPackageName,
+            componentNames = gridItems.applicationInfoGridItems.map { it.componentName },
+            fileManager = fileManager,
+            iconKeyGenerator = iconKeyGenerator,
+        )
+
         HomeData(
             userData = userData,
             gridItems = currentGridItems,
@@ -78,53 +82,7 @@ class GetHomeDataUseCase @Inject constructor(
             dockGridItemsByPage = dockGridItemsByPage,
             hasShortcutHostPermission = launcherAppsWrapper.hasShortcutHostPermission,
             hasSystemFeatureAppWidgets = packageManagerWrapper.hasSystemFeatureAppWidgets,
-            iconPackInfoFilePaths = getIconPackInfoFilePaths(
-                iconPackInfoPackageName = userData.generalSettings.iconPackInfoPackageName,
-                applicationInfoGridItems = gridItems.applicationInfoGridItems,
-            ),
+            iconPackInfoFilePaths = iconPackInfoFilePaths,
         )
     }.flowOn(ioDispatcher)
-
-    private suspend fun getIconPackInfoFilePaths(
-        iconPackInfoPackageName: String,
-        applicationInfoGridItems: List<ApplicationInfoGridItem>,
-    ): Map<String, String?> {
-        if (iconPackInfoPackageName.isEmpty()) {
-            return emptyMap()
-        }
-
-        val iconPacksDirectory = fileManager.getFilesDirectory(
-            FileManager.ICON_PACKS_DIR,
-        )
-
-        val iconPackDirectory = File(
-            iconPacksDirectory,
-            iconPackInfoPackageName,
-        )
-
-        return applicationInfoGridItems.associate {
-            val iconPackInfoFile = File(
-                iconPackDirectory,
-                iconKeyGenerator.getHashedName(
-                    name = it.componentName,
-                ),
-            )
-
-            it.id to iconPackInfoFile
-                .takeIf(File::exists)
-                ?.absolutePath
-        }.toMap()
-    }
-
-    private fun GridItems.toGridItems(): List<GridItem> = buildList {
-        addAll(
-            applicationInfoGridItems.map {
-                it.asGridItem()
-            },
-        )
-        addAll(widgetGridItems.map { it.asGridItem() })
-        addAll(shortcutInfoGridItems.map { it.asGridItem() })
-        addAll(shortcutConfigGridItems.map { it.asGridItem() })
-        addAll(folderGridItems.map { it.asGridItem() })
-    }.filter { it.isTopLevel() }
 }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/AddPackageUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/AddPackageUseCase.kt
@@ -36,10 +36,11 @@ import com.eblan.launcher.domain.repository.EblanApplicationInfoRepository
 import com.eblan.launcher.domain.repository.EblanShortcutConfigRepository
 import com.eblan.launcher.domain.repository.EblanShortcutInfoRepository
 import com.eblan.launcher.domain.repository.FolderGridItemRepository
+import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
-import com.eblan.launcher.domain.usecase.grid.GetGridItemsUseCase
 import com.eblan.launcher.domain.usecase.grid.isTopLevel
 import com.eblan.launcher.domain.usecase.util.cacheIconPackFile
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -62,8 +63,8 @@ class AddPackageUseCase @Inject constructor(
     private val iconPackManager: IconPackManager,
     private val iconKeyGenerator: IconKeyGenerator,
     private val applicationInfoGridItemRepository: ApplicationInfoGridItemRepository,
-    private val getGridItemsUseCase: GetGridItemsUseCase,
     private val folderGridItemRepository: FolderGridItemRepository,
+    private val gridRepository: GridRepository,
     @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(
@@ -148,7 +149,7 @@ class AddPackageUseCase @Inject constructor(
 
         if (!homeSettings.addNewAppsToHomeScreen) return
 
-        val gridItems = getGridItemsUseCase()
+        val gridItems = gridRepository.getGridItems().toGridItems()
             .filter {
                 it.isTopLevel() && it.associate == Associate.Grid
             }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/launcherapps/SyncDataUseCase.kt
@@ -40,12 +40,13 @@ import com.eblan.launcher.domain.repository.EblanApplicationInfoRepository
 import com.eblan.launcher.domain.repository.EblanShortcutConfigRepository
 import com.eblan.launcher.domain.repository.EblanShortcutInfoRepository
 import com.eblan.launcher.domain.repository.FolderGridItemRepository
+import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.repository.ShortcutConfigGridItemRepository
 import com.eblan.launcher.domain.repository.ShortcutInfoGridItemRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
 import com.eblan.launcher.domain.repository.WidgetGridItemRepository
-import com.eblan.launcher.domain.usecase.grid.GetGridItemsUseCase
 import com.eblan.launcher.domain.usecase.grid.isTopLevel
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import com.eblan.launcher.domain.usecase.util.updateIconPackInfos
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.currentCoroutineContext
@@ -73,8 +74,8 @@ class SyncDataUseCase @Inject constructor(
     private val iconPackManager: IconPackManager,
     private val shortcutConfigGridItemRepository: ShortcutConfigGridItemRepository,
     private val iconKeyGenerator: IconKeyGenerator,
-    private val getGridItemsUseCase: GetGridItemsUseCase,
     private val folderGridItemRepository: FolderGridItemRepository,
+    private val gridRepository: GridRepository,
     @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke() {
@@ -205,7 +206,7 @@ class SyncDataUseCase @Inject constructor(
     ) {
         if (!homeSettings.addNewAppsToHomeScreen || experimentalSettings.firstLaunch) return
 
-        val gridItems = getGridItemsUseCase()
+        val gridItems = gridRepository.getGridItems().toGridItems()
             .filter {
                 it.isTopLevel() && it.associate == Associate.Grid
             }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinShortcutToHomeScreenUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinShortcutToHomeScreenUseCase.kt
@@ -30,8 +30,8 @@ import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
-import com.eblan.launcher.domain.usecase.grid.GetGridItemsUseCase
 import com.eblan.launcher.domain.usecase.grid.isTopLevel
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -46,7 +46,6 @@ class AddPinShortcutToHomeScreenUseCase @Inject constructor(
     private val gridRepository: GridRepository,
     private val packageManagerWrapper: PackageManagerWrapper,
     private val iconKeyGenerator: IconKeyGenerator,
-    private val getGridItemsUseCase: GetGridItemsUseCase,
     @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) {
     @OptIn(ExperimentalUuidApi::class)
@@ -122,7 +121,7 @@ class AddPinShortcutToHomeScreenUseCase @Inject constructor(
             swipeDown = eblanAction,
         )
 
-        val gridItems = getGridItemsUseCase()
+        val gridItems = gridRepository.getGridItems().toGridItems()
             .filter {
                 it.isTopLevel() && it.associate == Associate.Grid
             }

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinWidgetToHomeScreenUseCase.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/pin/AddPinWidgetToHomeScreenUseCase.kt
@@ -32,8 +32,8 @@ import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
 import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.repository.UserDataRepository
-import com.eblan.launcher.domain.usecase.grid.GetGridItemsUseCase
 import com.eblan.launcher.domain.usecase.grid.isTopLevel
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -48,7 +48,6 @@ class AddPinWidgetToHomeScreenUseCase @Inject constructor(
     private val packageManagerWrapper: PackageManagerWrapper,
     private val gridRepository: GridRepository,
     private val iconKeyGenerator: IconKeyGenerator,
-    private val getGridItemsUseCase: GetGridItemsUseCase,
     @param:Dispatcher(EblanDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) {
     @OptIn(ExperimentalUuidApi::class)
@@ -165,7 +164,7 @@ class AddPinWidgetToHomeScreenUseCase @Inject constructor(
             swipeDown = eblanAction,
         )
 
-        val gridItems = getGridItemsUseCase().filter {
+        val gridItems = gridRepository.getGridItems().toGridItems().filter {
             it.isTopLevel() && it.associate == Associate.Grid
         }
 

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/util/GridItemUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/util/GridItemUtil.kt
@@ -23,6 +23,7 @@ import com.eblan.launcher.domain.framework.FileManager
 import com.eblan.launcher.domain.framework.LauncherAppsWrapper
 import com.eblan.launcher.domain.model.GridItem
 import com.eblan.launcher.domain.model.GridItemData
+import com.eblan.launcher.domain.model.GridItems
 import com.eblan.launcher.domain.model.ShortcutQuery
 import com.eblan.launcher.domain.model.ShortcutQueryFlag
 import com.eblan.launcher.domain.repository.FolderGridItemRepository
@@ -96,6 +97,18 @@ suspend fun getFolderGridItemsById(
             else -> error("Unsupported folder grid item")
         }
     }
+}
+
+internal fun GridItems.toGridItems(): List<GridItem> = buildList {
+    addAll(
+        applicationInfoGridItems.map {
+            it.asGridItem()
+        },
+    )
+    addAll(widgetGridItems.map { it.asGridItem() })
+    addAll(shortcutInfoGridItems.map { it.asGridItem() })
+    addAll(shortcutConfigGridItems.map { it.asGridItem() })
+    addAll(folderGridItems.map { it.asGridItem() })
 }
 
 private suspend fun updatePinShortcutsByPackageName(

--- a/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/util/IconPackInfoUtil.kt
+++ b/domain/use-case/src/main/kotlin/com/eblan/launcher/domain/usecase/util/IconPackInfoUtil.kt
@@ -94,3 +94,34 @@ internal suspend fun cacheIconPackFile(
         )
     }
 }
+
+internal suspend fun getIconPackInfoFilePaths(
+    iconPackInfoPackageName: String,
+    componentNames: List<String>,
+    fileManager: FileManager,
+    iconKeyGenerator: IconKeyGenerator,
+): Map<String, String?> {
+    if (iconPackInfoPackageName.isEmpty()) {
+        return emptyMap()
+    }
+
+    val iconPacksDirectory = fileManager.getFilesDirectory(
+        FileManager.ICON_PACKS_DIR,
+    )
+
+    val iconPackDirectory = File(
+        iconPacksDirectory,
+        iconPackInfoPackageName,
+    )
+
+    return componentNames.associateWith {
+        val iconPackInfoFile = File(
+            iconPackDirectory,
+            iconKeyGenerator.getHashedName(name = it),
+        )
+
+        iconPackInfoFile
+            .takeIf(File::exists)
+            ?.absolutePath
+    }.toMap()
+}

--- a/domain/use-case/src/test/kotlin/com/eblan/launcher/domain/usecase/grid/MoveGridItemUseCaseTest.kt
+++ b/domain/use-case/src/test/kotlin/com/eblan/launcher/domain/usecase/grid/MoveGridItemUseCaseTest.kt
@@ -24,6 +24,7 @@ import com.eblan.launcher.domain.model.WidgetGridItem
 import com.eblan.launcher.domain.model.getEblanAction
 import com.eblan.launcher.domain.model.getGridItemSettings
 import com.eblan.launcher.domain.repository.FakeGridRepository
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -53,18 +54,12 @@ class MoveGridItemUseCaseTest {
             initialGridItems = gridItems,
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
-        )
-
         val moveGridItemUseCase = MoveGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val movingGridItem = getGridItemsUseCase()
+        val movingGridItem = gridItems.toGridItems()
             .single()
             .copy(
                 startColumn = 2,
@@ -106,31 +101,27 @@ class MoveGridItemUseCaseTest {
             startRow = 1,
         )
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = GridItems(
-                applicationInfoGridItems = listOf(
-                    applicationInfoGridItem,
-                    conflictingApplicationInfoGridItem,
-                ),
-                widgetGridItems = emptyList(),
-                shortcutInfoGridItems = emptyList(),
-                shortcutConfigGridItems = emptyList(),
-                folderGridItems = emptyList(),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(
+                applicationInfoGridItem,
+                conflictingApplicationInfoGridItem,
             ),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val moveGridItemUseCase = MoveGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val movingGridItem = getGridItemsUseCase()
+        val movingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 startColumn = 2,
@@ -169,31 +160,27 @@ class MoveGridItemUseCaseTest {
             startRow = 1,
         )
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = GridItems(
-                applicationInfoGridItems = listOf(
-                    applicationInfoGridItem,
-                    otherPageApplicationInfoGridItem,
-                ),
-                widgetGridItems = emptyList(),
-                shortcutInfoGridItems = emptyList(),
-                shortcutConfigGridItems = emptyList(),
-                folderGridItems = emptyList(),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(
+                applicationInfoGridItem,
+                otherPageApplicationInfoGridItem,
             ),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val moveGridItemUseCase = MoveGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val movingGridItem = getGridItemsUseCase()
+        val movingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 startColumn = 2,
@@ -260,31 +247,27 @@ class MoveGridItemUseCaseTest {
             associate = Associate.Dock,
         )
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = GridItems(
-                applicationInfoGridItems = listOf(
-                    applicationInfoGridItem,
-                    dockApplicationInfoGridItem,
-                ),
-                widgetGridItems = emptyList(),
-                shortcutInfoGridItems = emptyList(),
-                shortcutConfigGridItems = emptyList(),
-                folderGridItems = emptyList(),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(
+                applicationInfoGridItem,
+                dockApplicationInfoGridItem,
             ),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val moveGridItemUseCase = MoveGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val movingGridItem = getGridItemsUseCase()
+        val movingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 startColumn = 2,
@@ -334,31 +317,27 @@ class MoveGridItemUseCaseTest {
             folderId = "folder",
         )
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = GridItems(
-                applicationInfoGridItems = listOf(
-                    applicationInfoGridItem,
-                    folderApplicationInfoGridItem,
-                ),
-                widgetGridItems = emptyList(),
-                shortcutInfoGridItems = emptyList(),
-                shortcutConfigGridItems = emptyList(),
-                folderGridItems = emptyList(),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(
+                applicationInfoGridItem,
+                folderApplicationInfoGridItem,
             ),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val moveGridItemUseCase = MoveGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val movingGridItem = getGridItemsUseCase()
+        val movingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 startColumn = 2,
@@ -403,28 +382,24 @@ class MoveGridItemUseCaseTest {
 
         val widgetGridItem = getWidgetGridItem()
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = GridItems(
-                applicationInfoGridItems = listOf(applicationInfoGridItem),
-                widgetGridItems = listOf(widgetGridItem),
-                shortcutInfoGridItems = emptyList(),
-                shortcutConfigGridItems = emptyList(),
-                folderGridItems = emptyList(),
-            ),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(applicationInfoGridItem),
+            widgetGridItems = listOf(widgetGridItem),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val moveGridItemUseCase = MoveGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val movingGridItem = getGridItemsUseCase()
+        val movingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 startColumn = 2,

--- a/domain/use-case/src/test/kotlin/com/eblan/launcher/domain/usecase/grid/ResizeGridItemUseCaseTest.kt
+++ b/domain/use-case/src/test/kotlin/com/eblan/launcher/domain/usecase/grid/ResizeGridItemUseCaseTest.kt
@@ -23,6 +23,7 @@ import com.eblan.launcher.domain.model.GridItems
 import com.eblan.launcher.domain.model.getEblanAction
 import com.eblan.launcher.domain.model.getGridItemSettings
 import com.eblan.launcher.domain.repository.FakeGridRepository
+import com.eblan.launcher.domain.usecase.util.toGridItems
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -37,24 +38,24 @@ class ResizeGridItemUseCaseTest {
     fun `resizes grid item when there are no conflicts`() = runTest(dispatcher) {
         val applicationInfoGridItem = getApplicationInfoGridItem()
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = getGridItems(
-                applicationInfoGridItems = listOf(applicationInfoGridItem),
-            ),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(applicationInfoGridItem),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val resizeGridItemUseCase = ResizeGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val resizingGridItem = getGridItemsUseCase()
+        val resizingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 columnSpan = 2,
@@ -85,27 +86,27 @@ class ResizeGridItemUseCaseTest {
             startRow = 0,
         )
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = getGridItems(
-                applicationInfoGridItems = listOf(
-                    applicationInfoGridItem,
-                    conflictingApplicationInfoGridItem,
-                ),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(
+                applicationInfoGridItem,
+                conflictingApplicationInfoGridItem,
             ),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val resizeGridItemUseCase = ResizeGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val resizingGridItem = getGridItemsUseCase()
+        val resizingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 columnSpan = 2,
@@ -123,11 +124,13 @@ class ResizeGridItemUseCaseTest {
         assertEquals(2, resizedGridItem.columnSpan)
         assertEquals(1, resizedGridItem.rowSpan)
 
-        val resolvedGridItem = getGridItemsUseCase()
+        val persistedGridItem = gridRepository
+            .getGridItems()
+            .applicationInfoGridItems
             .first { it.id == conflictingApplicationInfoGridItem.id }
 
-        assertEquals(2, resolvedGridItem.startColumn)
-        assertEquals(0, resolvedGridItem.startRow)
+        assertEquals(2, persistedGridItem.startColumn)
+        assertEquals(0, persistedGridItem.startRow)
     }
 
     @Test
@@ -169,27 +172,27 @@ class ResizeGridItemUseCaseTest {
             ),
         )
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = getGridItems(
-                applicationInfoGridItems = listOf(
-                    applicationInfoGridItem,
-                    *conflictingApplicationInfoGridItems.toTypedArray(),
-                ),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(
+                applicationInfoGridItem,
+                *conflictingApplicationInfoGridItems.toTypedArray(),
             ),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val resizeGridItemUseCase = ResizeGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val resizingGridItem = getGridItemsUseCase()
+        val resizingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 columnSpan = 2,
@@ -222,27 +225,27 @@ class ResizeGridItemUseCaseTest {
             startRow = 0,
         )
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = getGridItems(
-                applicationInfoGridItems = listOf(
-                    applicationInfoGridItem,
-                    otherPageApplicationInfoGridItem,
-                ),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(
+                applicationInfoGridItem,
+                otherPageApplicationInfoGridItem,
             ),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
 
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val resizeGridItemUseCase = ResizeGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val resizingGridItem = getGridItemsUseCase()
+        val resizingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 columnSpan = 2,
@@ -275,27 +278,26 @@ class ResizeGridItemUseCaseTest {
             startRow = 0,
         )
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = getGridItems(
-                applicationInfoGridItems = listOf(
-                    applicationInfoGridItem,
-                    dockApplicationInfoGridItem,
-                ),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(
+                applicationInfoGridItem,
+                dockApplicationInfoGridItem,
             ),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
-
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val resizeGridItemUseCase = ResizeGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val resizingGridItem = getGridItemsUseCase()
+        val resizingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 columnSpan = 2,
@@ -327,27 +329,26 @@ class ResizeGridItemUseCaseTest {
             folderId = "folder",
         )
 
-        val gridRepository = FakeGridRepository(
-            initialGridItems = getGridItems(
-                applicationInfoGridItems = listOf(
-                    applicationInfoGridItem,
-                    folderApplicationInfoGridItem,
-                ),
+        val gridItems = GridItems(
+            applicationInfoGridItems = listOf(
+                applicationInfoGridItem,
+                folderApplicationInfoGridItem,
             ),
+            widgetGridItems = emptyList(),
+            shortcutInfoGridItems = emptyList(),
+            shortcutConfigGridItems = emptyList(),
+            folderGridItems = emptyList(),
         )
-
-        val getGridItemsUseCase = GetGridItemsUseCase(
-            gridRepository = gridRepository,
-            ioDispatcher = dispatcher,
+        val gridRepository = FakeGridRepository(
+            initialGridItems = gridItems,
         )
 
         val resizeGridItemUseCase = ResizeGridItemUseCase(
             gridRepository = gridRepository,
-            getGridItemsUseCase = getGridItemsUseCase,
             defaultDispatcher = dispatcher,
         )
 
-        val resizingGridItem = getGridItemsUseCase()
+        val resizingGridItem = gridItems.toGridItems()
             .first { it.id == applicationInfoGridItem.id }
             .copy(
                 columnSpan = 2,
@@ -365,16 +366,6 @@ class ResizeGridItemUseCaseTest {
         assertEquals(2, resizedGridItem.columnSpan)
         assertEquals(1, resizedGridItem.rowSpan)
     }
-
-    private fun getGridItems(
-        applicationInfoGridItems: List<ApplicationInfoGridItem> = emptyList(),
-    ) = GridItems(
-        applicationInfoGridItems = applicationInfoGridItems,
-        widgetGridItems = emptyList(),
-        shortcutInfoGridItems = emptyList(),
-        shortcutConfigGridItems = emptyList(),
-        folderGridItems = emptyList(),
-    )
 
     private fun getApplicationInfoGridItem(
         id: String = "app",

--- a/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/EditGridItemViewModel.kt
+++ b/feature/edit-grid-item/src/main/kotlin/com/eblan/launcher/feature/editgriditem/EditGridItemViewModel.kt
@@ -31,7 +31,7 @@ import com.eblan.launcher.domain.model.PackageManagerIconPackInfo
 import com.eblan.launcher.domain.repository.GridRepository
 import com.eblan.launcher.domain.usecase.application.GetEblanApplicationInfosUseCase
 import com.eblan.launcher.domain.usecase.grid.DeleteGridItemCustomIconUseCase
-import com.eblan.launcher.domain.usecase.grid.GetGridItemsUseCase
+import com.eblan.launcher.domain.usecase.grid.GetGridItemByIdUseCase
 import com.eblan.launcher.domain.usecase.grid.UpdateGridItemCustomIconUseCase
 import com.eblan.launcher.feature.editgriditem.model.EditGridItemUiState
 import com.eblan.launcher.feature.editgriditem.navigation.EditGridItemRouteData
@@ -54,9 +54,9 @@ internal class EditGridItemViewModel @Inject constructor(
     packageManagerWrapper: PackageManagerWrapper,
     private val gridRepository: GridRepository,
     getEblanApplicationInfosUseCase: GetEblanApplicationInfosUseCase,
-    private val getGridItemsUseCase: GetGridItemsUseCase,
     private val updateGridItemCustomIconUseCase: UpdateGridItemCustomIconUseCase,
     private val deleteGridItemCustomIconUseCase: DeleteGridItemCustomIconUseCase,
+    private val getGridItemByIdUseCase: GetGridItemByIdUseCase,
     @param:Dispatcher(EblanDispatchers.Default) private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private val editGridItemRouteData = savedStateHandle.toRoute<EditGridItemRouteData>()
@@ -169,9 +169,7 @@ internal class EditGridItemViewModel @Inject constructor(
         viewModelScope.launch(defaultDispatcher) {
             _editGridItemUiState.update {
                 EditGridItemUiState.Success(
-                    gridItem = getGridItemsUseCase().find {
-                        it.id == editGridItemRouteData.id
-                    },
+                    gridItem = getGridItemByIdUseCase(id = editGridItemRouteData.id),
                 )
             }
         }


### PR DESCRIPTION
This commit removes the `GetGridItemsUseCase` as a direct dependency from several use cases. Instead, these use cases now directly access the `GridRepository` to retrieve grid items. This change simplifies dependencies and centralizes grid item retrieval logic.

Closes #976 

The affected use cases include:
- `MoveGridItemUseCase`
- `AddPinShortcutToHomeScreenUseCase`
- `AddPinWidgetToHomeScreenUseCase`
- `AddPackageUseCase`
- `SyncDataUseCase`
- `ResizeGridItemUseCase`
- `EditGridItemViewModel` (which used `GetGridItemByIdUseCase` that was refactored from `GetGridItemsUseCase`)

This refactoring aligns with the ongoing effort to streamline data fetching and reduce unnecessary indirection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grid items can now be retrieved directly by ID, improving item loading in the edit experience.
  * Added centralized handling for converting and filtering grid items.
  * Improved icon-pack cache path resolution.

* **Refactor**
  * Streamlined grid-item access across home screen, launcher, pinning, moving, and resizing workflows.
  * Reduced redundant data-loading dependencies while preserving existing behavior.

* **Tests**
  * Updated grid movement and resizing coverage for the revised item-loading flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->